### PR TITLE
to fix v1.5.8 Usage return 

### DIFF
--- a/chat_stream.go
+++ b/chat_stream.go
@@ -21,6 +21,7 @@ type ChatCompletionStreamResponse struct {
 	Created int64                        `json:"created"`
 	Model   string                       `json:"model"`
 	Choices []ChatCompletionStreamChoice `json:"choices"`
+	Usage   Usage                        `json:"usage"`
 }
 
 // ChatCompletionStream

--- a/chat_stream.go
+++ b/chat_stream.go
@@ -21,7 +21,7 @@ type ChatCompletionStreamResponse struct {
 	Created int64                        `json:"created"`
 	Model   string                       `json:"model"`
 	Choices []ChatCompletionStreamChoice `json:"choices"`
-	Usage   Usage                        `json:"usage"`
+	Usage   Usage                        `json:"usage,omitempty"`
 }
 
 // ChatCompletionStream

--- a/chat_stream.go
+++ b/chat_stream.go
@@ -21,7 +21,6 @@ type ChatCompletionStreamResponse struct {
 	Created int64                        `json:"created"`
 	Model   string                       `json:"model"`
 	Choices []ChatCompletionStreamChoice `json:"choices"`
-	Usage   Usage                        `json:"usage,omitempty"`
 }
 
 // ChatCompletionStream


### PR DESCRIPTION
In the pr on [215](https://github.com/sashabaranov/go-openai/pull/215). I found that I used the wrong way to add Usage. when `stream = true` will not  return `Usage` filed.
![usage](https://user-images.githubusercontent.com/596076/229359992-b9018087-17c9-46ae-b1da-5e984aecf912.png)
`Usage` should be calculated by the user himself.