### PR TITLE
feat(config): can use the proxy URL to call the OpenAI API

### DIFF
--- a/config.go
+++ b/config.go
@@ -50,6 +50,22 @@ func DefaultConfig(authToken string) ClientConfig {
 	}
 }
 
+func DefaultConfigWithUrl(authToken string, proxyUrl string) ClientConfig {
+	if proxyUrl == "" {
+		proxyUrl = openaiAPIURLv1
+	}
+	return ClientConfig{
+		authToken: authToken,
+		BaseURL:   proxyUrl,
+		APIType:   APITypeOpenAI,
+		OrgID:     "",
+
+		HTTPClient: &http.Client{},
+
+		EmptyMessagesLimit: defaultEmptyMessagesLimit,
+	}
+}
+
 func DefaultAzureConfig(apiKey, baseURL string) ClientConfig {
 	return ClientConfig{
 		authToken:  apiKey,


### PR DESCRIPTION
In some regions, OpenAI is not accessible. This commit can be completed by calling openai.NewClientWithConfig(openai.DefaultConfigWithUrl(authToken, proxyUrl)). This will be helpful to those people.:-)