### PR TITLE
docs: added instructions for obtaining OpenAI API key to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,6 @@ This library provides unofficial Go clients for [OpenAI API](https://platform.op
 * DALL·E 2
 * Whisper
 
-### Getting an OpenAI API Key:
-
-1. Visit the OpenAI website at [https://platform.openai.com/account/api-keys](https://platform.openai.com/account/api-keys).
-2. If you don't have an account, click on "Sign Up" to create one. If you do, click "Log In".
-3. Once logged in, navigate to your API key management page.
-4. Click on "Create new secret key".
-5. Enter a name for your new key, then click "Create secret key".
-6. Your new API key will be displayed. Use this key to interact with the OpenAI API.
-
-**Note:** Your API key is sensitive information. Do not share it with anyone.
-
 ### Installation:
 ```
 go get github.com/sashabaranov/go-openai
@@ -62,6 +51,17 @@ func main() {
 }
 
 ```
+
+### Getting an OpenAI API Key:
+
+1. Visit the OpenAI website at [https://platform.openai.com/account/api-keys](https://platform.openai.com/account/api-keys).
+2. If you don't have an account, click on "Sign Up" to create one. If you do, click "Log In".
+3. Once logged in, navigate to your API key management page.
+4. Click on "Create new secret key".
+5. Enter a name for your new key, then click "Create secret key".
+6. Your new API key will be displayed. Use this key to interact with the OpenAI API.
+
+**Note:** Your API key is sensitive information. Do not share it with anyone.
 
 ### Other examples:
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ This library provides unofficial Go clients for [OpenAI API](https://platform.op
 * DALL·E 2
 * Whisper
 
+### Getting an OpenAI API Key:
+
+1. Visit the OpenAI website at [https://platform.openai.com/account/api-keys](https://platform.openai.com/account/api-keys).
+2. If you don't have an account, click on "Sign Up" to create one. If you do, click "Log In".
+3. Once logged in, navigate to your API key management page.
+4. Click on "Create new secret key".
+5. Enter a name for your new key, then click "Create secret key".
+6. Your new API key will be displayed. Use this key to interact with the OpenAI API.
+
+**Note:** Your API key is sensitive information. Do not share it with anyone.
+
 ### Installation:
 ```
 go get github.com/sashabaranov/go-openai


### PR DESCRIPTION
@sashabaranov 

**Describe the change**
Adding instructions on how to obtain the OpenAI API key in README solves the following problems:

1. **Ease and Convenience**: New developers can quickly understand how to obtain the API key, enabling them to start using the library faster.
2. **Preventing Misunderstandings**: Without clear instructions, developers could potentially follow incorrect steps, leading to wasted time or potential security risks.
3. **Reducing Queries**: By providing clear instructions, there's less need for developers to ask questions or make inquiries about obtaining the API key, freeing up time for the maintainers of the library.

**Tests**
None.

**Additional context**
Issue: #73
