### PR TITLE
remove omitempty tag from temperature fields (#333)

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -34,7 +34,7 @@ type ChatCompletionRequest struct {
 	Model            string                  `json:"model"`
 	Messages         []ChatCompletionMessage `json:"messages"`
 	MaxTokens        int                     `json:"max_tokens,omitempty"`
-	Temperature      float32                 `json:"temperature,omitempty"`
+	Temperature      float32                 `json:"temperature"`
 	TopP             float32                 `json:"top_p,omitempty"`
 	N                int                     `json:"n,omitempty"`
 	Stream           bool                    `json:"stream,omitempty"`

--- a/completion.go
+++ b/completion.go
@@ -90,7 +90,7 @@ type CompletionRequest struct {
 	Prompt           any            `json:"prompt,omitempty"`
 	Suffix           string         `json:"suffix,omitempty"`
 	MaxTokens        int            `json:"max_tokens,omitempty"`
-	Temperature      float32        `json:"temperature,omitempty"`
+	Temperature      float32        `json:"temperature"`
 	TopP             float32        `json:"top_p,omitempty"`
 	N                int            `json:"n,omitempty"`
 	Stream           bool           `json:"stream,omitempty"`

--- a/edits.go
+++ b/edits.go
@@ -12,7 +12,7 @@ type EditsRequest struct {
 	Input       string  `json:"input,omitempty"`
 	Instruction string  `json:"instruction,omitempty"`
 	N           int     `json:"n,omitempty"`
-	Temperature float32 `json:"temperature,omitempty"`
+	Temperature float32 `json:"temperature"`
 	TopP        float32 `json:"top_p,omitempty"`
 }
 


### PR DESCRIPTION
~I confirmed the OpenAI API documentation. The default value for temperature is `1`. The temperature field of the request structure was given an `omitempty` tag, so a value of `0` was removed from the request parameter. It would be better to remove the `omitempty` tag so that `0` can be used.~

Oops, removing the omitempty tag changes the default value in this client library.
I thought it would be better to change the temperature type to pointer(*float32). But that is BREAKING CHANGES.

Refs:
- https://platform.openai.com/docs/api-reference/chat/create#chat/create-temperature
- https://platform.openai.com/docs/api-reference/completions/create#completions/create-temperature
- https://platform.openai.com/docs/api-reference/edits/create#edits/create-temperature

Note: For audio api only, the default value for temperature is `0`.
Refs: https://platform.openai.com/docs/api-reference/audio/create