### PR TITLE
refactor: refactoring http request creation and sending

### DIFF
--- a/api_internal_test.go
+++ b/api_internal_test.go
@@ -94,7 +94,7 @@ func TestRequestAuthHeader(t *testing.T) {
 			az.OrgID = c.OrgID
 
 			cli := NewClientWithConfig(az)
-			req, err := cli.newStreamRequest(context.Background(), "POST", "/chat/completions", nil, "")
+			req, err := cli.newRequest(context.Background(), "POST", "/chat/completions")
 			if err != nil {
 				t.Errorf("Failed to create request: %v", err)
 			}

--- a/audio.go
+++ b/audio.go
@@ -95,11 +95,11 @@ func (c *Client) callAudioAPI(
 	}
 
 	urlSuffix := fmt.Sprintf("/audio/%s", endpointSuffix)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.fullURL(urlSuffix, request.Model), &formBody)
+	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL(urlSuffix, request.Model),
+		withBody(&formBody), withContentType(builder.FormDataContentType()))
 	if err != nil {
 		return AudioResponse{}, err
 	}
-	req.Header.Add("Content-Type", builder.FormDataContentType())
 
 	if request.HasJSONResponse() {
 		err = c.sendRequest(req, &response)

--- a/chat.go
+++ b/chat.go
@@ -148,7 +148,7 @@ func (c *Client) CreateChatCompletion(
 		return
 	}
 
-	req, err := c.requestBuilder.Build(ctx, http.MethodPost, c.fullURL(urlSuffix, request.Model), request)
+	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL(urlSuffix, request.Model), withBody(request))
 	if err != nil {
 		return
 	}

--- a/chat_stream.go
+++ b/chat_stream.go
@@ -1,10 +1,8 @@
 package openai
 
 import (
-	"bufio"
 	"context"
-
-	utils "github.com/sashabaranov/go-openai/internal"
+	"net/http"
 )
 
 type ChatCompletionStreamChoiceDelta struct {
@@ -47,27 +45,17 @@ func (c *Client) CreateChatCompletionStream(
 	}
 
 	request.Stream = true
-	req, err := c.newStreamRequest(ctx, "POST", urlSuffix, request, request.Model)
+	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL(urlSuffix, request.Model), withBody(request))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := sendRequestStream[ChatCompletionStreamResponse](c, req)
 	if err != nil {
 		return
 	}
-
-	resp, err := c.config.HTTPClient.Do(req) //nolint:bodyclose // body is closed in stream.Close()
-	if err != nil {
-		return
-	}
-	if isFailureStatusCode(resp) {
-		return nil, c.handleErrorResp(resp)
-	}
-
 	stream = &ChatCompletionStream{
-		streamReader: &streamReader[ChatCompletionStreamResponse]{
-			emptyMessagesLimit: c.config.EmptyMessagesLimit,
-			reader:             bufio.NewReader(resp.Body),
-			response:           resp,
-			errAccumulator:     utils.NewErrorAccumulator(),
-			unmarshaler:        &utils.JSONUnmarshaler{},
-		},
+		streamReader: resp,
 	}
 	return
 }

--- a/client_test.go
+++ b/client_test.go
@@ -16,7 +16,7 @@ var errTestRequestBuilderFailed = errors.New("test request builder failed")
 
 type failingRequestBuilder struct{}
 
