### PR TITLE
add "name" property for ChatCompletionMessage

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -59,7 +59,7 @@ func TestAPI(t *testing.T) {
 			Model: GPT3Dot5Turbo,
 			Messages: []ChatCompletionMessage{
 				{
-					Role:    "user",
+					Role:    ChatMessageRoleUser,
 					Content: "Hello!",
 				},
 			},
@@ -67,7 +67,25 @@ func TestAPI(t *testing.T) {
 	)
 
 	if err != nil {
-		t.Errorf("CreateChatCompletion returned error: %v", err)
+		t.Errorf("CreateChatCompletion (without name) returned error: %v", err)
+	}
+
+	_, err = c.CreateChatCompletion(
+		ctx,
+		ChatCompletionRequest{
+			Model: GPT3Dot5Turbo,
+			Messages: []ChatCompletionMessage{
+				{
+					Role:    ChatMessageRoleUser,
+					Name:    "John_Doe",
+					Content: "Hello!",
+				},
+			},
+		},
+	)
+
+	if err != nil {
+		t.Errorf("CreateChatCompletion (with name) returned error: %v", err)
 	}
 
 	stream, err := c.CreateCompletionStream(ctx, CompletionRequest{

--- a/chat.go
+++ b/chat.go
@@ -21,6 +21,7 @@ var (
 
 type ChatCompletionMessage struct {
 	Role    string `json:"role"`
+	Name    string `json:"name,omitempty"`
 	Content string `json:"content"`
 }
 

--- a/chat.go
+++ b/chat.go
@@ -21,8 +21,13 @@ var (
 
 type ChatCompletionMessage struct {
 	Role    string `json:"role"`
-	Name    string `json:"name,omitempty"`
 	Content string `json:"content"`
+
+	// This property isn't in the official documentation, but it's in
+	// the documentation for the official library for python:
+	// - https://github.com/openai/openai-python/blob/main/chatml.md
+	// - https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb
+	Name string `json:"name,omitempty"`
 }
 
 // ChatCompletionRequest represents a request structure for chat completion API.


### PR DESCRIPTION
I found an undocumented possibility - for messages of the gpt-3.5 model, you can additionally specify the "name" property. This additional feature is useful for chats with multiple participants.

Found in the examples of the official library for python (Item No. 6 - Counting tokens for chat API calls): [https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken .ipynb](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb)