### PR TITLE
models: add *-0613 models

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -17,11 +17,15 @@ var (
 // GPT3 Models are designed for text-based tasks. For code-specific
 // tasks, please refer to the Codex series of models.
 const (
+	GPT432K0613             = "gpt-4-32k-0613"
 	GPT432K0314             = "gpt-4-32k-0314"
 	GPT432K                 = "gpt-4-32k"
+	GPT40613                = "gpt-4-0613"
 	GPT40314                = "gpt-4-0314"
 	GPT4                    = "gpt-4"
+	GPT3Dot5Turbo0613       = "gpt-3.5-turbo-0613"
 	GPT3Dot5Turbo0301       = "gpt-3.5-turbo-0301"
+	GPT3Dot5Turbo16K        = "gpt-3.5-turbo-16k"
 	GPT3Dot5Turbo           = "gpt-3.5-turbo"
 	GPT3TextDavinci003      = "text-davinci-003"
 	GPT3TextDavinci002      = "text-davinci-002"
@@ -50,10 +54,14 @@ var disabledModelsForEndpoints = map[string]map[string]bool{
 	"/completions": {
 		GPT3Dot5Turbo:     true,
 		GPT3Dot5Turbo0301: true,
+		GPT3Dot5Turbo0613: true,
+		GPT3Dot5Turbo16K:  true,
 		GPT4:              true,
 		GPT40314:          true,
+		GPT40613:          true,
 		GPT432K:           true,
 		GPT432K0314:       true,
+		GPT432K0613:       true,
 	},
 	"/chat/completions": {
 		CodexCodeDavinci002:     true,


### PR DESCRIPTION
Added GPT3Dot5Turbo0613, GPT3Dot5Turbo16K, GPT40613, and GPT432K0613
models from [June update](https://openai.com/blog/function-calling-and-other-api-updates)

Issue #360
