### PR TITLE
Azure OpenAI API version 2023-05-15

### DIFF
--- a/api_internal_test.go
+++ b/api_internal_test.go
@@ -122,7 +122,7 @@ func TestAzureFullURL(t *testing.T) {
 			"chatgpt-demo",
 			"https://httpbin.org/" +
 				"openai/deployments/chatgpt-demo" +
-				"/chat/completions?api-version=2023-03-15-preview",
+				"/chat/completions?api-version=2023-05-15",
 		},
 		{
 			"AzureBaseURLWithoutSlashOK",
@@ -131,7 +131,7 @@ func TestAzureFullURL(t *testing.T) {
 			"chatgpt-demo",
 			"https://httpbin.org/" +
 				"openai/deployments/chatgpt-demo" +
-				"/chat/completions?api-version=2023-03-15-preview",
+				"/chat/completions?api-version=2023-05-15",
 		},
 	}
 

--- a/config.go
+++ b/config.go
@@ -56,7 +56,7 @@ func DefaultAzureConfig(apiKey, baseURL string) ClientConfig {
 		BaseURL:    baseURL,
 		OrgID:      "",
 		APIType:    APITypeAzure,
-		APIVersion: "2023-03-15-preview",
+		APIVersion: "2023-05-15",
 		AzureModelMapperFunc: func(model string) string {
 			return regexp.MustCompile(`[.:]`).ReplaceAllString(model, "")
 		},


### PR DESCRIPTION
Azure OpenAI API version 2023-05-15 has been released.

* [What's new in Azure OpenAI Service? \- Azure Cognitive Services \| Microsoft Learn](https://learn.microsoft.com/en-us/azure/cognitive-services/openai/whats-new#azure-openai-chat-completion-general-availability-ga)

<img width="752" alt="image" src="https://github.com/sashabaranov/go-openai/assets/1491856/1f3dbb94-42af-4394-9d3f-be1d481f5415">

* [Azure OpenAI Service REST API reference \- Azure OpenAI \| Microsoft Learn](https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference#rest-api-versioning)

<img width="750" alt="image" src="https://github.com/sashabaranov/go-openai/assets/1491856/ccb07c85-0b9b-4c03-bf98-48520c975eb0">

In response to the above announcement, I have updated the version specification.