### PR TITLE
Adds support for audio captioning with Whisper

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,47 @@ func main() {
 </details>
 
 <details>
+<summary>Audio Captions</summary>
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+func main() {
+	c := openai.NewClient(os.Getenv("OPENAI_KEY"))
+
+	req := openai.AudioRequest{
+		Model:    openai.Whisper1,
+		FilePath: os.Args[1],
+		Format:   openai.AudioResponseFormatSRT,
+	}
+	resp, err := c.CreateTranscription(context.Background(), req)
+	if err != nil {
+		fmt.Printf("Transcription error: %v\n", err)
+		return
+	}
+	f, err := os.Create(os.Args[1] + ".srt")
+	if err != nil {
+		fmt.Printf("Could not open file: %v\n", err)
+		return
+	}
+	defer f.Close()
+	if _, err := f.WriteString(resp.Text); err != nil {
+		fmt.Printf("Error writing to file: %v\n", err)
+		return
+	}
+}
+```
+</details>
+
+<details>
 <summary>DALL-E 2 image generation</summary>
 
 ```go

--- a/README.md
+++ b/README.md
@@ -134,3 +134,34 @@ func main() {
 }
 ```
 </details>
+
+<details>
+<summary>Audio Speech-To-Text</summary>
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+func main() {
+	c := openai.NewClient("your token")
+	ctx := context.Background()
+
+	req := openai.AudioRequest{
+		Model:    openai.Whisper1,
+		FilePath: "recording.mp3",
+	}
+	resp, err := c.CreateTranscription(ctx, req)
+	if err != nil {
+		fmt.Printf("Transcription error: %v\n", err)
+		return
+	}
+	fmt.Println(resp.Text)
+}
+```
+</details>

--- a/audio.go
+++ b/audio.go
@@ -13,7 +13,7 @@ const (
 	Whisper1 = "whisper-1"
 )
 
-// Response formats
+// Response formats; Whisper uses JSON by default.
 const (
 	AudioResponseFormatJSON = "json"
 	AudioResponseFormatSRT  = "srt"

--- a/audio.go
+++ b/audio.go
@@ -13,6 +13,13 @@ const (
 	Whisper1 = "whisper-1"
 )
 
+// Response formats
+const (
+	AudioResponseFormatJSON = "json"
+	AudioResponseFormatSRT  = "srt"
+	AudioResponseFormatVTT  = "vtt"
+)
+
 // AudioRequest represents a request structure for audio API.
 // ResponseFormat is not supported for now. We only return JSON text, which may be sufficient.
 type AudioRequest struct {
@@ -21,6 +28,7 @@ type AudioRequest struct {
 	Prompt      string // For translation, it should be in English
 	Temperature float32
 	Language    string // For translation, just do not use it. It seems "en" works, not confirmed...
+	Format      string
 }
 
 // AudioResponse represents a response structure for audio API.
@@ -66,8 +74,17 @@ func (c *Client) callAudioAPI(
 	}
 	req.Header.Add("Content-Type", builder.formDataContentType())
 
-	err = c.sendRequest(req, &response)
+	if request.HasJSONResponse() {
+		err = c.sendRequest(req, &response)
+	} else {
+		err = c.sendRequest(req, &response.Text)
+	}
 	return
+}
+
+// HasJSONResponse returns true if the response format is JSON.
+func (r AudioRequest) HasJSONResponse() bool {
+	return r.Format == "" || r.Format == AudioResponseFormatJSON
 }
 
 // audioMultipartForm creates a form with audio file contents and the name of the model to use for
@@ -94,6 +111,14 @@ func audioMultipartForm(request AudioRequest, b formBuilder) error {
 		err = b.writeField("prompt", request.Prompt)
 		if err != nil {
 			return fmt.Errorf("writing prompt: %w", err)
+		}
+	}
+
+	// Create a form field for the format (if provided)
+	if request.Format != "" {
+		err = b.writeField("response_format", request.Format)
+		if err != nil {
+			return fmt.Errorf("writing format: %w", err)
 		}
 	}
 

--- a/audio.go
+++ b/audio.go
@@ -13,11 +13,13 @@ const (
 	Whisper1 = "whisper-1"
 )
 
-// Response formats; Whisper uses JSON by default.
+// Response formats; Whisper uses AudioResponseFormatJSON by default.
+type AudioResponseFormat string
+
 const (
-	AudioResponseFormatJSON = "json"
-	AudioResponseFormatSRT  = "srt"
-	AudioResponseFormatVTT  = "vtt"
+	AudioResponseFormatJSON AudioResponseFormat = "json"
+	AudioResponseFormatSRT  AudioResponseFormat = "srt"
+	AudioResponseFormatVTT  AudioResponseFormat = "vtt"
 )
 
 // AudioRequest represents a request structure for audio API.
@@ -28,7 +30,7 @@ type AudioRequest struct {
 	Prompt      string // For translation, it should be in English
 	Temperature float32
 	Language    string // For translation, just do not use it. It seems "en" works, not confirmed...
-	Format      string
+	Format      AudioResponseFormat
 }
 
 // AudioResponse represents a response structure for audio API.
@@ -116,7 +118,7 @@ func audioMultipartForm(request AudioRequest, b formBuilder) error {
 
 	// Create a form field for the format (if provided)
 	if request.Format != "" {
-		err = b.writeField("response_format", request.Format)
+		err = b.writeField("response_format", string(request.Format))
 		if err != nil {
 			return fmt.Errorf("writing format: %w", err)
 		}

--- a/audio_test.go
+++ b/audio_test.go
@@ -112,6 +112,7 @@ func TestAudioWithOptionalArgs(t *testing.T) {
 				Prompt:      "用简体中文",
 				Temperature: 0.5,
 				Language:    "zh",
+				Format:      AudioResponseFormatSRT,
 			}
 			_, err = tc.createFn(ctx, req)
 			checks.NoError(t, err, "audio API error")
@@ -179,6 +180,7 @@ func TestAudioWithFailingFormBuilder(t *testing.T) {
 		Prompt:      "test",
 		Temperature: 0.5,
 		Language:    "en",
+		Format:      AudioResponseFormatSRT,
 	}
 
 	mockFailedErr := fmt.Errorf("mock form builder fail")
@@ -202,7 +204,7 @@ func TestAudioWithFailingFormBuilder(t *testing.T) {
 		return nil
 	}
 
-	failOn := []string{"model", "prompt", "temperature", "language"}
+	failOn := []string{"model", "prompt", "temperature", "language", "response_format"}
 	for _, failingField := range failOn {
 		failForField = failingField
 		mockFailedErr = fmt.Errorf("mock form builder fail on field %s", failingField)

--- a/client.go
+++ b/client.go
@@ -85,21 +85,23 @@ func (c *Client) sendRequest(req *http.Request, v interface{}) error {
 		return fmt.Errorf("error, status code: %d, message: %w", res.StatusCode, errRes.Error)
 	}
 
-	if v != nil {
-		if result, ok := v.(*string); ok {
-			b, err := io.ReadAll(res.Body)
-			if err != nil {
-				return err
-			}
-			*result = string(b)
-			return nil
-		}
-		if err = json.NewDecoder(res.Body).Decode(v); err != nil {
-			return err
-		}
+	return decodeResponse(v, *res)
+}
+
+func decodeResponse(v interface{}, res http.Response) error {
+	if v == nil {
+		return nil
 	}
 
-	return nil
+	if result, ok := v.(*string); ok {
+		b, err := io.ReadAll(res.Body)
+		if err != nil {
+			return err
+		}
+		*result = string(b)
+		return nil
+	}
+	return json.NewDecoder(res.Body).Decode(v)
 }
 
 func (c *Client) fullURL(suffix string) string {

--- a/client.go
+++ b/client.go
@@ -86,6 +86,14 @@ func (c *Client) sendRequest(req *http.Request, v interface{}) error {
 	}
 
 	if v != nil {
+		if result, ok := v.(*string); ok {
+			b, err := io.ReadAll(res.Body)
+			if err != nil {
+				return err
+			}
+			*result = string(b)
+			return nil
+		}
 		if err = json.NewDecoder(res.Body).Decode(v); err != nil {
 			return err
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,9 @@
 package openai //nolint:testpackage // testing private field
 
 import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
 	"testing"
 )
 
@@ -18,5 +21,49 @@ func TestClient(t *testing.T) {
 	}
 	if client.config.OrgID != mockOrg {
 		t.Errorf("Client does not contain proper orgID")
+	}
+}
+
+func TestDecodeResponse(t *testing.T) {
+	stringInput := ""
+
+	testCases := []struct {
+		name     string
+		input    interface{}
+		response http.Response
+	}{
+		{
+			name:  "nil input",
+			input: nil,
+			response: http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+			},
+		},
+		{
+			name:  "string input",
+			input: &stringInput,
+			response: http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader([]byte("test"))),
+			},
+		},
+		{
+			name:  "map input",
+			input: &map[string]interface{}{},
+			response: http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader([]byte(`{"test": "test"}`))),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := decodeResponse(tc.input, tc.response)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+		})
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -2,8 +2,7 @@ package openai //nolint:testpackage // testing private field
 
 import (
 	"bytes"
-	"io/ioutil"
-	"net/http"
+	"io"
 	"testing"
 )
 
@@ -28,39 +27,30 @@ func TestDecodeResponse(t *testing.T) {
 	stringInput := ""
 
 	testCases := []struct {
-		name     string
-		input    interface{}
-		response http.Response
+		name  string
+		value interface{}
+		body  io.Reader
 	}{
 		{
 			name:  "nil input",
-			input: nil,
-			response: http.Response{
-				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
-			},
+			value: nil,
+			body:  bytes.NewReader([]byte("")),
 		},
 		{
 			name:  "string input",
-			input: &stringInput,
-			response: http.Response{
-				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("test"))),
-			},
+			value: &stringInput,
+			body:  bytes.NewReader([]byte("test")),
 		},
 		{
 			name:  "map input",
-			input: &map[string]interface{}{},
-			response: http.Response{
-				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte(`{"test": "test"}`))),
-			},
+			value: &map[string]interface{}{},
+			body:  bytes.NewReader([]byte(`{"test": "test"}`)),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := decodeResponse(tc.input, tc.response)
+			err := decodeResponse(tc.body, tc.value)
 			if err != nil {
 				t.Errorf("Unexpected error: %v", err)
 			}


### PR DESCRIPTION
Closes https://github.com/sashabaranov/go-openai/issues/143

Allows users to add a `Format: ` argument to the request to get captions from the audio apis.

Demonstration (using the same code added for README)

https://user-images.githubusercontent.com/4222666/232965446-78a47bc5-d7eb-4439-a161-3ff13f2600ff.mov

Broke `decodeResponse` out of client, because cyclomatic complexity  got above 20 with the string response changes.

Added tests for `decodeResponse` to not decrease code coverage