### PR TITLE
feat: make finish reason nullable in json marshal

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -85,6 +85,13 @@ const (
 	FinishReasonNull          FinishReason = "null"
 )
 
+func (r FinishReason) MarshalJSON() ([]byte, error) {
+	if r == FinishReasonNull || r == "" {
+		return []byte("null"), nil
+	}
+	return []byte(`"` + string(r) + `"`), nil // best effort to not break future API changes
+}
+
 type ChatCompletionChoice struct {
 	Index   int                   `json:"index"`
 	Message ChatCompletionMessage `json:"message"`

--- a/chat_test.go
+++ b/chat_test.go
@@ -298,3 +298,34 @@ func getChatCompletionBody(r *http.Request) (ChatCompletionRequest, error) {
 	}
 	return completion, nil
 }
+
+func TestFinishReason(t *testing.T) {
+	c := &ChatCompletionChoice{
+		FinishReason: FinishReasonNull,
+	}
+	resBytes, _ := json.Marshal(c)
+	if !strings.Contains(string(resBytes), `"finish_reason":null`) {
+		t.Error("null should not be quoted")
+	}
+
+	c.FinishReason = ""
+
+	resBytes, _ = json.Marshal(c)
+	if !strings.Contains(string(resBytes), `"finish_reason":null`) {
+		t.Error("null should not be quoted")
+	}
+
+	otherReasons := []FinishReason{
+		FinishReasonStop,
+		FinishReasonLength,
+		FinishReasonFunctionCall,
+		FinishReasonContentFilter,
+	}
+	for _, r := range otherReasons {
+		c.FinishReason = r
+		resBytes, _ = json.Marshal(c)
+		if !strings.Contains(string(resBytes), fmt.Sprintf(`"finish_reason":"%s"`, r)) {
+			t.Errorf("%s should be quoted", r)
+		}
+	}
+}


### PR DESCRIPTION
**Describe the change**

this PR added a `MarshalJSON` to `FinishReason`. 

**Describe your solution**

`MarshalJSON` implemented `Marshaler` interface in package `encoding/json` 

If `FinishReason` is `FinishReasonNull` or empty string, we can render it as `null` instead of `"null"`.

**Tests**

```
c := &ChatCompletionChoice{
	FinishReason: FinishReasonNull,
}
jsonBytes, _ := json.Marshal(c)
fmt.Println(string(jsonBytes)) // it will print { .... "finish_reason": null }
```

Since i am not sure is this PR expected, i didn't add a lot of test cases in *_test.go file in the PR. but it was test locally. 
