### PR TITLE
docs: add requires go version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This library provides unofficial Go clients for [OpenAI API](https://platform.op
 ```
 go get github.com/sashabaranov/go-openai
 ```
-
+Currently, go-openai requires Go version 1.18 or greater.
 
 ### ChatGPT example usage:
 


### PR DESCRIPTION
I'd like go-openai to declare that 1.18 or greater is required because it uses generics internally.