### PR TITLE
Fix OpenAI error when properties is empty in function call : object s…

### DIFF
--- a/jsonschema/json.go
+++ b/jsonschema/json.go
@@ -27,7 +27,7 @@ type Definition struct {
 	// one element, where each element is unique. You will probably only use this with strings.
 	Enum []string `json:"enum,omitempty"`
 	// Properties describes the properties of an object, if the schema type is Object.
-	Properties map[string]Definition `json:"properties,omitempty"`
+	Properties map[string]Definition `json:"properties"`
 	// Required specifies which properties are required, if the schema type is Object.
 	Required []string `json:"required,omitempty"`
 	// Items specifies which data type an array contains, if the schema type is Array.


### PR DESCRIPTION
when properties is empty in function call, OpenAI API will return error: 
- status: 400
- msg: object schema missing properties