### PR TITLE
fix parsing error of api error response (#381)

### DIFF
--- a/error.go
+++ b/error.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // APIError provides error information returned by the OpenAI API.
@@ -41,7 +42,14 @@ func (e *APIError) UnmarshalJSON(data []byte) (err error) {
 
 	err = json.Unmarshal(rawMap["message"], &e.Message)
 	if err != nil {
-		return
+		// If the parameter field of a function call is invalid as a JSON schema
+		// refs: https://github.com/sashabaranov/go-openai/issues/381
+		var messages []string
+		err = json.Unmarshal(rawMap["message"], &messages)
+		if err != nil {
+			return
+		}
+		e.Message = strings.Join(messages, ", ")
 	}
 
 	// optional fields for azure openai


### PR DESCRIPTION
Fix #381

**Context:**
Basically, it is a `string`. However, if the json schema of the `parameters` field is invalid, as shown below, it is likely to be an `array`.

```bash
$ curl https://api.openai.com/v1/chat/completions -u :$OPENAI_API_KEY -H 'Content-Type: application/json' -d '{
  "model": "gpt-3.5-turbo-0613",
  "messages": [
    {"role": "user", "content": "What is the weather like in Boston?"}
  ],
  "functions": [
    {
      "name": "get_current_weather",
      "parameters": {
        "type": "object"
      }
    }
  ]
}'

{
  "error":{
     "message":[
        "Invalid schema for function 'get_current_weather': In context=(), object schema missing properties"
     ],
     "type":"invalid_request_error",
     "param":null,
     "code":null
  }
}
```