### PR TITLE
fix: invalid schema for function 'func_name': None is not of type 'object' (#429)(#432)

### DIFF
--- a/api_integration_test.go
+++ b/api_integration_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/sashabaranov/go-openai"
 	. "github.com/sashabaranov/go-openai"
 	"github.com/sashabaranov/go-openai/internal/test/checks"
 	"github.com/sashabaranov/go-openai/jsonschema"
@@ -105,15 +104,15 @@ func TestAPI(t *testing.T) {
 
 	_, err = c.CreateChatCompletion(
 		context.Background(),
-		openai.ChatCompletionRequest{
-			Model: openai.GPT3Dot5Turbo,
-			Messages: []openai.ChatCompletionMessage{
+		ChatCompletionRequest{
+			Model: GPT3Dot5Turbo,
+			Messages: []ChatCompletionMessage{
 				{
-					Role:    openai.ChatMessageRoleUser,
+					Role:    ChatMessageRoleUser,
 					Content: "What is the weather like in Boston?",
 				},
 			},
-			Functions: []openai.FunctionDefinition{{
+			Functions: []FunctionDefinition{{
 				Name: "get_current_weather",
 				Parameters: jsonschema.Definition{
 					Type: jsonschema.Object,

--- a/jsonschema/json.go
+++ b/jsonschema/json.go
@@ -36,23 +36,14 @@ type Definition struct {
 	Items *Definition `json:"items,omitempty"`
 }
 
-func (d *Definition) MarshalJSON() ([]byte, error) {
-	d.initializeProperties()
-	return json.Marshal(*d)
-}
-
-func (d *Definition) initializeProperties() {
+func (d Definition) MarshalJSON() ([]byte, error) {
 	if d.Properties == nil {
 		d.Properties = make(map[string]Definition)
-		return
 	}
-
-	for k, v := range d.Properties {
-		if v.Properties == nil {
-			v.Properties = make(map[string]Definition)
-		} else {
-			v.initializeProperties()
-		}
-		d.Properties[k] = v
-	}
+	type Alias Definition
+	return json.Marshal(struct {
+		Alias
+	}{
+		Alias: (Alias)(d),
+	})
 }

--- a/jsonschema/json_test.go
+++ b/jsonschema/json_test.go
@@ -172,30 +172,40 @@ func TestDefinition_MarshalJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotBytes, err := json.Marshal(&tt.def)
-			if err != nil {
-				t.Errorf("Failed to Marshal JSON: error = %v", err)
-				return
-			}
-
-			var got map[string]interface{}
-			err = json.Unmarshal(gotBytes, &got)
-			if err != nil {
-				t.Errorf("Failed to Unmarshal JSON: error =  %v", err)
-				return
-			}
-
 			wantBytes := []byte(tt.want)
 			var want map[string]interface{}
-			err = json.Unmarshal(wantBytes, &want)
+			err := json.Unmarshal(wantBytes, &want)
 			if err != nil {
 				t.Errorf("Failed to Unmarshal JSON: error = %v", err)
 				return
 			}
 
+			got := structToMap(t, tt.def)
+			gotPtr := structToMap(t, &tt.def)
+
 			if !reflect.DeepEqual(got, want) {
 				t.Errorf("MarshalJSON() got = %v, want %v", got, want)
 			}
+			if !reflect.DeepEqual(gotPtr, want) {
+				t.Errorf("MarshalJSON() gotPtr = %v, want %v", gotPtr, want)
+			}
 		})
 	}
+}
+
+func structToMap(t *testing.T, v any) map[string]any {
+	t.Helper()
+	gotBytes, err := json.Marshal(v)
+	if err != nil {
+		t.Errorf("Failed to Marshal JSON: error = %v", err)
+		return nil
+	}
+
+	var got map[string]interface{}
+	err = json.Unmarshal(gotBytes, &got)
+	if err != nil {
+		t.Errorf("Failed to Unmarshal JSON: error =  %v", err)
+		return nil
+	}
+	return got
 }


### PR DESCRIPTION
**Describe the change**
The problem recurs when Parameters is a value instead of a pointer. MarshalJSON in Definition does not execute MarshalJSON if Definition is a value because the receiver is a pointer.
```
func (d *Definition) MarshalJSON() ([]byte, error)
```
Refs:
- https://github.com/sashabaranov/go-openai/pull/433#issuecomment-1629401793
- https://github.com/sashabaranov/go-openai/pull/433#issuecomment-1629430142

error message:
```
 invalid schema for function 'func_name': None is not of type 'object' 
```

request to reproduce:
```
	req := openai.ChatCompletionRequest{
		Model: openai.GPT3Dot5Turbo,
		Messages: []openai.ChatCompletionMessage{
			{
				Role:    openai.ChatMessageRoleUser,
				Content: "What is the weather like in Boston?",
			},
		},
		Functions: []openai.FunctionDefinition{{
			Name: "get_current_weather",
			Parameters: jsonschema.Definition{ // <= The problem recurs when Parameters is a value instead of a pointer.
				Type: jsonschema.Object,
				Properties: map[string]jsonschema.Definition{
					"location": {
						Type:        jsonschema.String,
						Description: "The city and state, e.g. San Francisco, CA",
					},
					"unit": {
						Type: jsonschema.String,
						Enum: []string{"celsius", "fahrenheit"},
					},
				},
				Required: []string{"location"},
			},
		}},
	}
```

**Describe your solution**
- MarshalJSON method is executed whether jsonschema.Definition in Parameters is a pointer or a value
- Initialization with an empty map if Properties is nil.

**Tests**
- Test MarshalJSON with both value and pointer.
- add integration test for function call.

**Additional context**
Issue: #429, #432
