### PR TITLE
When the azure service is unavailable, the error message returned does not contain the error node

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,27 @@
+name: Sanity check
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  prcheck:
+    name: Sanity check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.19'
+    - name: Run vet
+      run: |
+        go vet .
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: latest
+    - name: Run tests
+      run: go test -race -covermode=atomic -coverprofile=coverage.out -v .
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3

--- a/error.go
+++ b/error.go
@@ -92,3 +92,24 @@ func (e *RequestError) Error() string {
 func (e *RequestError) Unwrap() error {
 	return e.Err
 }
+
+func (e *ErrorResponse) UnmarshalJSON(data []byte) (err error) {
+	var rawMap map[string]json.RawMessage
+	err = json.Unmarshal(data, &rawMap)
+	if err != nil {
+		return
+	}
+	if _, ok := rawMap["error"]; !ok {
+		e.Error = &APIError{
+			Code: "unknown",
+		}
+		if _, ok := rawMap["message"]; ok {
+			if json.Unmarshal(rawMap["message"], &e.Error.Message) == nil {
+				return
+			}
+		}
+		e.Error.Message = string(data)
+		return
+	}
+	return json.Unmarshal(rawMap["error"], &e.Error)
+}

--- a/error.go
+++ b/error.go
@@ -103,7 +103,7 @@ func (e *ErrorResponse) UnmarshalJSON(data []byte) (err error) {
 		e.Error = &APIError{
 			Code: "unknown",
 		}
-		if _, ok := rawMap["message"]; ok {
+		if _, okMessage := rawMap["message"]; okMessage {
 			if json.Unmarshal(rawMap["message"], &e.Error.Message) == nil {
 				return
 			}

--- a/error_test.go
+++ b/error_test.go
@@ -228,6 +228,21 @@ func TestErrorResponse(t *testing.T) {
 			response: `{ "statusCode": 500, "message": 100 }`,
 			expected: `{ "statusCode": 500, "message": 100 }`,
 		},
+		{
+			name:     "parse when the message is string",
+			response: `{"error":{"message":"foo","type":"invalid_request_error","param":null,"code":null}}`,
+			expected: `foo`,
+		},
+		{
+			name:     "parse when the message is array with single item",
+			response: `{"error":{"message":["foo"],"type":"invalid_request_error","param":null,"code":null}}`,
+			expected: `foo`,
+		},
+		{
+			name:     "parse when the message is array with multiple items",
+			response: `{"error":{"message":["foo", "bar", "baz"],"type":"invalid_request_error","param":null,"code":null}}`,
+			expected: `foo, bar, baz`,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/error_test.go
+++ b/error_test.go
@@ -180,7 +180,7 @@ func assertAPIErrorType(t *testing.T, apiErr APIError, typ string) {
 	}
 }
 
-func TestRequestError(t *testing.T) {
+func TestRequestErrorUnmarshalJSON(t *testing.T) {
 	var err error = &RequestError{
 		HTTPStatusCode: http.StatusTeapot,
 		Err:            errors.New("i am a teapot"),

--- a/error_test.go
+++ b/error_test.go
@@ -180,7 +180,7 @@ func assertAPIErrorType(t *testing.T, apiErr APIError, typ string) {
 	}
 }
 
-func TestRequestErrorUnmarshalJSON(t *testing.T) {
+func TestRequestError(t *testing.T) {
 	var err error = &RequestError{
 		HTTPStatusCode: http.StatusTeapot,
 		Err:            errors.New("i am a teapot"),
@@ -200,7 +200,7 @@ func TestRequestErrorUnmarshalJSON(t *testing.T) {
 	}
 }
 
-func TestErrorResponse(t *testing.T) {
+func TestErrorResponseUnmarshalJSON(t *testing.T) {
 	type testCase struct {
 		name     string
 		response string


### PR DESCRIPTION
**Describe the change**
The Json deserialization function of the custom structure ErrorResponse returns the correct and expected message copy for the case where there is no error node in the APIError return information.

**Describe your solution**
In the custom ErrorResponse structure json deserialization function, judge whether the error node is included, if not, get the message node as the error message, if not, use the response body as the error message.

**Tests**
Please refer to the TestErrorResponse function in error_test.go. 

Issue: When the azure service is unavailable, the error message returned does not contain the error node
For example:
```json
{
    "statusCode": 500,
    "message": "Internal server error",
    "activityId": ""
}
```
