### PR TITLE
Allow embeddings requests to be tokens or strings

### DIFF
--- a/embeddings.go
+++ b/embeddings.go
@@ -149,7 +149,7 @@ func (r EmbeddingRequest) ToEmbeddingRequest() BaseEmbeddingRequest {
 }
 
 type EmbeddingRequestTokens struct {
-	// Input is a slice of slices of ints ([][]int) representing a slice of slices of tokens for which you want to generate an Embedding vector.
+	// Input is a slice of slices of ints ([][]int) for which you want to generate an Embedding vector.
 	// Each input must not exceed 8192 tokens in length.
 	// OpenAPI suggests replacing newlines (\n) in your input with a single space, as they
 	// have observed inferior results when newlines are present.
@@ -173,9 +173,9 @@ func (r EmbeddingRequestTokens) ToEmbeddingRequest() BaseEmbeddingRequest {
 
 // CreateEmbeddings returns an EmbeddingResponse which will contain an Embedding for every item in |request.Input|.
 // https://beta.openai.com/docs/api-reference/embeddings/create
-func (c *Client) CreateEmbeddings(ctx context.Context, request EmbeddingRequestBody) (resp EmbeddingResponse, err error) {
-	baseRequest := request.ToEmbeddingRequest()
-	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL("/embeddings", baseRequest.Model.String()), withBody(baseRequest))
+func (c *Client) CreateEmbeddings(ctx context.Context, body EmbeddingRequestBody) (resp EmbeddingResponse, err error) {
+	baseReq := body.ToEmbeddingRequest()
+	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL("/embeddings", baseReq.Model.String()), withBody(baseReq))
 	if err != nil {
 		return
 	}

--- a/embeddings.go
+++ b/embeddings.go
@@ -171,7 +171,7 @@ func (r EmbeddingRequestTokens) ToEmbeddingRequest() BaseEmbeddingRequest {
 	}
 }
 
-// CreateEmbeddings returns an EmbeddingResponse which will contain an Embedding for every item in |request.Input|.
+// CreateEmbeddings returns an EmbeddingResponse which will contain an Embedding for every item in |body.Input|.
 // https://beta.openai.com/docs/api-reference/embeddings/create
 func (c *Client) CreateEmbeddings(ctx context.Context, body EmbeddingRequestBody) (resp EmbeddingResponse, err error) {
 	baseReq := body.ToEmbeddingRequest()

--- a/embeddings.go
+++ b/embeddings.go
@@ -180,8 +180,8 @@ func (r EmbeddingRequestTokens) Convert() EmbeddingRequest {
 //
 // Body should be of type EmbeddingRequestStrings for embedding strings or EmbeddingRequestTokens
 // for embedding groups of text already converted to tokens.
-func (c *Client) CreateEmbeddings(ctx context.Context, r EmbeddingRequestConverter) (res EmbeddingResponse, err error) {
-	baseReq := r.Convert()
+func (c *Client) CreateEmbeddings(ctx context.Context, conv EmbeddingRequestConverter) (res EmbeddingResponse, err error) { //nolint:lll
+	baseReq := conv.Convert()
 	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL("/embeddings", baseReq.Model.String()), withBody(baseReq))
 	if err != nil {
 		return

--- a/embeddings.go
+++ b/embeddings.go
@@ -119,7 +119,7 @@ type EmbeddingRequestBody interface {
 }
 
 type BaseEmbeddingRequest struct {
-	Input interface{}    `json:"input"`
+	Input any            `json:"input"`
 	Model EmbeddingModel `json:"model"`
 	User  string         `json:"user"`
 }

--- a/embeddings.go
+++ b/embeddings.go
@@ -177,6 +177,9 @@ func (r EmbeddingRequestTokens) Convert() EmbeddingRequest {
 
 // CreateEmbeddings returns an EmbeddingResponse which will contain an Embedding for every item in |body.Input|.
 // https://beta.openai.com/docs/api-reference/embeddings/create
+//
+// Body should be of type EmbeddingRequestStrings for embedding strings or EmbeddingRequestTokens
+// for embedding groups of text already converted to tokens.
 func (c *Client) CreateEmbeddings(ctx context.Context, body EmbeddingRequestConverter) (resp EmbeddingResponse, err error) {
 	baseReq := body.Convert()
 	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL("/embeddings", baseReq.Model.String()), withBody(baseReq))

--- a/embeddings.go
+++ b/embeddings.go
@@ -180,14 +180,14 @@ func (r EmbeddingRequestTokens) Convert() EmbeddingRequest {
 //
 // Body should be of type EmbeddingRequestStrings for embedding strings or EmbeddingRequestTokens
 // for embedding groups of text already converted to tokens.
-func (c *Client) CreateEmbeddings(ctx context.Context, body EmbeddingRequestConverter) (resp EmbeddingResponse, err error) {
-	baseReq := body.Convert()
+func (c *Client) CreateEmbeddings(ctx context.Context, r EmbeddingRequestConverter) (res EmbeddingResponse, err error) {
+	baseReq := r.Convert()
 	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL("/embeddings", baseReq.Model.String()), withBody(baseReq))
 	if err != nil {
 		return
 	}
 
-	err = c.sendRequest(req, &resp)
+	err = c.sendRequest(req, &res)
 
 	return
 }

--- a/embeddings_test.go
+++ b/embeddings_test.go
@@ -92,4 +92,8 @@ func TestEmbeddingEndpoint(t *testing.T) {
 	)
 	_, err := client.CreateEmbeddings(context.Background(), EmbeddingRequest{})
 	checks.NoError(t, err, "CreateEmbeddings error")
+
+	// test create embeddings with tokens
+	_, err = client.CreateEmbeddings(context.Background(), EmbeddingRequestTokens{})
+	checks.NoError(t, err, "CreateEmbeddings error")
 }

--- a/embeddings_test.go
+++ b/embeddings_test.go
@@ -32,6 +32,7 @@ func TestEmbedding(t *testing.T) {
 		BabbageCodeSearchText,
 	}
 	for _, model := range embeddedModels {
+		// test embedding request with strings (simple embedding request)
 		embeddingReq := EmbeddingRequest{
 			Input: []string{
 				"The food was delicious and the waiter",
@@ -47,6 +48,21 @@ func TestEmbedding(t *testing.T) {
 			t.Fatalf("Expected embedding request to contain model field")
 		}
 
+		// test embedding request with strings
+		embeddingReqStrings := EmbeddingRequestStrings{
+			Input: []string{
+				"The food was delicious and the waiter",
+				"Other examples of embedding request",
+			},
+			Model: model,
+		}
+		marshaled, err = json.Marshal(embeddingReqStrings)
+		checks.NoError(t, err, "Could not marshal embedding request")
+		if !bytes.Contains(marshaled, []byte(`"model":"`+model.String()+`"`)) {
+			t.Fatalf("Expected embedding request to contain model field")
+		}
+
+		// test embedding request with tokens
 		embeddingReqTokens := EmbeddingRequestTokens{
 			Input: [][]int{
 				{464, 2057, 373, 12625, 290, 262, 46612},
@@ -88,10 +104,15 @@ func TestEmbeddingEndpoint(t *testing.T) {
 			fmt.Fprintln(w, string(resBytes))
 		},
 	)
+	// test create embeddings with strings (simple embedding request)
 	_, err := client.CreateEmbeddings(context.Background(), EmbeddingRequest{})
 	checks.NoError(t, err, "CreateEmbeddings error")
 
+	// test create embeddings with strings
+	_, err = client.CreateEmbeddings(context.Background(), EmbeddingRequestStrings{})
+	checks.NoError(t, err, "CreateEmbeddings strings error")
+
 	// test create embeddings with tokens
 	_, err = client.CreateEmbeddings(context.Background(), EmbeddingRequestTokens{})
-	checks.NoError(t, err, "CreateEmbeddings error")
+	checks.NoError(t, err, "CreateEmbeddings tokens error")
 }

--- a/embeddings_test.go
+++ b/embeddings_test.go
@@ -46,6 +46,21 @@ func TestEmbedding(t *testing.T) {
 		if !bytes.Contains(marshaled, []byte(`"model":"`+model.String()+`"`)) {
 			t.Fatalf("Expected embedding request to contain model field")
 		}
+
+		embeddingReqTokens := EmbeddingRequestTokens{
+			Input: [][]int{
+				{464, 2057, 373, 12625, 290, 262, 46612},
+				{6395, 6096, 286, 11525, 12083, 2581},
+			},
+			Model: model,
+		}
+		// marshal embeddingReq to JSON and confirm that the model field equals
+		// the AdaSearchQuery type
+		marshaled, err = json.Marshal(embeddingReqTokens)
+		checks.NoError(t, err, "Could not marshal embedding request")
+		if !bytes.Contains(marshaled, []byte(`"model":"`+model.String()+`"`)) {
+			t.Fatalf("Expected embedding request to contain model field")
+		}
 	}
 }
 

--- a/embeddings_test.go
+++ b/embeddings_test.go
@@ -54,8 +54,6 @@ func TestEmbedding(t *testing.T) {
 			},
 			Model: model,
 		}
-		// marshal embeddingReq to JSON and confirm that the model field equals
-		// the AdaSearchQuery type
 		marshaled, err = json.Marshal(embeddingReqTokens)
 		checks.NoError(t, err, "Could not marshal embedding request")
 		if !bytes.Contains(marshaled, []byte(`"model":"`+model.String()+`"`)) {


### PR DESCRIPTION
Addresses #240 

There may be a cleaner way to do this, but this is the best way I could think of quickly to not cause any breaking changes and to maintain some semblance of type checking for the user (instead of just changing the Input field type in EmbeddingRequest from string to interface{}).

Also modified the test case for it.

Thanks for all of the work you guys do on this project!