### PR TITLE
Added an option to provide file for speech recognition not as a local file, but as bytes

### DIFF
--- a/form_builder.go
+++ b/form_builder.go
@@ -8,6 +8,7 @@ import (
 
 type formBuilder interface {
 	createFormFile(fieldname string, file *os.File) error
+	createFormFileFromBytes(fieldname, fileName string, data []byte) error
 	writeField(fieldname, value string) error
 	close() error
 	formDataContentType() string
@@ -30,6 +31,19 @@ func (fb *defaultFormBuilder) createFormFile(fieldname string, file *os.File) er
 	}
 
 	_, err = io.Copy(fieldWriter, file)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (fb *defaultFormBuilder) createFormFileFromBytes(fieldname, fileName string, data []byte) error {
+	fieldWriter, err := fb.writer.CreateFormFile(fieldname, fileName)
+	if err != nil {
+		return err
+	}
+
+	_, err = fieldWriter.Write(data)
 	if err != nil {
 		return err
 	}

--- a/image_test.go
+++ b/image_test.go
@@ -263,13 +263,18 @@ func handleVariateImageEndpoint(w http.ResponseWriter, r *http.Request) {
 }
 
 type mockFormBuilder struct {
-	mockCreateFormFile func(string, *os.File) error
-	mockWriteField     func(string, string) error
-	mockClose          func() error
+	mockCreateFormFile  func(string, *os.File) error
+	mockCreateFormBytes func(string, string, []byte) error
+	mockWriteField      func(string, string) error
+	mockClose           func() error
 }
 
 func (fb *mockFormBuilder) createFormFile(fieldname string, file *os.File) error {
 	return fb.mockCreateFormFile(fieldname, file)
+}
+
+func (fb *mockFormBuilder) createFormFileFromBytes(fieldname, fileName string, data []byte) error {
+	return fb.mockCreateFormBytes(fieldname, fileName, data)
 }
 
 func (fb *mockFormBuilder) writeField(fieldname, value string) error {


### PR DESCRIPTION
Added an option to provide file for speech recognition not as a local file, but as bytes

Useful when file resides on a CDN and is not available locally.