### PR TITLE
fix: added defer to close audio file

### DIFF
--- a/audio.go
+++ b/audio.go
@@ -79,6 +79,7 @@ func audioMultipartForm(request AudioRequest, w *multipart.Writer) error {
 	if err != nil {
 		return fmt.Errorf("opening audio file: %w", err)
 	}
+	defer f.Close()
 
 	fw, err := w.CreateFormFile("file", f.Name())
 	if err != nil {


### PR DESCRIPTION
This PR solve the above issue:
- #175 

In some cases, the audio file opened for reading is not closed, making it impossible to remove it.

The `f.Close` call was added at the end of the execution of the `audioMultipartForm` function.