### PR TITLE
Resolve json Unmarshal error when API returns an int instead of a string

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -143,6 +143,51 @@ func TestAPIError(t *testing.T) {
 	}
 }
 
+func TestAPIErrorCode(t *testing.T) {
+	// test integer code
+	response := `{"code":418,"message":"I'm a teapot","param":"prompt","type":"teapot_error"}`
+	var apiErr APIError
+	err := json.Unmarshal([]byte(response), &apiErr)
+	checks.NoError(t, err, "Unexpected Unmarshal API response error")
+
+	code, err := apiErr.Code()
+	checks.NoError(t, err, "Unexpected API code error")
+
+	switch v := code.(type) {
+	case int:
+		if v != 418 {
+			t.Fatalf("Unexpected API code integer: %d; expected 418", v)
+		}
+	default:
+		t.Fatalf("Unexpected API error code type: %T", v)
+	}
+
+	// test string code
+	response = `{"code":"teapot","message":"I'm a teapot","param":"prompt","type":"teapot_error"}`
+	err = json.Unmarshal([]byte(response), &apiErr)
+	checks.NoError(t, err, "Unexpected Unmarshal API response error")
+
+	code, err = apiErr.Code()
+	checks.NoError(t, err, "Unexpected API code error")
+
+	switch v := code.(type) {
+	case *string:
+		if *v != "teapot" {
+			t.Fatalf("Unexpected API code string: %s; expected `teapot`", *v)
+		}
+	default:
+		t.Fatalf("Unexpected API error code type: %T", v)
+	}
+
+	// test unknown code type
+	response = `{"code":true,"message":"I'm a teapot","param":"prompt","type":"teapot_error"}`
+	err = json.Unmarshal([]byte(response), &apiErr)
+	checks.NoError(t, err, "Unexpected Unmarshal API response error")
+
+	_, err = apiErr.Code()
+	checks.HasError(t, err, "Expected error for unknown API code type")
+}
+
 func TestRequestError(t *testing.T) {
 	var err error
 

--- a/api_test.go
+++ b/api_test.go
@@ -1,6 +1,8 @@
 package openai_test
 
 import (
+	"encoding/json"
+
 	. "github.com/sashabaranov/go-openai"
 	"github.com/sashabaranov/go-openai/internal/test/checks"
 
@@ -121,12 +123,20 @@ func TestAPIError(t *testing.T) {
 		t.Fatalf("Unexpected API error status code: %d", apiErr.StatusCode)
 	}
 
-	code, err := apiErr.CodeAsStringPtr()
+	code, err := apiErr.Code()
 	if err != nil {
 		t.Fatalf("Unexpected API error code: %s", err)
 	}
-	if code != nil && *code != "invalid_api_key" {
-		t.Fatalf("Unexpected API error code: %s", *code)
+
+	switch v := code.(type) {
+	case int:
+		t.Fatalf("Unexpected API error code integer: %d; expected string `invalid_api_key`", v)
+	case *string:
+		if *v != "invalid_api_key" {
+			t.Fatalf("Unexpected API error code: %s", *v)
+		}
+	default:
+		t.Fatalf("Unexpected API error code type: %T", v)
 	}
 	if apiErr.Error() == "" {
 		t.Fatal("Empty error message occurred")

--- a/api_test.go
+++ b/api_test.go
@@ -120,8 +120,13 @@ func TestAPIError(t *testing.T) {
 	if apiErr.StatusCode != 401 {
 		t.Fatalf("Unexpected API error status code: %d", apiErr.StatusCode)
 	}
-	if *apiErr.Code != "invalid_api_key" {
-		t.Fatalf("Unexpected API error code: %s", *apiErr.Code)
+
+	code, err := apiErr.CodeAsStringPtr()
+	if err != nil {
+		t.Fatalf("Unexpected API error code: %s", err)
+	}
+	if code != nil && *code != "invalid_api_key" {
+		t.Fatalf("Unexpected API error code: %s", *code)
 	}
 	if apiErr.Error() == "" {
 		t.Fatal("Empty error message occurred")

--- a/error.go
+++ b/error.go
@@ -1,14 +1,17 @@
 package openai
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // APIError provides error information returned by the OpenAI API.
 type APIError struct {
-	Code       *string `json:"code,omitempty"`
-	Message    string  `json:"message"`
-	Param      *string `json:"param,omitempty"`
-	Type       string  `json:"type"`
-	StatusCode int     `json:"-"`
+	Code       json.RawMessage `json:"code,omitempty"`
+	Message    string          `json:"message"`
+	Param      *string         `json:"param,omitempty"`
+	Type       string          `json:"type"`
+	StatusCode int             `json:"-"`
 }
 
 // RequestError provides informations about generic request errors.
@@ -23,6 +26,22 @@ type ErrorResponse struct {
 
 func (e *APIError) Error() string {
 	return e.Message
+}
+
+func (e *APIError) CodeAsStringPtr() (*string, error) {
+	var s string
+	if err := json.Unmarshal(e.Code, &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+func (e *APIError) CodeAsInt() (int, error) {
+	var i int
+	if err := json.Unmarshal(e.Code, &i); err != nil {
+		return 0, err
+	}
+	return i, nil
 }
 
 func (e *RequestError) Error() string {

--- a/error.go
+++ b/error.go
@@ -7,7 +7,7 @@ import (
 
 // APIError provides error information returned by the OpenAI API.
 type APIError struct {
-	Code       json.RawMessage `json:"code,omitempty"`
+	C          json.RawMessage `json:"code,omitempty"`
 	Message    string          `json:"message"`
 	Param      *string         `json:"param,omitempty"`
 	Type       string          `json:"type"`
@@ -28,20 +28,17 @@ func (e *APIError) Error() string {
 	return e.Message
 }
 
-func (e *APIError) CodeAsStringPtr() (*string, error) {
-	var s string
-	if err := json.Unmarshal(e.Code, &s); err != nil {
-		return nil, err
-	}
-	return &s, nil
-}
-
-func (e *APIError) CodeAsInt() (int, error) {
+// Code returns the error code as an int or string, depending on the API response.
+func (e *APIError) Code() (any, error) {
 	var i int
-	if err := json.Unmarshal(e.Code, &i); err != nil {
-		return 0, err
+	if err := json.Unmarshal(e.C, &i); err == nil {
+		return i, nil
 	}
-	return i, nil
+	var s string
+	if err := json.Unmarshal(e.C, &s); err == nil {
+		return &s, nil
+	}
+	return nil, fmt.Errorf("unknown code type: %s", e.C)
 }
 
 func (e *RequestError) Error() string {


### PR DESCRIPTION
This resolves https://github.com/sashabaranov/go-openai/issues/244 .

In the case of an invalid API key, the `APIError.Code` is a string pointer, but `APIError.Code` can be an integer for other API errors, such as when the API quota has been exceeded.

By changing the `APIError.Code` type to [`json.RawMessage`](https://pkg.go.dev/encoding/json#RawMessage), we can delay parsing the value until we need it (in most cases, we probably don't need it, since the struct also contains a StatusCode and error message, in which case `APIError.Code` can be ignored).

I've updated the invalid API Key test to parse the string `"invalid_api_key"` as it did before, using a new method, `APIError.CodeAsStringPtr()`, but I was unable to think of a good test for the quota error that returns an integer. Despite that, I still provided a method to decode the `APIError.Code` as an int if anyone needs it (`APIError.CodeAsInt()`)