### PR TITLE
更改 常量为外部可访问常量，目的是可以自定义配置，比如使用自定义 baseUrl 方便作反向代理

### DIFF
--- a/client.go
+++ b/client.go
@@ -49,10 +49,10 @@ func (c *Client) sendRequest(req *http.Request, v any) error {
 	req.Header.Set("Accept", "application/json; charset=utf-8")
 	// Azure API Key authentication
 	if c.config.APIType == APITypeAzure {
-		req.Header.Set(AzureAPIKeyHeader, c.config.authToken)
+		req.Header.Set(AzureAPIKeyHeader, c.config.AuthToken)
 	} else {
 		// OpenAI or Azure AD authentication
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.authToken))
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.AuthToken))
 	}
 
 	// Check whether Content-Type is already set, Upload Files API requires
@@ -110,7 +110,7 @@ func (c *Client) fullURL(suffix string, args ...any) string {
 		// if suffix is /models change to {endpoint}/openai/models?api-version=2022-12-01
 		// https://learn.microsoft.com/en-us/rest/api/cognitiveservices/azureopenaistable/models/list?tabs=HTTP
 		if strings.Contains(suffix, "/models") {
-			return fmt.Sprintf("%s/%s%s?api-version=%s", baseURL, azureAPIPrefix, suffix, c.config.APIVersion)
+			return fmt.Sprintf("%s/%s%s?api-version=%s", baseURL, AzureAPIPrefix, suffix, c.config.APIVersion)
 		}
 		azureDeploymentName := "UNKNOWN"
 		if len(args) > 0 {
@@ -120,7 +120,7 @@ func (c *Client) fullURL(suffix string, args ...any) string {
 			}
 		}
 		return fmt.Sprintf("%s/%s/%s/%s%s?api-version=%s",
-			baseURL, azureAPIPrefix, azureDeploymentsPrefix,
+			baseURL, AzureAPIPrefix, AzureDeploymentsPrefix,
 			azureDeploymentName, suffix, c.config.APIVersion,
 		)
 	}
@@ -148,10 +148,10 @@ func (c *Client) newStreamRequest(
 	// https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference#authentication
 	// Azure API Key authentication
 	if c.config.APIType == APITypeAzure {
-		req.Header.Set(AzureAPIKeyHeader, c.config.authToken)
+		req.Header.Set(AzureAPIKeyHeader, c.config.AuthToken)
 	} else {
 		// OpenAI or Azure AD authentication
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.authToken))
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.AuthToken))
 	}
 	if c.config.OrgID != "" {
 		req.Header.Set("OpenAI-Organization", c.config.OrgID)

--- a/config.go
+++ b/config.go
@@ -6,11 +6,11 @@ import (
 )
 
 const (
-	openaiAPIURLv1                 = "https://api.openai.com/v1"
-	defaultEmptyMessagesLimit uint = 300
+	OpenaiAPIURLv1                 = "https://api.openai.com/v1"
+	DefaultEmptyMessagesLimit uint = 300
 
-	azureAPIPrefix         = "openai"
-	azureDeploymentsPrefix = "deployments"
+	AzureAPIPrefix         = "openai"
+	AzureDeploymentsPrefix = "deployments"
 )
 
 type APIType string
@@ -25,7 +25,7 @@ const AzureAPIKeyHeader = "api-key"
 
 // ClientConfig is a configuration of a client.
 type ClientConfig struct {
-	authToken string
+	AuthToken string
 
 	BaseURL              string
 	OrgID                string
@@ -39,20 +39,20 @@ type ClientConfig struct {
 
 func DefaultConfig(authToken string) ClientConfig {
 	return ClientConfig{
-		authToken: authToken,
-		BaseURL:   openaiAPIURLv1,
+		AuthToken: authToken,
+		BaseURL:   OpenaiAPIURLv1,
 		APIType:   APITypeOpenAI,
 		OrgID:     "",
 
 		HTTPClient: &http.Client{},
 
-		EmptyMessagesLimit: defaultEmptyMessagesLimit,
+		EmptyMessagesLimit: DefaultEmptyMessagesLimit,
 	}
 }
 
 func DefaultAzureConfig(apiKey, baseURL string) ClientConfig {
 	return ClientConfig{
-		authToken:  apiKey,
+		AuthToken:  apiKey,
 		BaseURL:    baseURL,
 		OrgID:      "",
 		APIType:    APITypeAzure,
@@ -63,7 +63,7 @@ func DefaultAzureConfig(apiKey, baseURL string) ClientConfig {
 
 		HTTPClient: &http.Client{},
 
-		EmptyMessagesLimit: defaultEmptyMessagesLimit,
+		EmptyMessagesLimit: DefaultEmptyMessagesLimit,
 	}
 }
 


### PR DESCRIPTION
OpenaiAPIURLv1                 = "https://api.openai.com/v1"
DefaultEmptyMessagesLimit uint = 300

AzureAPIPrefix         = "openai"
AzureDeploymentsPrefix = "deployments"

更改 常量为外部可访问常量，目的是可以自定义配置，比如使用自定义 baseUrl 方便作反向代理