### PR TITLE
Check if the model param is valid for moderations endpoint

### DIFF
--- a/moderation.go
+++ b/moderation.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"errors"
 	"net/http"
 )
 
@@ -17,6 +18,15 @@ const (
 	ModerationTextLatest = "text-moderation-latest"
 	ModerationText001    = "text-moderation-001"
 )
+
+var (
+	ErrModerationInvalidModel = errors.New("this model is not supported with moderation, please use text-moderation-stable or text-moderation-latest instead") //nolint:lll
+)
+
+var validModerationModel = map[string]struct{}{
+	ModerationTextStable: {},
+	ModerationTextLatest: {},
+}
 
 // ModerationRequest represents a request structure for moderation API.
 type ModerationRequest struct {
@@ -63,6 +73,10 @@ type ModerationResponse struct {
 // Moderations — perform a moderation api call over a string.
 // Input can be an array or slice but a string will reduce the complexity.
 func (c *Client) Moderations(ctx context.Context, request ModerationRequest) (response ModerationResponse, err error) {
+	if _, ok := validModerationModel[request.Model]; len(request.Model) > 0 && !ok {
+		err = ErrModerationInvalidModel
+		return
+	}
 	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL("/moderations", request.Model), withBody(&request))
 	if err != nil {
 		return

--- a/moderation.go
+++ b/moderation.go
@@ -16,7 +16,8 @@ import (
 const (
 	ModerationTextStable = "text-moderation-stable"
 	ModerationTextLatest = "text-moderation-latest"
-	ModerationText001    = "text-moderation-001"
+	// Deprecated: use ModerationTextStable and ModerationTextLatest instead.
+	ModerationText001 = "text-moderation-001"
 )
 
 var (

--- a/moderation_test.go
+++ b/moderation_test.go
@@ -27,6 +27,18 @@ func TestModerations(t *testing.T) {
 	checks.NoError(t, err, "Moderation error")
 }
 
+// TestModerationsWithIncorrectModel Tests passing an incorrect model to Moderations request.
+func TestModerationsWithIncorrectModel(t *testing.T) {
+	client, server, teardown := setupOpenAITestServer()
+	defer teardown()
+	server.RegisterHandler("/v1/moderations", handleModerationEndpoint)
+	_, err := client.Moderations(context.Background(), ModerationRequest{
+		Model: GPT3Dot5Turbo,
+		Input: "I want to kill them.",
+	})
+	checks.ErrorIs(t, err, ErrModerationInvalidModel)
+}
+
 // handleModerationEndpoint Handles the moderation endpoint by the test server.
 func handleModerationEndpoint(w http.ResponseWriter, r *http.Request) {
 	var err error

--- a/moderation_test.go
+++ b/moderation_test.go
@@ -27,16 +27,39 @@ func TestModerations(t *testing.T) {
 	checks.NoError(t, err, "Moderation error")
 }
 
-// TestModerationsWithIncorrectModel Tests passing an incorrect model to Moderations request.
-func TestModerationsWithIncorrectModel(t *testing.T) {
+// TestModerationsWithIncorrectModel Tests passing valid and invalid models to moderations endpoint.
+func TestModerationsWithDifferentModelOptions(t *testing.T) {
+	var modelOptions []struct {
+		model  string
+		expect error
+	}
+	modelOptions = append(modelOptions,
+		getModerationModelTestOption(GPT3Dot5Turbo, ErrModerationInvalidModel),
+		getModerationModelTestOption(ModerationTextStable, nil),
+		getModerationModelTestOption(ModerationTextLatest, nil),
+		getModerationModelTestOption("", nil),
+	)
 	client, server, teardown := setupOpenAITestServer()
 	defer teardown()
 	server.RegisterHandler("/v1/moderations", handleModerationEndpoint)
-	_, err := client.Moderations(context.Background(), ModerationRequest{
-		Model: GPT3Dot5Turbo,
-		Input: "I want to kill them.",
-	})
-	checks.ErrorIs(t, err, ErrModerationInvalidModel)
+	for _, modelTest := range modelOptions {
+		_, err := client.Moderations(context.Background(), ModerationRequest{
+			Model: modelTest.model,
+			Input: "I want to kill them.",
+		})
+		checks.ErrorIs(t, err, modelTest.expect,
+			fmt.Sprintf("Moderations(..) expects err: %v, actual err:%v", modelTest.expect, err))
+	}
+}
+
+func getModerationModelTestOption(model string, expect error) struct {
+	model  string
+	expect error
+} {
+	return struct {
+		model  string
+		expect error
+	}{model: model, expect: expect}
 }
 
 // handleModerationEndpoint Handles the moderation endpoint by the test server.


### PR DESCRIPTION
Currently there are only [two models available](https://platform.openai.com/docs/api-reference/moderations/create) for OpenAI /moderations endpoint, which are `text-moderation-stable` and `text-moderation-latest`. In the official python library `openai-python`. The method Moderation will check if the model param is in `VALID_MODEL_NAMES` and returns an error when it's not. 

```python
 def _prepare_create(cls, input, model, api_key):
        if model is not None and model not in cls.VALID_MODEL_NAMES:
            raise ValueError(
                f"The parameter model should be chosen from {cls.VALID_MODEL_NAMES} "
                f"and it is default to be None."
            )

        instance = cls(api_key=api_key)
        params = {"input": input}
        if model is not None:
            params["model"] = model
        return instance, params
```

It would be great if we can add similar checks before passing the request to `/v1/moderations` endpoint.

