### PR TITLE
Add readme example of ChatGPT streaming completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,61 @@ func main() {
 Other examples:
 
 <details>
+<summary>ChatGPT streaming completion</summary>
+
+```go
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	openai "github.com/sashabaranov/go-openai"
+)
+
+func main() {
+	c := openai.NewClient("your token")
+	ctx := context.Background()
+
+	req := openai.ChatCompletionRequest{
+		Model:     openai.GPT3Dot5Turbo,
+		MaxTokens: 20,
+		Messages: []openai.ChatCompletionMessage{
+			{
+				Role:    openai.ChatMessageRoleUser,
+				Content: "Lorem ipsum",
+			},
+		},
+		Stream: true,
+	}
+	stream, err := c.CreateChatCompletionStream(ctx, req)
+	if err != nil {
+		fmt.Printf("ChatCompletionStream error: %v\n", err)
+		return
+	}
+	defer stream.Close()
+
+	fmt.Printf("Stream response: ")
+	for {
+		response, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			fmt.Println("\nStream finished")
+			return
+		}
+
+		if err != nil {
+			fmt.Printf("\nStream error: %v\n", err)
+			return
+		}
+
+		fmt.Printf(response.Choices[0].Delta.Content)
+	}
+}
+```
+</details>
+
+<details>
 <summary>GPT-3 completion</summary>
 
 ```go


### PR DESCRIPTION
When using `ChatCompletionStream`, I implemented the code by referencing the following test.

https://github.com/sashabaranov/go-openai/blob/a8acb5f63bcb4d5966d1a57709a32315eeff1ff9/chat_stream_test.go#L53

As it seems that #164 encountered the same issue, I  added an example of usage to the README.