### PR TITLE
fix: function_call can be a string or an object

### DIFF
--- a/chat_stream.go
+++ b/chat_stream.go
@@ -8,8 +8,9 @@ import (
 )
 
 type ChatCompletionStreamChoiceDelta struct {
-	Content string `json:"content,omitempty"`
-	Role    string `json:"role,omitempty"`
+	Content      string        `json:"content,omitempty"`
+	Role         string        `json:"role,omitempty"`
+	FunctionCall *FunctionCall `json:"function_call,omitempty"`
 }
 
 type ChatCompletionStreamChoice struct {
@@ -43,6 +44,11 @@ func (c *Client) CreateChatCompletionStream(
 	urlSuffix := chatCompletionsSuffix
 	if !checkEndpointSupportsModel(urlSuffix, request.Model) {
 		err = ErrChatCompletionInvalidModel
+		return
+	}
+
+	if !checkFunctionCall(request.FunctionCall) {
+		err = ErrChatCompletionInvalidFunctionCall
 		return
 	}
 


### PR DESCRIPTION
According to the document, `function_call` parameter can a string literal: "none", "auto", or an object with a key "name".

https://platform.openai.com/docs/api-reference/chat/create#chat/create-function_call

Also added `FunctionCall` to `ChatCompletionStreamChoiceDelta`.