### PR TITLE
Implement optional io.Reader in AudioRequest (#303) (#265)

### DIFF
--- a/audio.go
+++ b/audio.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 
@@ -27,8 +28,14 @@ const (
 // AudioRequest represents a request structure for audio API.
 // ResponseFormat is not supported for now. We only return JSON text, which may be sufficient.
 type AudioRequest struct {
-	Model       string
-	FilePath    string
+	Model string
+
+	// FilePath is either an existing file in your filesystem or a filename representing the contents of Reader.
+	FilePath string
+
+	// Reader is an optional io.Reader when you do not want to use an existing file.
+	Reader io.Reader
+
 	Prompt      string // For translation, it should be in English
 	Temperature float32
 	Language    string // For translation, just do not use it. It seems "en" works, not confirmed...
@@ -95,15 +102,24 @@ func (r AudioRequest) HasJSONResponse() bool {
 // audioMultipartForm creates a form with audio file contents and the name of the model to use for
 // audio processing.
 func audioMultipartForm(request AudioRequest, b utils.FormBuilder) error {
-	f, err := os.Open(request.FilePath)
-	if err != nil {
-		return fmt.Errorf("opening audio file: %w", err)
-	}
-	defer f.Close()
+	var err error
 
-	err = b.CreateFormFile("file", f)
-	if err != nil {
-		return fmt.Errorf("creating form file: %w", err)
+	if request.Reader != nil {
+		err = b.CreateFormFileReader("file", request.Reader, request.FilePath)
+		if err != nil {
+			return fmt.Errorf("creating form using reader: %w", err)
+		}
+	} else {
+		f, err := os.Open(request.FilePath)
+		if err != nil {
+			return fmt.Errorf("opening audio file: %w", err)
+		}
+		defer f.Close()
+
+		err = b.CreateFormFile("file", f)
+		if err != nil {
+			return fmt.Errorf("creating form file: %w", err)
+		}
 	}
 
 	err = b.WriteField("model", request.Model)

--- a/audio.go
+++ b/audio.go
@@ -102,10 +102,8 @@ func (r AudioRequest) HasJSONResponse() bool {
 // audioMultipartForm creates a form with audio file contents and the name of the model to use for
 // audio processing.
 func audioMultipartForm(request AudioRequest, b utils.FormBuilder) error {
-	var err error
-
 	if request.Reader != nil {
-		err = b.CreateFormFileReader("file", request.Reader, request.FilePath)
+		err := b.CreateFormFileReader("file", request.Reader, request.FilePath)
 		if err != nil {
 			return fmt.Errorf("creating form using reader: %w", err)
 		}
@@ -122,7 +120,7 @@ func audioMultipartForm(request AudioRequest, b utils.FormBuilder) error {
 		}
 	}
 
-	err = b.WriteField("model", request.Model)
+	err := b.WriteField("model", request.Model)
 	if err != nil {
 		return fmt.Errorf("writing model name: %w", err)
 	}

--- a/audio_test.go
+++ b/audio_test.go
@@ -2,6 +2,7 @@ package openai //nolint:testpackage // testing private field
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -11,12 +12,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"testing"
 
 	"github.com/sashabaranov/go-openai/internal/test"
 	"github.com/sashabaranov/go-openai/internal/test/checks"
-
-	"context"
-	"testing"
 )
 
 // TestAudio Tests the transcription and translation endpoints of the API using the mocked server.
@@ -60,6 +59,16 @@ func TestAudio(t *testing.T) {
 
 			req := AudioRequest{
 				FilePath: path,
+				Model:    "whisper-3",
+			}
+			_, err = tc.createFn(ctx, req)
+			checks.NoError(t, err, "audio API error")
+		})
+
+		t.Run(tc.name+" (with reader)", func(t *testing.T) {
+			req := AudioRequest{
+				FilePath: "fake.webm",
+				Reader:   bytes.NewBuffer([]byte(`some webm binary data`)),
 				Model:    "whisper-3",
 			}
 			_, err = tc.createFn(ctx, req)

--- a/audio_test.go
+++ b/audio_test.go
@@ -261,4 +261,15 @@ func TestCreateFileField(t *testing.T) {
 		err := createFileField(req, mockBuilder)
 		checks.ErrorIs(t, err, mockFailedErr, "createFileField using a reader should return error if form builder fails")
 	})
+
+	t.Run("createFileField failing open", func(t *testing.T) {
+		req := AudioRequest{
+			FilePath: "non_existing_file.wav",
+		}
+
+		mockBuilder := &mockFormBuilder{}
+
+		err := createFileField(req, mockBuilder)
+		checks.HasError(t, err, "createFileField using file should return error when open file fails")
+	})
 }

--- a/image_test.go
+++ b/image_test.go
@@ -264,13 +264,18 @@ func handleVariateImageEndpoint(w http.ResponseWriter, r *http.Request) {
 }
 
 type mockFormBuilder struct {
-	mockCreateFormFile func(string, *os.File) error
-	mockWriteField     func(string, string) error
-	mockClose          func() error
+	mockCreateFormFile       func(string, *os.File) error
+	mockCreateFormFileReader func(string, io.Reader, string) error
+	mockWriteField           func(string, string) error
+	mockClose                func() error
 }
 
 func (fb *mockFormBuilder) CreateFormFile(fieldname string, file *os.File) error {
 	return fb.mockCreateFormFile(fieldname, file)
+}
+
+func (fb *mockFormBuilder) CreateFormFileReader(fieldname string, r io.Reader, filename string) error {
+	return fb.mockCreateFormFileReader(fieldname, r, filename)
 }
 
 func (fb *mockFormBuilder) WriteField(fieldname, value string) error {

--- a/internal/form_builder.go
+++ b/internal/form_builder.go
@@ -1,13 +1,16 @@
 package openai
 
 import (
+	"fmt"
 	"io"
 	"mime/multipart"
 	"os"
+	"path"
 )
 
 type FormBuilder interface {
 	CreateFormFile(fieldname string, file *os.File) error
+	CreateFormFileReader(fieldname string, r io.Reader, filename string) error
 	WriteField(fieldname, value string) error
 	Close() error
 	FormDataContentType() string
@@ -24,15 +27,28 @@ func NewFormBuilder(body io.Writer) *DefaultFormBuilder {
 }
 
 func (fb *DefaultFormBuilder) CreateFormFile(fieldname string, file *os.File) error {
-	fieldWriter, err := fb.writer.CreateFormFile(fieldname, file.Name())
+	return fb.createFormFile(fieldname, file, file.Name())
+}
+
+func (fb *DefaultFormBuilder) CreateFormFileReader(fieldname string, r io.Reader, filename string) error {
+	return fb.createFormFile(fieldname, r, path.Base(filename))
+}
+
+func (fb *DefaultFormBuilder) createFormFile(fieldname string, r io.Reader, filename string) error {
+	if filename == "" {
+		return fmt.Errorf("filename cannot be empty")
+	}
+
+	fieldWriter, err := fb.writer.CreateFormFile(fieldname, filename)
 	if err != nil {
 		return err
 	}
 
-	_, err = io.Copy(fieldWriter, file)
+	_, err = io.Copy(fieldWriter, r)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
This change adds an optional `io.Reader` to the `AudioRequest` structure. This addition makes this structure more versatile and allows you to use a different source other than an existing file from your filesystem. It also maintaining backwards compatibility.

I'd be glad to implement the same logic for the other Request types (`FileRequest`, `ImageEditRequest`, `ImageVariRequest`) in preferably subsequent PR's.
