### PR TITLE
Add support for azure openai new version API (2023-07-01-preview)

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -21,6 +21,35 @@ var (
 	ErrChatCompletionStreamNotSupported = errors.New("streaming is not supported with this method, please use CreateChatCompletionStream")              //nolint:lll
 )
 
+type Hate struct {
+	Filtered bool   `json:"filtered"`
+	Severity string `json:"severity,omitempty"`
+}
+type SelfHarm struct {
+	Filtered bool   `json:"filtered"`
+	Severity string `json:"severity,omitempty"`
+}
+type Sexual struct {
+	Filtered bool   `json:"filtered"`
+	Severity string `json:"severity,omitempty"`
+}
+type Violence struct {
+	Filtered bool   `json:"filtered"`
+	Severity string `json:"severity,omitempty"`
+}
+
+type ContentFilterResults struct {
+	Hate     Hate     `json:"hate,omitempty"`
+	SelfHarm SelfHarm `json:"self_harm,omitempty"`
+	Sexual   SelfHarm `json:"sexual,omitempty"`
+	Violence Violence `json:"violence,omitempty"`
+}
+
+type PromptAnnotation struct {
+	PromptIndex          int                  `json:"prompt_index,omitempty"`
+	ContentFilterResults ContentFilterResults `json:"content_filter_results,omitempty"`
+}
+
 type ChatCompletionMessage struct {
 	Role    string `json:"role"`
 	Content string `json:"content"`
@@ -65,7 +94,7 @@ type FunctionDefinition struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
 	// Parameters is an object describing the function.
-	// You can pass json.RawMessage to describe the schema,
+	// You can pass a []byte describing the schema,
 	// or you can pass in a struct which serializes to the proper JSON schema.
 	// The jsonschema package is provided for convenience, but you should
 	// consider another specialized library if you require more complex schemas.

--- a/chat_stream.go
+++ b/chat_stream.go
@@ -12,17 +12,19 @@ type ChatCompletionStreamChoiceDelta struct {
 }
 
 type ChatCompletionStreamChoice struct {
-	Index        int                             `json:"index"`
-	Delta        ChatCompletionStreamChoiceDelta `json:"delta"`
-	FinishReason FinishReason                    `json:"finish_reason"`
+	Index                int                             `json:"index"`
+	Delta                ChatCompletionStreamChoiceDelta `json:"delta"`
+	FinishReason         FinishReason                    `json:"finish_reason"`
+	ContentFillerResults ContentFilterResults            `json:"content_filter_results,omitempty"`
 }
 
 type ChatCompletionStreamResponse struct {
-	ID      string                       `json:"id"`
-	Object  string                       `json:"object"`
-	Created int64                        `json:"created"`
-	Model   string                       `json:"model"`
-	Choices []ChatCompletionStreamChoice `json:"choices"`
+	ID                string                       `json:"id"`
+	Object            string                       `json:"object"`
+	Created           int64                        `json:"created"`
+	Model             string                       `json:"model"`
+	Choices           []ChatCompletionStreamChoice `json:"choices"`
+	PromptAnnotations []PromptAnnotation           `json:"prompt_annotations,omitempty"`
 }
 
 // ChatCompletionStream

--- a/chat_stream.go
+++ b/chat_stream.go
@@ -15,7 +15,7 @@ type ChatCompletionStreamChoice struct {
 	Index                int                             `json:"index"`
 	Delta                ChatCompletionStreamChoiceDelta `json:"delta"`
 	FinishReason         FinishReason                    `json:"finish_reason"`
-	ContentFillerResults ContentFilterResults            `json:"content_filter_results,omitempty"`
+	ContentFilterResults ContentFilterResults            `json:"content_filter_results,omitempty"`
 }
 
 type ChatCompletionStreamResponse struct {


### PR DESCRIPTION
Added support for the `2023-07-01-preview` API of Azure openai. The API before `2023-07-01-preview` has problems with function calling support. Starting from the `2023-07-01-preview` version, azure openai fixes the problems that existed before function calling.

#444 