### PR TITLE
Resolve issue #296: Remove httpbin dependency from TestRequestError

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -226,8 +228,13 @@ func TestAPIErrorUnmarshalJSONInvalidMessage(t *testing.T) {
 func TestRequestError(t *testing.T) {
 	var err error
 
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	}))
+	defer ts.Close()
+
 	config := DefaultConfig("dummy")
-	config.BaseURL = "https://httpbin.org/status/418?"
+	config.BaseURL = ts.URL
 	c := NewClientWithConfig(config)
 	ctx := context.Background()
 	_, err = c.ListEngines(ctx)


### PR DESCRIPTION
This pull request addresses and resolves issue #296 by removing the dependency on httpbin from the TestRequestError function.