### PR TITLE
CompletionBatchingRequestSupport

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -78,6 +78,17 @@ func checkEndpointSupportsModel(endpoint, model string) bool {
 	return !disabledModelsForEndpoints[endpoint][model]
 }
 
+func checkPromptType(prompt any) (ok bool) {
+	if prompt != nil {
+		switch prompt.(type) {
+		case string, []string:
+		default:
+			return
+		}
+	}
+	return true
+}
+
 // CompletionRequest represents a request structure for completion API.
 type CompletionRequest struct {
 	Model            string         `json:"model"`
@@ -144,9 +155,7 @@ func (c *Client) CreateCompletion(
 		return
 	}
 
-	switch request.Prompt.(type) {
-	case string, []string:
-	default:
+	if !checkPromptType(request.Prompt) {
 		err = ErrCompletionRequestPromptTypeNotSupported
 		return
 	}

--- a/completion.go
+++ b/completion.go
@@ -78,15 +78,10 @@ func checkEndpointSupportsModel(endpoint, model string) bool {
 	return !disabledModelsForEndpoints[endpoint][model]
 }
 
-func checkPromptType(prompt any) (ok bool) {
-	if prompt != nil {
-		switch prompt.(type) {
-		case string, []string:
-		default:
-			return
-		}
-	}
-	return true
+func checkPromptType(prompt any) bool {
+	_, isString := prompt.(string)
+	_, isStringSlice := prompt.([]string)
+	return prompt == nil || isString || isStringSlice
 }
 
 // CompletionRequest represents a request structure for completion API.

--- a/completion.go
+++ b/completion.go
@@ -138,16 +138,16 @@ func (c *Client) CreateCompletion(
 		return
 	}
 
+	urlSuffix := "/completions"
+	if !checkEndpointSupportsModel(urlSuffix, request.Model) {
+		err = ErrCompletionUnsupportedModel
+		return
+	}
+
 	switch request.Prompt.(type) {
 	case string, []string:
 	default:
 		err = ErrCompletionRequestPromptTypeNotSupported
-		return
-	}
-
-	urlSuffix := "/completions"
-	if !checkEndpointSupportsModel(urlSuffix, request.Model) {
-		err = ErrCompletionUnsupportedModel
 		return
 	}
 

--- a/completion.go
+++ b/completion.go
@@ -81,7 +81,7 @@ func checkEndpointSupportsModel(endpoint, model string) bool {
 func checkPromptType(prompt any) bool {
 	_, isString := prompt.(string)
 	_, isStringSlice := prompt.([]string)
-	return prompt == nil || isString || isStringSlice
+	return isString || isStringSlice
 }
 
 // CompletionRequest represents a request structure for completion API.

--- a/completion.go
+++ b/completion.go
@@ -7,8 +7,9 @@ import (
 )
 
 var (
-	ErrCompletionUnsupportedModel   = errors.New("this model is not supported with this method, please use CreateChatCompletion client method instead") //nolint:lll
-	ErrCompletionStreamNotSupported = errors.New("streaming is not supported with this method, please use CreateCompletionStream")                      //nolint:lll
+	ErrCompletionUnsupportedModel              = errors.New("this model is not supported with this method, please use CreateChatCompletion client method instead") //nolint:lll
+	ErrCompletionStreamNotSupported            = errors.New("streaming is not supported with this method, please use CreateCompletionStream")                      //nolint:lll
+	ErrCompletionRequestPromptTypeNotSupported = errors.New("the type of CompletionRequest.Promp only supports string and []string")                               //nolint:lll
 )
 
 // GPT3 Defines the models provided by OpenAI to use when generating
@@ -80,7 +81,7 @@ func checkEndpointSupportsModel(endpoint, model string) bool {
 // CompletionRequest represents a request structure for completion API.
 type CompletionRequest struct {
 	Model            string         `json:"model"`
-	Prompt           string         `json:"prompt,omitempty"`
+	Prompt           any            `json:"prompt,omitempty"`
 	Suffix           string         `json:"suffix,omitempty"`
 	MaxTokens        int            `json:"max_tokens,omitempty"`
 	Temperature      float32        `json:"temperature,omitempty"`
@@ -134,6 +135,13 @@ func (c *Client) CreateCompletion(
 ) (response CompletionResponse, err error) {
 	if request.Stream {
 		err = ErrCompletionStreamNotSupported
+		return
+	}
+
+	switch request.Prompt.(type) {
+	case string, []string:
+	default:
+		err = ErrCompletionRequestPromptTypeNotSupported
 		return
 	}
 

--- a/completion_test.go
+++ b/completion_test.go
@@ -98,14 +98,14 @@ func handleCompletionEndpoint(w http.ResponseWriter, r *http.Request) {
 		// generate a random string of length completionReq.Length
 		completionStr := strings.Repeat("a", completionReq.MaxTokens)
 		if completionReq.Echo {
-			completionStr = completionReq.Prompt + completionStr
+			completionStr = completionReq.Prompt.(string) + completionStr
 		}
 		res.Choices = append(res.Choices, CompletionChoice{
 			Text:  completionStr,
 			Index: i,
 		})
 	}
-	inputTokens := numTokens(completionReq.Prompt) * completionReq.N
+	inputTokens := numTokens(completionReq.Prompt.(string)) * completionReq.N
 	completionTokens := completionReq.MaxTokens * completionReq.N
 	res.Usage = Usage{
 		PromptTokens:     inputTokens,

--- a/request_builder_test.go
+++ b/request_builder_test.go
@@ -51,8 +51,13 @@ func TestClientReturnsRequestBuilderErrors(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, err = client.CreateCompletion(ctx, CompletionRequest{Prompt: "testing"})
+	_, err = client.CreateCompletion(ctx, CompletionRequest{})
 	if !errors.Is(err, errTestRequestBuilderFailed) {
+		t.Fatalf("Did not return error when request builder failed: %v", err)
+	}
+
+	_, err = client.CreateCompletion(ctx, CompletionRequest{Prompt: 1})
+	if !errors.Is(err, ErrCompletionRequestPromptTypeNotSupported) {
 		t.Fatalf("Did not return error when request builder failed: %v", err)
 	}
 
@@ -63,6 +68,11 @@ func TestClientReturnsRequestBuilderErrors(t *testing.T) {
 
 	_, err = client.CreateChatCompletionStream(ctx, ChatCompletionRequest{Model: GPT3Dot5Turbo})
 	if !errors.Is(err, errTestRequestBuilderFailed) {
+		t.Fatalf("Did not return error when request builder failed: %v", err)
+	}
+
+	_, err = client.CreateCompletionStream(ctx, CompletionRequest{Prompt: 1})
+	if !errors.Is(err, ErrCompletionRequestPromptTypeNotSupported) {
 		t.Fatalf("Did not return error when request builder failed: %v", err)
 	}
 

--- a/request_builder_test.go
+++ b/request_builder_test.go
@@ -55,11 +55,6 @@ func TestClientReturnsRequestBuilderErrors(t *testing.T) {
 	if !errors.Is(err, errTestRequestBuilderFailed) {
 		t.Fatalf("Did not return error when request builder failed: %v", err)
 	}
-	//nolint:lll
-	_, err = client.CreateCompletion(ctx, CompletionRequest{Prompt: 1})
-	if !errors.Is(err, ErrCompletionRequestPromptTypeNotSupported) {
-		t.Fatalf("Did not return error when request builder failed: %v", err)
-	}
 
 	_, err = client.CreateChatCompletion(ctx, ChatCompletionRequest{Model: GPT3Dot5Turbo})
 	if !errors.Is(err, errTestRequestBuilderFailed) {
@@ -68,11 +63,6 @@ func TestClientReturnsRequestBuilderErrors(t *testing.T) {
 
 	_, err = client.CreateChatCompletionStream(ctx, ChatCompletionRequest{Model: GPT3Dot5Turbo})
 	if !errors.Is(err, errTestRequestBuilderFailed) {
-		t.Fatalf("Did not return error when request builder failed: %v", err)
-	}
-	//nolint:lll
-	_, err = client.CreateCompletionStream(ctx, CompletionRequest{Prompt: 1})
-	if !errors.Is(err, ErrCompletionRequestPromptTypeNotSupported) {
 		t.Fatalf("Did not return error when request builder failed: %v", err)
 	}
 
@@ -153,6 +143,30 @@ func TestClientReturnsRequestBuilderErrors(t *testing.T) {
 
 	_, err = client.ListModels(ctx)
 	if !errors.Is(err, errTestRequestBuilderFailed) {
+		t.Fatalf("Did not return error when request builder failed: %v", err)
+	}
+}
+
+func TestReturnsRequestBuilderErrorsAddtion(t *testing.T) {
+	var err error
+	ts := test.NewTestServer().OpenAITestServer()
+	ts.Start()
+	defer ts.Close()
+
+	config := DefaultConfig(test.GetTestToken())
+	config.BaseURL = ts.URL + "/v1"
+	client := NewClientWithConfig(config)
+	client.requestBuilder = &failingRequestBuilder{}
+
+	ctx := context.Background()
+
+	_, err = client.CreateCompletion(ctx, CompletionRequest{Prompt: 1})
+	if !errors.Is(err, ErrCompletionRequestPromptTypeNotSupported) {
+		t.Fatalf("Did not return error when request builder failed: %v", err)
+	}
+
+	_, err = client.CreateCompletionStream(ctx, CompletionRequest{Prompt: 1})
+	if !errors.Is(err, ErrCompletionRequestPromptTypeNotSupported) {
 		t.Fatalf("Did not return error when request builder failed: %v", err)
 	}
 }

--- a/request_builder_test.go
+++ b/request_builder_test.go
@@ -51,7 +51,7 @@ func TestClientReturnsRequestBuilderErrors(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, err = client.CreateCompletion(ctx, CompletionRequest{})
+	_, err = client.CreateCompletion(ctx, CompletionRequest{Prompt: "testing"})
 	if !errors.Is(err, errTestRequestBuilderFailed) {
 		t.Fatalf("Did not return error when request builder failed: %v", err)
 	}

--- a/request_builder_test.go
+++ b/request_builder_test.go
@@ -38,6 +38,7 @@ func TestRequestBuilderReturnsMarshallerErrors(t *testing.T) {
 	}
 }
 
+//nolint
 func TestClientReturnsRequestBuilderErrors(t *testing.T) {
 	var err error
 	ts := test.NewTestServer().OpenAITestServer()

--- a/request_builder_test.go
+++ b/request_builder_test.go
@@ -38,7 +38,6 @@ func TestRequestBuilderReturnsMarshallerErrors(t *testing.T) {
 	}
 }
 
-//nolint
 func TestClientReturnsRequestBuilderErrors(t *testing.T) {
 	var err error
 	ts := test.NewTestServer().OpenAITestServer()
@@ -56,7 +55,7 @@ func TestClientReturnsRequestBuilderErrors(t *testing.T) {
 	if !errors.Is(err, errTestRequestBuilderFailed) {
 		t.Fatalf("Did not return error when request builder failed: %v", err)
 	}
-
+	//nolint:lll
 	_, err = client.CreateCompletion(ctx, CompletionRequest{Prompt: 1})
 	if !errors.Is(err, ErrCompletionRequestPromptTypeNotSupported) {
 		t.Fatalf("Did not return error when request builder failed: %v", err)
@@ -71,7 +70,7 @@ func TestClientReturnsRequestBuilderErrors(t *testing.T) {
 	if !errors.Is(err, errTestRequestBuilderFailed) {
 		t.Fatalf("Did not return error when request builder failed: %v", err)
 	}
-
+	//nolint:lll
 	_, err = client.CreateCompletionStream(ctx, CompletionRequest{Prompt: 1})
 	if !errors.Is(err, ErrCompletionRequestPromptTypeNotSupported) {
 		t.Fatalf("Did not return error when request builder failed: %v", err)

--- a/stream.go
+++ b/stream.go
@@ -27,7 +27,7 @@ func (c *Client) CreateCompletionStream(
 		err = ErrCompletionUnsupportedModel
 		return
 	}
-	
+
 	switch request.Prompt.(type) {
 	case string, []string:
 	default:

--- a/stream.go
+++ b/stream.go
@@ -28,9 +28,7 @@ func (c *Client) CreateCompletionStream(
 		return
 	}
 
-	switch request.Prompt.(type) {
-	case string, []string:
-	default:
+	if !checkPromptType(request.Prompt) {
 		err = ErrCompletionRequestPromptTypeNotSupported
 		return
 	}

--- a/stream.go
+++ b/stream.go
@@ -27,6 +27,13 @@ func (c *Client) CreateCompletionStream(
 		err = ErrCompletionUnsupportedModel
 		return
 	}
+	
+	switch request.Prompt.(type) {
+	case string, []string:
+	default:
+		err = ErrCompletionRequestPromptTypeNotSupported
+		return
+	}
 
 	request.Stream = true
 	req, err := c.newStreamRequest(ctx, "POST", urlSuffix, request)


### PR DESCRIPTION
solve iusse #201   i think this feature is useful
i closed  pr #210   because  I think there are too many unnecessary changes, here is a more concise change to implement
```go
c := openai.NewClient("your token")
	ctx := context.Background()

	
	// test CreateCompletion
	reqNor := CompletionRequest{
		Prompt:    []string{"Lorem ipsum", "Lorem ipsum", "Lorem ipsum"}, //use string or []string 
		Model:     GPT3Curie,
		MaxTokens: 5,
	}
	resp, err := c.CreateCompletion(ctx, reqNor)
	checks.NoError(t, err, "CreateCompletion returned error")
	if err == nil {
		for _, c := range resp.Choices {
			t.Logf("index =`%d`,text is `%s` \n", c.Index, c.Text)
		}
	}
```
`Prompt`   can be assigned `string` or `[]string` type
Streaming is also supported
```go
c := openai.NewClient("your token")
	ctx := context.Background()

	// test CreateCompletionStream
	streq := CompletionRequest{
		Model:     GPT3Curie,
		MaxTokens: 5,
		Prompt:   []string{ "a dog entered the alley", "a dog entered the alley", "a dog entered the alley"},
		Stream:    true,
	}
	stream, err := c.CreateCompletionStream(ctx, streq)
	if err != nil {
		t.Logf("CompletionStream error: %v\n", err)
		return
	}
	
	defer stream.Close()
	type index = int
	choicesMap := make(map[index]string)
	for {
		response, streamErr := stream.Recv()
		if errors.Is(streamErr, io.EOF) {
			t.Logf("CompletionBatch Stream finished")
			break
		}

		if streamErr != nil {
			checks.NoError(t, streamErr, "CompletionBatchStream error:Stream error")
		}
		t.Logf("Stream response: %#+v\n", response.Choices)
		choicesMap[response.Choices[0].Index] += response.Choices[0].Text
	}
	for k, v := range choicesMap {
		t.Logf("choice_index:%d,text:%s", k, v)
	}
```