-func (*failingRequestBuilder) Build(_ context.Context, _, _ string, _ any) (*http.Request, error) {
+func (*failingRequestBuilder) Build(_ context.Context, _, _ string, _ any, _ http.Header) (*http.Request, error) {
 	return nil, errTestRequestBuilderFailed
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -41,9 +41,10 @@ func TestDecodeResponse(t *testing.T) {
 	stringInput := ""
 
 	testCases := []struct {
-		name  string
-		value interface{}
-		body  io.Reader
+		name     string
+		value    interface{}
+		body     io.Reader
+		hasError bool
 	}{
 		{
 			name:  "nil input",
@@ -60,16 +61,30 @@ func TestDecodeResponse(t *testing.T) {
 			value: &map[string]interface{}{},
 			body:  bytes.NewReader([]byte(`{"test": "test"}`)),
 		},
+		{
+			name:     "reader return error",
+			value:    &stringInput,
+			body:     &errorReader{err: errors.New("dummy")},
+			hasError: true,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := decodeResponse(tc.body, tc.value)
-			if err != nil {
+			if (err != nil) != tc.hasError {
 				t.Errorf("Unexpected error: %v", err)
 			}
 		})
 	}
+}
+
+type errorReader struct {
+	err error
+}
+
+func (e *errorReader) Read(_ []byte) (n int, err error) {
+	return 0, e.err
 }
 
 func TestHandleErrorResp(t *testing.T) {

--- a/completion.go
+++ b/completion.go
@@ -165,7 +165,7 @@ func (c *Client) CreateCompletion(
 		return
 	}
 
-	req, err := c.requestBuilder.Build(ctx, http.MethodPost, c.fullURL(urlSuffix, request.Model), request)
+	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL(urlSuffix, request.Model), withBody(request))
 	if err != nil {
 		return
 	}

--- a/edits.go
+++ b/edits.go
@@ -32,7 +32,7 @@ type EditsResponse struct {
 
 // Perform an API call to the Edits endpoint.
 func (c *Client) Edits(ctx context.Context, request EditsRequest) (response EditsResponse, err error) {
-	req, err := c.requestBuilder.Build(ctx, http.MethodPost, c.fullURL("/edits", fmt.Sprint(request.Model)), request)
+	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL("/edits", fmt.Sprint(request.Model)), withBody(request))
 	if err != nil {
 		return
 	}

--- a/embeddings.go
+++ b/embeddings.go
@@ -132,7 +132,7 @@ type EmbeddingRequest struct {
 // CreateEmbeddings returns an EmbeddingResponse which will contain an Embedding for every item in |request.Input|.
 // https://beta.openai.com/docs/api-reference/embeddings/create
 func (c *Client) CreateEmbeddings(ctx context.Context, request EmbeddingRequest) (resp EmbeddingResponse, err error) {
-	req, err := c.requestBuilder.Build(ctx, http.MethodPost, c.fullURL("/embeddings", request.Model.String()), request)
+	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL("/embeddings", request.Model.String()), withBody(request))
 	if err != nil {
 		return
 	}

--- a/engines.go
+++ b/engines.go
@@ -22,7 +22,7 @@ type EnginesList struct {
 // ListEngines Lists the currently available engines, and provides basic
 // information about each option such as the owner and availability.
 func (c *Client) ListEngines(ctx context.Context) (engines EnginesList, err error) {
-	req, err := c.requestBuilder.Build(ctx, http.MethodGet, c.fullURL("/engines"), nil)
+	req, err := c.newRequest(ctx, http.MethodGet, c.fullURL("/engines"))
 	if err != nil {
 		return
 	}
@@ -38,7 +38,7 @@ func (c *Client) GetEngine(
 	engineID string,
 ) (engine Engine, err error) {
 	urlSuffix := fmt.Sprintf("/engines/%s", engineID)
-	req, err := c.requestBuilder.Build(ctx, http.MethodGet, c.fullURL(urlSuffix), nil)
+	req, err := c.newRequest(ctx, http.MethodGet, c.fullURL(urlSuffix))
 	if err != nil {
 		return
 	}

--- a/fine_tunes.go
+++ b/fine_tunes.go
@@ -68,7 +68,7 @@ type FineTuneDeleteResponse struct {
 
 func (c *Client) CreateFineTune(ctx context.Context, request FineTuneRequest) (response FineTune, err error) {
 	urlSuffix := "/fine-tunes"
-	req, err := c.requestBuilder.Build(ctx, http.MethodPost, c.fullURL(urlSuffix), request)
+	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL(urlSuffix), withBody(request))
 	if err != nil {
 		return
 	}
@@ -79,7 +79,7 @@ func (c *Client) CreateFineTune(ctx context.Context, request FineTuneRequest) (r
 
 // CancelFineTune cancel a fine-tune job.
 func (c *Client) CancelFineTune(ctx context.Context, fineTuneID string) (response FineTune, err error) {
-	req, err := c.requestBuilder.Build(ctx, http.MethodPost, c.fullURL("/fine-tunes/"+fineTuneID+"/cancel"), nil)
+	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL("/fine-tunes/"+fineTuneID+"/cancel"))
 	if err != nil {
 		return
 	}
@@ -89,7 +89,7 @@ func (c *Client) CancelFineTune(ctx context.Context, fineTuneID string) (respons
 }
 
 func (c *Client) ListFineTunes(ctx context.Context) (response FineTuneList, err error) {
-	req, err := c.requestBuilder.Build(ctx, http.MethodGet, c.fullURL("/fine-tunes"), nil)
+	req, err := c.newRequest(ctx, http.MethodGet, c.fullURL("/fine-tunes"))
 	if err != nil {
 		return
 	}
@@ -100,7 +100,7 @@ func (c *Client) ListFineTunes(ctx context.Context) (response FineTuneList, err 
 
 func (c *Client) GetFineTune(ctx context.Context, fineTuneID string) (response FineTune, err error) {
 	urlSuffix := fmt.Sprintf("/fine-tunes/%s", fineTuneID)
-	req, err := c.requestBuilder.Build(ctx, http.MethodGet, c.fullURL(urlSuffix), nil)
+	req, err := c.newRequest(ctx, http.MethodGet, c.fullURL(urlSuffix))
 	if err != nil {
 		return
 	}
@@ -110,7 +110,7 @@ func (c *Client) GetFineTune(ctx context.Context, fineTuneID string) (response F
 }
 
 func (c *Client) DeleteFineTune(ctx context.Context, fineTuneID string) (response FineTuneDeleteResponse, err error) {
-	req, err := c.requestBuilder.Build(ctx, http.MethodDelete, c.fullURL("/fine-tunes/"+fineTuneID), nil)
+	req, err := c.newRequest(ctx, http.MethodDelete, c.fullURL("/fine-tunes/"+fineTuneID))
 	if err != nil {
 		return
 	}
@@ -120,7 +120,7 @@ func (c *Client) DeleteFineTune(ctx context.Context, fineTuneID string) (respons
 }
 
 func (c *Client) ListFineTuneEvents(ctx context.Context, fineTuneID string) (response FineTuneEventList, err error) {
-	req, err := c.requestBuilder.Build(ctx, http.MethodGet, c.fullURL("/fine-tunes/"+fineTuneID+"/events"), nil)
+	req, err := c.newRequest(ctx, http.MethodGet, c.fullURL("/fine-tunes/"+fineTuneID+"/events"))
 	if err != nil {
 		return
 	}

--- a/image.go
+++ b/image.go
@@ -44,7 +44,7 @@ type ImageResponseDataInner struct {
 // CreateImage - API call to create an image. This is the main endpoint of the DALL-E API.
 func (c *Client) CreateImage(ctx context.Context, request ImageRequest) (response ImageResponse, err error) {
 	urlSuffix := "/images/generations"
-	req, err := c.requestBuilder.Build(ctx, http.MethodPost, c.fullURL(urlSuffix), request)
+	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL(urlSuffix), withBody(request))
 	if err != nil {
 		return
 	}
@@ -107,13 +107,12 @@ func (c *Client) CreateEditImage(ctx context.Context, request ImageEditRequest) 
 		return
 	}
 
-	urlSuffix := "/images/edits"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.fullURL(urlSuffix), body)
+	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL("/images/edits"),
+		withBody(body), withContentType(builder.FormDataContentType()))
 	if err != nil {
 		return
 	}
 
-	req.Header.Set("Content-Type", builder.FormDataContentType())
 	err = c.sendRequest(req, &response)
 	return
 }
@@ -158,14 +157,12 @@ func (c *Client) CreateVariImage(ctx context.Context, request ImageVariRequest) 
 		return
 	}
 
-	//https://platform.openai.com/docs/api-reference/images/create-variation
-	urlSuffix := "/images/variations"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.fullURL(urlSuffix), body)
+	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL("/images/variations"),
+		withBody(body), withContentType(builder.FormDataContentType()))
 	if err != nil {
 		return
 	}
 
-	req.Header.Set("Content-Type", builder.FormDataContentType())
 	err = c.sendRequest(req, &response)
 	return
 }

--- a/internal/request_builder.go
+++ b/internal/request_builder.go
@@ -21,8 +21,13 @@ func NewRequestBuilder() *HTTPRequestBuilder {
 	}
 }
 
-func (b *HTTPRequestBuilder) Build(ctx context.Context,
-	method, url string, body any, header http.Header) (req *http.Request, err error) {
+func (b *HTTPRequestBuilder) Build(
+	ctx context.Context,
+	method string,
+	url string,
+	body any,
+	header http.Header,
+) (req *http.Request, err error) {
 	var bodyReader io.Reader
 	if body != nil {
 		if v, ok := body.(io.Reader); ok {

--- a/internal/request_builder.go
+++ b/internal/request_builder.go
@@ -21,7 +21,8 @@ func NewRequestBuilder() *HTTPRequestBuilder {
 	}
 }
 
-func (b *HTTPRequestBuilder) Build(ctx context.Context, method, url string, body any, header http.Header) (req *http.Request, err error) {
+func (b *HTTPRequestBuilder) Build(ctx context.Context,
+	method, url string, body any, header http.Header) (req *http.Request, err error) {
 	var bodyReader io.Reader
 	if body != nil {
 		if v, ok := body.(io.Reader); ok {

--- a/internal/request_builder.go
+++ b/internal/request_builder.go
@@ -3,11 +3,12 @@ package openai
 import (
 	"bytes"
 	"context"
+	"io"
 	"net/http"
 )
 
 type RequestBuilder interface {
-	Build(ctx context.Context, method, url string, request any) (*http.Request, error)
+	Build(ctx context.Context, method, url string, body any, header http.Header) (*http.Request, error)
 }
 
 type HTTPRequestBuilder struct {
@@ -20,21 +21,26 @@ func NewRequestBuilder() *HTTPRequestBuilder {
 	}
 }
 
-func (b *HTTPRequestBuilder) Build(ctx context.Context, method, url string, request any) (*http.Request, error) {
-	if request == nil {
-		return http.NewRequestWithContext(ctx, method, url, nil)
+func (b *HTTPRequestBuilder) Build(ctx context.Context, method, url string, body any, header http.Header) (req *http.Request, err error) {
+	var bodyReader io.Reader
+	if body != nil {
+		if v, ok := body.(io.Reader); ok {
+			bodyReader = v
+		} else {
+			var reqBytes []byte
+			reqBytes, err = b.marshaller.Marshal(body)
+			if err != nil {
+				return
+			}
+			bodyReader = bytes.NewBuffer(reqBytes)
+		}
 	}
-
-	var reqBytes []byte
-	reqBytes, err := b.marshaller.Marshal(request)
+	req, err = http.NewRequestWithContext(ctx, method, url, bodyReader)
 	if err != nil {
-		return nil, err
+		return
 	}
-
-	return http.NewRequestWithContext(
-		ctx,
-		method,
-		url,
-		bytes.NewBuffer(reqBytes),
-	)
+	if header != nil {
+		req.Header = header
+	}
+	return
 }

--- a/internal/request_builder_test.go
+++ b/internal/request_builder_test.go
@@ -22,7 +22,7 @@ func TestRequestBuilderReturnsMarshallerErrors(t *testing.T) {
 		marshaller: &failingMarshaller{},
 	}
 
-	_, err := builder.Build(context.Background(), "", "", struct{}{})
+	_, err := builder.Build(context.Background(), "", "", struct{}{}, nil)
 	if !errors.Is(err, errTestMarshallerFailed) {
 		t.Fatalf("Did not return error when marshaller failed: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestRequestBuilderReturnsRequest(t *testing.T) {
 		reqBytes, _ = b.marshaller.Marshal(request)
 		want, _     = http.NewRequestWithContext(ctx, method, url, bytes.NewBuffer(reqBytes))
 	)
-	got, _ := b.Build(ctx, method, url, request)
+	got, _ := b.Build(ctx, method, url, request, nil)
 	if !reflect.DeepEqual(got.Body, want.Body) ||
 		!reflect.DeepEqual(got.URL, want.URL) ||
 		!reflect.DeepEqual(got.Method, want.Method) {
@@ -54,7 +54,7 @@ func TestRequestBuilderReturnsRequestWhenRequestOfArgsIsNil(t *testing.T) {
 		want, _ = http.NewRequestWithContext(ctx, method, url, nil)
 	)
 	b := NewRequestBuilder()
-	got, _ := b.Build(ctx, method, url, nil)
+	got, _ := b.Build(ctx, method, url, nil, nil)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Build() got = %v, want %v", got, want)
 	}

--- a/models.go
+++ b/models.go
@@ -41,7 +41,7 @@ type ModelsList struct {
 // ListModels Lists the currently available models,
 // and provides basic information about each model such as the model id and parent.
 func (c *Client) ListModels(ctx context.Context) (models ModelsList, err error) {
-	req, err := c.requestBuilder.Build(ctx, http.MethodGet, c.fullURL("/models"), nil)
+	req, err := c.newRequest(ctx, http.MethodGet, c.fullURL("/models"))
 	if err != nil {
 		return
 	}
@@ -54,7 +54,7 @@ func (c *Client) ListModels(ctx context.Context) (models ModelsList, err error) 
 // the model such as the owner and permissioning.
 func (c *Client) GetModel(ctx context.Context, modelID string) (model Model, err error) {
 	urlSuffix := fmt.Sprintf("/models/%s", modelID)
-	req, err := c.requestBuilder.Build(ctx, http.MethodGet, c.fullURL(urlSuffix), nil)
+	req, err := c.newRequest(ctx, http.MethodGet, c.fullURL(urlSuffix))
 	if err != nil {
 		return
 	}

--- a/moderation.go
+++ b/moderation.go
@@ -63,7 +63,7 @@ type ModerationResponse struct {
 // Moderations — perform a moderation api call over a string.
 // Input can be an array or slice but a string will reduce the complexity.
 func (c *Client) Moderations(ctx context.Context, request ModerationRequest) (response ModerationResponse, err error) {
-	req, err := c.requestBuilder.Build(ctx, http.MethodPost, c.fullURL("/moderations", request.Model), request)
+	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL("/moderations", request.Model), withBody(&request))
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
`http.Request` creation and sending were duplicated, so they have been aggregated into a common function.

- `RequestBuilder#Build` function calls were aggregated into the `Client#newRequest` function.
- All public functions build `http.Request` in the `Client#newRequest` function.
- The sending of `http.Request` is now aggregated into the following three functions.
  - `Client#sendRequest` function: marshalling the response into a structure
  - `Client#sendRequestRaw` function: returns the Body of the response as is 
  - `Client#sendRequestStream` function: use generics to specify a `streamable` type.