### PR TITLE
Update comment for `jsonSchema.FunctionDefinition`

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -65,7 +65,7 @@ type FunctionDefinition struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
 	// Parameters is an object describing the function.
-	// You can pass a []byte describing the schema,
+	// You can pass json.RawMessage to describe the schema,
 	// or you can pass in a struct which serializes to the proper JSON schema.
 	// The jsonschema package is provided for convenience, but you should
 	// consider another specialized library if you require more complex schemas.


### PR DESCRIPTION
**Describe the change**
Currently, the comment for the `Parameters` property in the `jsonschema.FunctionDefinition` struct says that you can pass in a `[]byte{}`. However, this does not work and you need to use `json.RawMessage()` instead. 

**Describe your solution**
Just updated the comment :)

**Tests**
Not applicable!

**Additional context**
Passing in `[]byte{}` leads to base64'd value
![image](https://github.com/sashabaranov/go-openai/assets/8949415/e7319669-b396-493e-b329-d1d41635190c)