### PR TITLE
Allow modifying requests to satisfy custom needs

### DIFF
--- a/client.go
+++ b/client.go
@@ -79,6 +79,13 @@ func (c *Client) newRequest(ctx context.Context, method, url string, setters ...
 		return nil, err
 	}
 	c.setCommonHeaders(req)
+
+	if c.config.CustomRequestModifier != nil {
+		if err = c.config.CustomRequestModifier(ctx, req); err != nil {
+			return nil, err
+		}
+	}
+
 	return req, nil
 }
 

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"context"
 	"net/http"
 	"regexp"
 )
@@ -33,6 +34,9 @@ type ClientConfig struct {
 	APIVersion           string                    // required when APIType is APITypeAzure or APITypeAzureAD
 	AzureModelMapperFunc func(model string) string // replace model to azure deployment name func
 	HTTPClient           *http.Client
+
+	// allows additional modification of request before sending
+	CustomRequestModifier func(ctx context.Context, req *http.Request) error
 
 	EmptyMessagesLimit uint
 }


### PR DESCRIPTION
Some company / organization service gateways may look for additional http headers for authentication or  tracing purpose. Having a request modifier hook in config allows such customization to be implemented without having to fork and patch the sdk.

Use ClientConfig.CustomRequestModifier to make any changes required to the request.

`TestChatCustomRequest` demonstrate a use case where a tracing header is added to the request.

Please let me know if any further changes are needed for this PR.
