### PR TITLE
add items, which is required for array type

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -95,6 +95,8 @@ type JSONSchemaDefine struct {
 	Properties map[string]*JSONSchemaDefine `json:"properties,omitempty"`
 	// Required is a required of JSON Schema. It used if Type is JSONSchemaTypeObject.
 	Required []string `json:"required,omitempty"`
+	// Items is a property of JSON Schema. It used if Type is JSONSchemaTypeArray.
+	Items map[string]*JSONSchemaDefine `json:"items,omitempty"`
 }
 
 type FinishReason string

--- a/chat.go
+++ b/chat.go
@@ -96,7 +96,7 @@ type JSONSchemaDefine struct {
 	// Required is a required of JSON Schema. It used if Type is JSONSchemaTypeObject.
 	Required []string `json:"required,omitempty"`
 	// Items is a property of JSON Schema. It used if Type is JSONSchemaTypeArray.
-	Items map[string]*JSONSchemaDefine `json:"items,omitempty"`
+	Items *JSONSchemaDefine `json:"items,omitempty"`
 }
 
 type FinishReason string


### PR DESCRIPTION
When using openai.JSONSchemaTypeArray, you must define and "Items" object, otherwise OpenAI will return a 400. 