### PR TITLE
Add Items to JSONSchemaDefine for JsonTypeArray.

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -95,6 +95,8 @@ type JSONSchemaDefine struct {
 	Properties map[string]*JSONSchemaDefine `json:"properties,omitempty"`
 	// Required is a required of JSON Schema. It used if Type is JSONSchemaTypeObject.
 	Required []string `json:"required,omitempty"`
+	// Items is a items of JSON Schema. It used if Type is JSONSchemaTypeArray.
+	Items *JSONSchemaDefine `json:"items,omitempty"`
 }
 
 type FinishReason string


### PR DESCRIPTION
In the current version (v1.11.0), when trying to use the `JsonTypeArray` in FunctionCall, it is not possible to define the array type, resulting in a 400 error.

I propose adding `Items` to `JSONSchemaDefine`. This would allow the array type to be specified and would eliminate the aforementioned error.

Could you please have a moment to take a look at it?

### example
```
func main() {
	ctx := context.Background()
	c := openai.NewClient("key")
	response, err := c.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
		Model: openai.GPT40613,
		Messages: []openai.ChatCompletionMessage{
			{
				Role:    openai.ChatMessageRoleUser,
				Content: "「What is the weather like in Boston?」Break down the above sentence into words",
			},
		},
		N:                0,
		Stream:           false,
		Stop:             nil,
		MaxTokens:        1024,
		PresencePenalty:  0,
		FrequencyPenalty: 0,
		LogitBias:        nil,
		Functions: []*openai.FunctionDefine{
			{
				Name:        "split_word",
				Description: "Break sentences into words",
				Parameters: &openai.FunctionParams{
					Type: openai.JSONSchemaTypeObject,
					Properties: map[string]*openai.JSONSchemaDefine{
						"list": {
							Type: openai.JSONSchemaTypeArray,
							Items: &openai.JSONSchemaDefine{
								Type: openai.JSONSchemaTypeString,
							},
							Description: "word list",
						},
						"count": {
							Type:        openai.JSONSchemaTypeNumber,
							Description: "word count",
						},
					},
					Required: []string{"list", "count"},
				},
			},
		},
	})
	if err != nil {
		panic(err)
	}
	if response.Choices[0].FinishReason != openai.FinishReasonFunctionCall {
		panic(err)
	}
	fmt.Println(response.Choices[0].Message.FunctionCall.Arguments)
}

/*
output: 
{
  "count": 7,
  "list": ["What", "is", "the", "weather", "like", "in", "Boston?"]
}
*/
```


### referrence
https://json-schema.org/understanding-json-schema/reference/array.html#id6
