### PR TITLE
feat: added function call info to chat completions

### DIFF
--- a/chat_stream.go
+++ b/chat_stream.go
@@ -8,8 +8,9 @@ import (
 )
 
 type ChatCompletionStreamChoiceDelta struct {
-	Content string `json:"content,omitempty"`
-	Role    string `json:"role,omitempty"`
+	Content      string        `json:"content,omitempty"`
+	Role         string        `json:"role,omitempty"`
+	FunctionCall *FunctionCall `json:"function_call,omitempty"`
 }
 
 type ChatCompletionStreamChoice struct {


### PR DESCRIPTION
Function calls are currently inaccessible in chat completion streams. This addresses that issue.