### PR TITLE
Add role attribute to ChatCompletionStreamChoiceDelta

### DIFF
--- a/chat_stream.go
+++ b/chat_stream.go
@@ -8,6 +8,7 @@ import (
 
 type ChatCompletionStreamChoiceDelta struct {
 	Content string `json:"content"`
+	Role    string `json:"role"`
 }
 
 type ChatCompletionStreamChoice struct {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/sashabaranov/go-openai
+module github.com/autopaca/go-openai
 
 go 1.18


### PR DESCRIPTION
The first response of the stream api contains the role attribute:
![image](https://user-images.githubusercontent.com/84277477/233323077-bc67aad0-cd9c-4fc9-b88a-ab37d71cdc21.png)

I believe this should be in the type definition.

Thank you for the great work sashabaranov!
