### PR TITLE
maintain underlying error structs to allow for type conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ This library provides Go clients for [OpenAI API](https://platform.openai.com/).
 * DALL·E 2
 * Whisper
 
-Installation:
+### Installation:
 ```
 go get github.com/sashabaranov/go-openai
 ```
 
 
-ChatGPT example usage:
+### ChatGPT example usage:
 
 ```go
 package main
@@ -52,9 +52,7 @@ func main() {
 
 ```
 
-
-
-Other examples:
+### Other examples:
 
 <details>
 <summary>ChatGPT streaming completion</summary>

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ Open-AI maintains clear documentation on how to [handle API errors](https://plat
 
 example:
 ```
-e := &APIError{}
+e := &openai.APIError{}
 if errors.As(err, &e) {
   switch e.HTTPStatusCode {
     case 401:

--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ if errors.As(err, &e) {
     case 401:
       // invalid auth or key (do not retry)
     case 429:
-	  // rate limiting or engine overload (wait and retry) 
-	case 500:
-	  // openai server error (retry)
-	default:
-	  // unhandled
-	}
+      // rate limiting or engine overload (wait and retry) 
+    case 500:
+      // openai server error (retry)
+    default:
+      // unhandled
+  }
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -52,30 +52,6 @@ func main() {
 
 ```
 
-
-### Error handling:
-
-Open-AI maintains clear documentation on how to [handle API errors](https://platform.openai.com/docs/guides/error-codes/api-errors)
-
-example:
-```
-e := &APIError{}
-if errors.As(err, &e) {
-  switch e.HTTPStatusCode {
-    case 401:
-      // invalid auth or key (do not retry)
-    case 429:
-      // rate limiting or engine overload (wait and retry) 
-    case 500:
-      // openai server error (retry)
-    default:
-      // unhandled
-  }
-}
-
-```
-
-
 ### Other examples:
 
 <details>
@@ -484,3 +460,29 @@ func main() {
 }
 ```
 </details>
+
+<details>
+<summary>Error handling</summary>
+
+Open-AI maintains clear documentation on how to [handle API errors](https://platform.openai.com/docs/guides/error-codes/api-errors)
+
+example:
+```
+e := &APIError{}
+if errors.As(err, &e) {
+  switch e.HTTPStatusCode {
+    case 401:
+      // invalid auth or key (do not retry)
+    case 429:
+      // rate limiting or engine overload (wait and retry) 
+    case 500:
+      // openai server error (retry)
+    default:
+      // unhandled
+  }
+}
+
+```
+</details>
+
+

--- a/README.md
+++ b/README.md
@@ -52,6 +52,30 @@ func main() {
 
 ```
 
+
+### Error handling:
+
+Open-AI maintains clear documentation on how to [handle API errors](https://platform.openai.com/docs/guides/error-codes/api-errors)
+
+example:
+```
+e := &APIError{}
+if errors.As(err, &e) {
+  switch e.HTTPStatusCode {
+    case 401:
+      // invalid auth or key (do not retry)
+    case 429:
+	  // rate limiting or engine overload (wait and retry) 
+	case 500:
+	  // openai server error (retry)
+	default:
+	  // unhandled
+	}
+}
+
+```
+
+
 ### Other examples:
 
 <details>

--- a/client.go
+++ b/client.go
@@ -144,15 +144,16 @@ func (c *Client) handleErrorResp(resp *http.Response) error {
 	var errRes ErrorResponse
 	err := json.NewDecoder(resp.Body).Decode(&errRes)
 	if err != nil || errRes.Error == nil {
-		reqErr := RequestError{
+		reqErr := &RequestError{
 			HTTPStatusCode: resp.StatusCode,
 			Err:            err,
 		}
 		if errRes.Error != nil {
-			reqErr.Err = errRes.Error
+			reqErr.Err = fmt.Errorf(errRes.Error.Message)
 		}
-		return fmt.Errorf("error, %w", &reqErr)
+		return reqErr
 	}
+
 	errRes.Error.HTTPStatusCode = resp.StatusCode
-	return fmt.Errorf("error, status code: %d, message: %w", resp.StatusCode, errRes.Error)
+	return errRes.Error
 }

--- a/client.go
+++ b/client.go
@@ -149,7 +149,7 @@ func (c *Client) handleErrorResp(resp *http.Response) error {
 			Err:            err,
 		}
 		if errRes.Error != nil {
-			reqErr.Err = fmt.Errorf(errRes.Error.Message)
+			reqErr.Err = errRes.Error
 		}
 		return reqErr
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -106,7 +106,7 @@ func TestHandleErrorResp(t *testing.T) {
 					}
 				}`,
 			)),
-			expected: "error, status code 401, message: Access denied due to Virtual Network/Firewall rules.",
+			expected: "error, status code: 401, message: Access denied due to Virtual Network/Firewall rules.",
 		},
 		{
 			name:     "503 Model Overloaded",

--- a/client_test.go
+++ b/client_test.go
@@ -2,6 +2,7 @@ package openai //nolint:testpackage // testing private field
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -133,6 +134,12 @@ func TestHandleErrorResp(t *testing.T) {
 			t.Log(err.Error())
 			if err.Error() != tc.expected {
 				t.Errorf("Unexpected error: %v , expected: %s", err, tc.expected)
+				t.Fail()
+			}
+
+			e := &APIError{}
+			if !errors.As(err, &e) {
+				t.Errorf("(%s) Expected error to be of type APIError", tc.name)
 				t.Fail()
 			}
 		})

--- a/error.go
+++ b/error.go
@@ -25,7 +25,7 @@ type ErrorResponse struct {
 }
 
 func (e *APIError) Error() string {
-	return e.Message
+	return fmt.Sprintf("error, status code: %d, message: %s", e.HTTPStatusCode, e.Message)
 }
 
 func (e *APIError) UnmarshalJSON(data []byte) (err error) {
@@ -70,7 +70,7 @@ func (e *APIError) UnmarshalJSON(data []byte) (err error) {
 }
 
 func (e *RequestError) Error() string {
-	return fmt.Sprintf("status code %d, message: %s", e.HTTPStatusCode, e.Err)
+	return fmt.Sprintf("error, status code: %d, message: %s", e.HTTPStatusCode, e.Err)
 }
 
 func (e *RequestError) Unwrap() error {

--- a/error.go
+++ b/error.go
@@ -25,7 +25,11 @@ type ErrorResponse struct {
 }
 
 func (e *APIError) Error() string {
-	return fmt.Sprintf("error, status code: %d, message: %s", e.HTTPStatusCode, e.Message)
+	if e.HTTPStatusCode > 0 {
+		return fmt.Sprintf("error, status code: %d, message: %s", e.HTTPStatusCode, e.Message)
+	}
+
+	return e.Message
 }
 
 func (e *APIError) UnmarshalJSON(data []byte) (err error) {


### PR DESCRIPTION
Resolves https://github.com/sashabaranov/go-openai/issues/292, https://github.com/sashabaranov/go-openai/issues/288


Maintains underlying error structs to allow consumers to utilize type conversion and create a defensive structure as defined by the Open AI error handling documentation.

It also slightly modifies the Error() functions to that they are responsible for converting the struct into an informational string versus just a fragment of its parent

Modifies only a single test that was missing a colon when all of the other tests have colons (including the RequestError Error function that was missing the colon that the other Error function included