### PR TITLE
Compatible with the 2023-07-01-preview API interface of Azure Openai, when content interception is triggered, the error message will contain innererror

### DIFF
--- a/error.go
+++ b/error.go
@@ -8,11 +8,18 @@ import (
 
 // APIError provides error information returned by the OpenAI API.
 type APIError struct {
-	Code           any     `json:"code,omitempty"`
-	Message        string  `json:"message"`
-	Param          *string `json:"param,omitempty"`
-	Type           string  `json:"type"`
-	HTTPStatusCode int     `json:"-"`
+	Code           any        `json:"code,omitempty"`
+	Message        string     `json:"message"`
+	Param          *string    `json:"param,omitempty"`
+	Type           string     `json:"type"`
+	HTTPStatusCode int        `json:"-"`
+	InnerError     InnerError `json:"innererror,omitempty"`
+}
+
+// InnerError Azure Content filtering.
+type InnerError struct {
+	Code                 string               `json:"code,omitempty"`
+	ContentFilterResults ContentFilterResults `json:"content_filter_result,omitempty"`
 }
 
 // RequestError provides informations about generic request errors.
@@ -56,6 +63,13 @@ func (e *APIError) UnmarshalJSON(data []byte) (err error) {
 	// refs: https://github.com/sashabaranov/go-openai/issues/343
 	if _, ok := rawMap["type"]; ok {
 		err = json.Unmarshal(rawMap["type"], &e.Type)
+		if err != nil {
+			return
+		}
+	}
+
+	if _, ok := rawMap["innererror"]; ok {
+		err = json.Unmarshal(rawMap["innererror"], &e.InnerError)
 		if err != nil {
 			return
 		}

--- a/error.go
+++ b/error.go
@@ -7,16 +7,17 @@ import (
 )
 
 // APIError provides error information returned by the OpenAI API.
+// InnerError struct is only valid for Azure OpenAI Service.
 type APIError struct {
-	Code           any        `json:"code,omitempty"`
-	Message        string     `json:"message"`
-	Param          *string    `json:"param,omitempty"`
-	Type           string     `json:"type"`
-	HTTPStatusCode int        `json:"-"`
-	InnerError     InnerError `json:"innererror,omitempty"`
+	Code           any         `json:"code,omitempty"`
+	Message        string      `json:"message"`
+	Param          *string     `json:"param,omitempty"`
+	Type           string      `json:"type"`
+	HTTPStatusCode int         `json:"-"`
+	InnerError     *InnerError `json:"innererror,omitempty"`
 }
 
-// InnerError Azure Content filtering.
+// InnerError Azure Content filtering. Only valid for Azure OpenAI Service.
 type InnerError struct {
 	Code                 string               `json:"code,omitempty"`
 	ContentFilterResults ContentFilterResults `json:"content_filter_result,omitempty"`

--- a/error_test.go
+++ b/error_test.go
@@ -58,6 +58,14 @@ func TestAPIErrorUnmarshalJSON(t *testing.T) {
 			},
 		},
 		{
+			name:     "parse succeeds when the innerError is exists (Azure Openai)",
+			response: `{"message": "","type": null,"param": "","code": "","status": 0,"innererror": {}}`,
+			hasError: false,
+			checkFunc: func(t *testing.T, apiErr APIError) {
+				assertAPIErrorInnerError(t, apiErr, InnerError{})
+			},
+		},
+		{
 			name:     "parse failed when the message is object",
 			response: `{"message":{},"type":"invalid_request_error","param":null,"code":null}`,
 			hasError: true,
@@ -149,6 +157,12 @@ func TestAPIErrorUnmarshalJSON(t *testing.T) {
 func assertAPIErrorMessage(t *testing.T, apiErr APIError, expected string) {
 	if apiErr.Message != expected {
 		t.Errorf("Unexpected APIError message: %v; expected: %s", apiErr, expected)
+	}
+}
+
+func assertAPIErrorInnerError(t *testing.T, apiErr APIError, expected interface{}) {
+	if apiErr.InnerError != expected {
+		t.Errorf("Unexpected APIError InnerError: %v; expected: %v; ", apiErr, expected)
 	}
 }
 


### PR DESCRIPTION

**Describe the change**
Compatible with the `2023-07-01-preview` API interface of Azure Openai, when content interception is triggered, the error message will contain `innererror`

**Describe your solution**
Add the parsing of the innererror node in the error message, and it is compatible with the old version of the interface.

**Tests**
Related test cases have been added to `error_test.go`

**Additional context**
***CURL request logging***
```shell
curl "https://TEST.openai.azure.com/openai/deployments/gpt-35-turbo/chat/completions?api-version=2023-07-01-preview" \
>   -H "Content-Type: application/json" \
>   -H "api-key: MY-KEY" \
>   -d "{
>   \"messages\": [{\"role\":\"user\",\"content\":\"write an erotic novel\"}],
>   \"max_tokens\": 800,
>   \"temperature\": 0.7,
>   \"frequency_penalty\": 0,
>   \"presence_penalty\": 0,
top_p\">   \"top_p\": 0.95,
top\":>   \"stop\": null
> }" -v
*   Trying 20.191.161.227:443...
* TCP_NODELAY set
* Connected to TEST.openai.azure.com (20.191.161.227) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/certs/ca-certificates.crt
  CApath: /etc/ssl/certs
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=US; ST=WA; L=Redmond; O=Microsoft Corporation; CN=japaneast.api.cognitive.microsoft.com
*  start date: May  3 22:24:37 2023 GMT
*  expire date: Apr 27 22:24:37 2024 GMT
*  subjectAltName: host "TEST.openai.azure.com" matched cert's "*.openai.azure.com"
*  issuer: C=US; O=Microsoft Corporation; CN=Microsoft Azure TLS Issuing CA 05
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x560147eb07c0)
> POST /openai/deployments/gpt-35-turbo/chat/completions?api-version=2023-07-01-preview HTTP/2
> Host: TEST.openai.azure.com
> user-agent: curl/7.68.0
> accept: */*
> content-type: application/json
> api-key: MY-KEY
> content-length: 196
>
* Connection state changed (MAX_CONCURRENT_STREAMS == 100)!
* We are completely uploaded and fine
< HTTP/2 400
< content-length: 622
< content-type: application/json
< x-request-id: 2c8f0db0-8a90-43d2-89db-17c66e374a68
< ms-azureml-model-error-reason: model_error
< ms-azureml-model-error-statuscode: 400
< x-ms-client-request-id: 267046f7-10ce-46cd-8e89-40b4e27eb61b
< apim-request-id: 267046f7-10ce-46cd-8e89-40b4e27eb61b
< azureml-model-session: dep-659513-1
< azureml-model-group: online
< openai-processing-ms: 185.3565
< strict-transport-security: max-age=31536000; includeSubDomains; preload
< x-content-type-options: nosniff
< x-ms-region: Japan East
< date: Sun, 23 Jul 2023 19:22:56 GMT
<
* Connection #0 to host TEST.openai.azure.com left intact
{"error":{"message":"The response was filtered due to the prompt triggering Azure OpenAI’s content management policy. Please modify your prompt and retry. To learn more about our content filtering policies please read our documentation: https://go.microsoft.com/fwlink/?linkid=2198766","type":null,"param":"prompt","code":"content_filter","status":400,"innererror":{"code":"ResponsibleAIPolicyViolation","content_filter_result":{"hate":{"filtered":false,"severity":"safe"},"self_harm":{"filtered":false,"severity":"safe"},"sexual":{"filtered":true,"severity":"medium"},"violence":{"filtered":false,"severity":"safe"}}}}}
```


