### PR TITLE
support openrouter client

### DIFF
--- a/client.go
+++ b/client.go
@@ -142,7 +142,6 @@ func sendRequestStream[T streamable](client *Client, req *http.Request) (*stream
 }
 
 func (c *Client) setCommonHeaders(req *http.Request) {
-
 	// https://openrouter.ai/docs#api-keys
 	// Set required header for OpenRouter API
 	if c.config.APIType == APITypeOpenRouter {

--- a/client.go
+++ b/client.go
@@ -142,12 +142,20 @@ func sendRequestStream[T streamable](client *Client, req *http.Request) (*stream
 }
 
 func (c *Client) setCommonHeaders(req *http.Request) {
+
+	// https://openrouter.ai/docs#api-keys
+	// Set required header for OpenRouter API
+	if c.config.APIType == APITypeOpenRouter {
+		req.Header.Set("HTTP-Referer", c.config.OpenRouterConfig.HTTPReferer)
+		req.Header.Set("X-Title", c.config.OpenRouterConfig.AppName)
+	}
+
 	// https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference#authentication
 	// Azure API Key authentication
 	if c.config.APIType == APITypeAzure {
 		req.Header.Set(AzureAPIKeyHeader, c.config.authToken)
 	} else {
-		// OpenAI or Azure AD authentication
+		// OpenAI, OpenRouterAI or Azure AD authentication
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.authToken))
 	}
 	if c.config.OrgID != "" {

--- a/config.go
+++ b/config.go
@@ -16,12 +16,18 @@ const (
 type APIType string
 
 const (
-	APITypeOpenAI  APIType = "OPEN_AI"
-	APITypeAzure   APIType = "AZURE"
-	APITypeAzureAD APIType = "AZURE_AD"
+	APITypeOpenAI     APIType = "OPEN_AI"
+	APITypeAzure      APIType = "AZURE"
+	APITypeAzureAD    APIType = "AZURE_AD"
+	APITypeOpenRouter APIType = "OPEN_ROUTER"
 )
 
 const AzureAPIKeyHeader = "api-key"
+
+type OpenRouterConfig struct {
+	HTTPReferer string // required for Open Router API to identify the client
+	AppName     string // name of application
+}
 
 // ClientConfig is a configuration of a client.
 type ClientConfig struct {
@@ -32,6 +38,7 @@ type ClientConfig struct {
 	APIType              APIType
 	APIVersion           string                    // required when APIType is APITypeAzure or APITypeAzureAD
 	AzureModelMapperFunc func(model string) string // replace model to azure deployment name func
+	OpenRouterConfig     *OpenRouterConfig         // required when APIType is APITypeOpenRouter
 	HTTPClient           *http.Client
 
 	EmptyMessagesLimit uint
@@ -43,6 +50,20 @@ func DefaultConfig(authToken string) ClientConfig {
 		BaseURL:   openaiAPIURLv1,
 		APIType:   APITypeOpenAI,
 		OrgID:     "",
+
+		HTTPClient: &http.Client{},
+
+		EmptyMessagesLimit: defaultEmptyMessagesLimit,
+	}
+}
+
+func DefaultOpenRouterConfig(authToken, baseURL string, openRouterConfig *OpenRouterConfig) ClientConfig {
+	return ClientConfig{
+		authToken:        authToken,
+		BaseURL:          baseURL,
+		APIType:          APITypeOpenRouter,
+		OrgID:            "",
+		OpenRouterConfig: openRouterConfig,
 
 		HTTPClient: &http.Client{},
 


### PR DESCRIPTION
**Describe the change**
Add a new type of AI backend integration [OpenRouter](https://openrouter.ai/docs)
Can read the doc for more detail, 
In general, it is providing a Model-agnostic ai service backend that provides a variety of service backends including Openai, claude, etc.

Its API schema is compatible with the OpenAI request, so it should be easy to introduce into this project.

**Describe your solution**
Add a new config constructor for open router ai and set the required HTTP header before sending out the request.

**Tests**
I'm using this client in my project to replace my Azure open ai integration.
