### PR TITLE
fix json marshaling error response of azure openai (#343)

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -134,6 +134,15 @@ func TestHandleErrorResp(t *testing.T) {
 				}`)),
 			expected: "error, status code: 503, message: That model...",
 		},
+		{
+			name:     "503 no message (Unknown response)",
+			httpCode: http.StatusServiceUnavailable,
+			body: bytes.NewReader([]byte(`
+				{
+					"error":{}
+				}`)),
+			expected: "error, status code: 503, message: ",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/error.go
+++ b/error.go
@@ -44,9 +44,13 @@ func (e *APIError) UnmarshalJSON(data []byte) (err error) {
 		return
 	}
 
-	err = json.Unmarshal(rawMap["type"], &e.Type)
-	if err != nil {
-		return
+	// optional fields for azure openai
+	// refs: https://github.com/sashabaranov/go-openai/issues/343
+	if _, ok := rawMap["type"]; ok {
+		err = json.Unmarshal(rawMap["type"], &e.Type)
+		if err != nil {
+			return
+		}
 	}
 
 	// optional fields


### PR DESCRIPTION
Fix #343

Azure OpenAI error response seems to be `type` field missing sometimes. Error (`unexpected end of JSON input`) when parsing `type` in `APIError.UnmarshalJSON` function.

Example error response:
```
# Azure OpenAI
{
   "error":{
      "code":"429",
      "message":"Requests to the Creates a completion for the chat message Operation under Azure OpenAI API version 2023-03-15-preview have exceeded token rate limit of your current OpenAI S0 pricing tier. Please retry after 17 seconds. Please go here: https://aka.ms/oai/quotaincrease if you would like to further increase the default rate limit."
   }
}
```

**Note:**
I also considered changing the `type` field to a pointer, but decided against it because that would be a breaking changes.