### PR TITLE
Enable using http proxy set in the env

### DIFF
--- a/config.go
+++ b/config.go
@@ -44,7 +44,11 @@ func DefaultConfig(authToken string) ClientConfig {
 		APIType:   APITypeOpenAI,
 		OrgID:     "",
 
-		HTTPClient: &http.Client{},
+		HTTPClient: &http.Client{
+			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment, // use http_proxy from env
+			},
+		},
 
 		EmptyMessagesLimit: defaultEmptyMessagesLimit,
 	}


### PR DESCRIPTION
When connecting to OpenAI, try to use a proxy set in the environment variables, such as HTTP_PROXY,HTTPS_PROXY and NO_PROXY