### PR TITLE
retry helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,6 +678,37 @@ func main() {
 }
 ```
 </details>
+
+<details>
+<summary>Retry requests on Open AI errors</summary>
+
+```go
+...
+import (
+  "github.com/sashabaranov/go-openai"
+  "github.com/sashabaranov/go-openai/retry"
+)
+...
+err := retry.OnError(ctx, backOff, func() error {
+  // create context with some timeout for preventing long requests
+  ctx, cancel := context.WithTimeout(ctx, time.Minute)
+  defer cancel()
+
+  // call OpenAI API
+  resp, err = openAIClient.CreateEmbeddings(ctx,
+    openai.EmbeddingRequest{
+      Input: []string{text},
+      Model: openai.AdaEmbeddingV2,
+  })
+  return err
+})
+if err != nil {
+  return nil, errors.Wrap(err, "error getting embeddings")
+}
+```
+
+</details>
+
 See the `examples/` folder for more.
 
 ### Integration tests:

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -1,0 +1,114 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+var (
+	ErrRetryLimitExceeded  = errors.New("retry limit exceeded")
+	ErrInvalidAuth         = errors.New("invalid auth or key")
+	ErrMakingRetryableCall = errors.New("error making retryable call to OpenAI API")
+	ErrContextError        = errors.New("context error")
+	ErrNotAnError          = errors.New("not an error")
+)
+
+type Backoff struct {
+	Steps          int
+	Duration       time.Duration
+	RetryableError func(error) bool
+	Logger         func(level, msg string)
+}
+
+func (b *Backoff) CanRetry(ctx context.Context, currentTry int, err error, d time.Duration) error {
+	if currentTry > b.Steps {
+		return errors.Join(err, ErrRetryLimitExceeded)
+	}
+
+	if b.Logger != nil {
+		b.Logger("info", fmt.Sprintf("retrying request after %s to OpenAI %d/%d [%s]", d.String(), currentTry, b.Steps, err.Error())) //nolint:lll
+	}
+
+	// wait before retry
+	select {
+	case <-time.After(d):
+	case <-ctx.Done():
+	}
+
+	return nil
+}
+
+const (
+	defaultRetrySteps    = 10
+	defaultRetryDuration = 5 * time.Second
+)
+
+var DefaultRetry = Backoff{
+	Steps:    defaultRetrySteps,
+	Duration: defaultRetryDuration,
+}
+
+func OnError(ctx context.Context, backoff Backoff, fn func() error) error { //nolint:gocognit
+	currentTry := 0
+
+	for ctx.Err() == nil {
+		err := fn()
+
+		// if no error or error is not retriable, return
+		if err == nil {
+			return nil
+		}
+
+		// for cases when need to retry call to OpenAI API
+		if errors.Is(err, ErrNotAnError) {
+			continue
+		}
+
+		currentTry++
+
+		if errors.Is(err, context.DeadlineExceeded) {
+			// when context deadline exceeded, we should make retry as soon as possible
+			if err = backoff.CanRetry(ctx, currentTry, err, time.Second); err != nil {
+				return errors.Join(err, ErrMakingRetryableCall)
+			}
+
+			continue
+		}
+
+		// if error is retriable, try to retry
+		if backoff.RetryableError != nil && backoff.RetryableError(err) {
+			if err = backoff.CanRetry(ctx, currentTry, err, backoff.Duration); err != nil {
+				return errors.Join(err, ErrMakingRetryableCall)
+			}
+
+			continue
+		}
+
+		// check if error is from OpenAI API
+		apiError := &openai.APIError{}
+		if errors.As(err, &apiError) {
+			switch apiError.HTTPStatusCode {
+			case http.StatusUnauthorized:
+				return errors.Join(err, ErrInvalidAuth)
+			case http.StatusTooManyRequests, http.StatusInternalServerError:
+				if err = backoff.CanRetry(ctx, currentTry, err, backoff.Duration); err != nil {
+					return errors.Join(err, ErrMakingRetryableCall)
+				}
+
+				continue
+			default:
+				return errors.Join(err, ErrMakingRetryableCall)
+			}
+		}
+
+		// some error from other API
+		return err
+	}
+
+	return errors.Join(ctx.Err(), ErrContextError)
+}

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -1,0 +1,176 @@
+package retry_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"testing"
+
+	"github.com/sashabaranov/go-openai"
+	"github.com/sashabaranov/go-openai/retry"
+)
+
+var ctx = context.Background()
+
+var (
+	errCustomError          = errors.New("some custom error")
+	errRetryableCustomError = errors.New("my custom retryable error")
+)
+
+func TestRetryableLoggerFunc(t *testing.T) {
+	t.Parallel()
+
+	result := ""
+
+	policy := retry.Backoff{
+		Steps:    3,
+		Duration: 0,
+		Logger: func(level, msg string) {
+			result += fmt.Sprintf("[%s]%s", level, msg)
+		},
+	}
+
+	_ = retry.OnError(ctx, policy, func() error {
+		return context.DeadlineExceeded
+	})
+
+	validLogs := "[info]retrying request after 1s to OpenAI 1/3 [context deadline exceeded][info]retrying request after 1s to OpenAI 2/3 [context deadline exceeded][info]retrying request after 1s to OpenAI 3/3 [context deadline exceeded]" //nolint:lll
+
+	if result != validLogs {
+		t.Errorf("got [%v], want [%v]", result, validLogs)
+	}
+}
+
+func TestRetryableErrorFunc(t *testing.T) {
+	t.Parallel()
+
+	policy := retry.Backoff{
+		RetryableError: func(err error) bool {
+			return errors.Is(err, errRetryableCustomError)
+		},
+	}
+
+	cases := make(map[error]bool)
+
+	cases[errCustomError] = false
+	cases[&openai.APIError{HTTPStatusCode: 401}] = false
+	cases[errRetryableCustomError] = true
+
+	for k, v := range cases {
+		if got := policy.RetryableError(k); v != got {
+			t.Errorf("got [%v], want [%v]", v, got)
+		}
+	}
+}
+
+func TestRetry(t *testing.T) {
+	t.Parallel()
+
+	canceledContext, cancel := context.WithCancel(ctx)
+	cancel()
+
+	testBackoffPolicy := retry.Backoff{
+		Steps: 1,
+		RetryableError: func(err error) bool {
+			return errors.Is(err, errRetryableCustomError)
+		},
+	}
+
+	type TestCases struct {
+		WithCanceledContext bool
+		Func                func() error
+		ExpectedError       string
+	}
+
+	testCases := []TestCases{
+		{
+			Func: func() error {
+				return nil
+			},
+		},
+		{
+			ExpectedError: "some custom error",
+			Func: func() error {
+				return errCustomError
+			},
+		},
+		{
+			WithCanceledContext: true,
+			ExpectedError:       "context canceled\ncontext error",
+			Func: func() error {
+				return nil
+			},
+		},
+		{
+			ExpectedError: "context deadline exceeded\nretry limit exceeded\nerror making retryable call to OpenAI API",
+			Func: func() error {
+				return context.DeadlineExceeded
+			},
+		},
+		{
+			ExpectedError: "my custom retryable error\nretry limit exceeded\nerror making retryable call to OpenAI API",
+			Func: func() error {
+				return errRetryableCustomError
+			},
+		},
+		{
+			ExpectedError: "error, status code: 401, message: bad auth\ninvalid auth or key",
+			Func: func() error {
+				return &openai.APIError{
+					HTTPStatusCode: http.StatusUnauthorized,
+					Message:        "bad auth",
+				}
+			},
+		},
+		{
+			ExpectedError: "error, status code: 429, message: some too many requests error\nretry limit exceeded\nerror making retryable call to OpenAI API", //nolint:lll
+			Func: func() error {
+				return &openai.APIError{
+					HTTPStatusCode: http.StatusTooManyRequests,
+					Message:        "some too many requests error",
+				}
+			},
+		},
+		{
+			ExpectedError: "error, status code: 500, message: some server error\nretry limit exceeded\nerror making retryable call to OpenAI API", //nolint:lll
+			Func: func() error {
+				return &openai.APIError{
+					HTTPStatusCode: http.StatusInternalServerError,
+					Message:        "some server error",
+				}
+			},
+		},
+		{
+			ExpectedError: "error, status code: 834, message: some status code error\nerror making retryable call to OpenAI API", //nolint:lll
+			Func: func() error {
+				return &openai.APIError{
+					HTTPStatusCode: 834,
+					Message:        "some status code error",
+				}
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testContext := ctx
+
+		if testCase.WithCanceledContext {
+			testContext = canceledContext
+		}
+
+		err := retry.OnError(testContext, testBackoffPolicy, testCase.Func)
+
+		if len(testCase.ExpectedError) > 0 {
+			if err == nil {
+				log.Fatal("expected error")
+			}
+
+			// test message text
+			if err.Error() != testCase.ExpectedError {
+				t.Fatalf("got [%s], want [%s]", err.Error(), testCase.ExpectedError)
+			}
+		}
+	}
+}


### PR DESCRIPTION
It's a real change to deal with Open AI API in production usage, it's sometimes freeze, or get's 500 errors... This change will help users to with deal with Open AI errors.

This helper by default will retry request 10 times with 5 seconds delay between each request on such errors:

- context deadline exceeded
- http error 500, 429
- custom user defined errors

Basic usage:
```go
...
import (
  "github.com/sashabaranov/go-openai"
  "github.com/sashabaranov/go-openai/retry"
)
...
err := retry.OnError(ctx, retry.DefaultRetry, func() error {
  // create context with some timeout for preventing long requests
  ctx, cancel := context.WithTimeout(ctx, time.Minute)
  defer cancel()

  // call OpenAI API
  resp, err = openAIClient.CreateEmbeddings(ctx,
    openai.EmbeddingRequest{
      Input: []string{text},
      Model: openai.AdaEmbeddingV2,
  })
  return err
})
if err != nil {
  return nil, errors.Wrap(err, "error getting embeddings")
}
```

Example of usage:
<details>
<summary>Simple example of usage this helper</summary>

```go
package main

import (
  "context"
  "fmt"
  "os"
  "time"

  "github.com/pkg/errors"
  "github.com/sashabaranov/go-openai"
  "github.com/sashabaranov/go-openai/retry"
)

var openAIClient *openai.Client

func main() {
  openAIClient = openai.NewClient(os.Getenv("OPENAI_TOKEN"))

  embedding, err := getEmbedding(context.TODO(), "test")
  if err != nil {
    panic(err)
  }

  fmt.Printf("embedings: %v ... %v", embedding[:10], embedding[len(embedding)-10:])
}

func getEmbedding(ctx context.Context, text string) ([]float32, error) {
  var (
    resp openai.EmbeddingResponse
    err  error
  )

  err = retry.OnError(ctx, retry.DefaultRetry, func() error {
    // create context with some timeout for preventing long requests
    ctx, cancel := context.WithTimeout(ctx, time.Minute)
    defer cancel()

    // call OpenAI API
    resp, err = openAIClient.CreateEmbeddings(ctx,
      openai.EmbeddingRequest{
        Input: []string{text},
        Model: openai.AdaEmbeddingV2,
      })

    return err
  })
  if err != nil {
    return nil, errors.Wrap(err, "error getting embeddings")
  }

  return resp.Data[0].Embedding, nil
}
```
</details>

<details>
<summary>Advanced example of usage this helper</summary>

```go
package main

import (
  "context"
  "fmt"
  "os"
  "time"

  "github.com/pkg/errors"
  "github.com/sashabaranov/go-openai"
  "github.com/sashabaranov/go-openai/retry"
)

var openAIClient *openai.Client

func main() {
  openAIClient = openai.NewClient(os.Getenv("OPENAI_TOKEN"))

  embedding, err := getEmbedding(context.Background(), "test")
  if err != nil {
    panic(err)
  }

  fmt.Printf("embedings: %v ... %v", embedding[:10], embedding[len(embedding)-10:])
}

func getEmbedding(ctx context.Context, text string) ([]float32, error) {
  var (
    resp openai.EmbeddingResponse
    err  error
  )

  myCustomError := errors.New("my custom error")

  backOff := retry.Backoff{
    Steps:    10,
    Duration: 10 * time.Second,
    // logs retry attempts
    Logger: func(level, msg string) {
      fmt.Printf("%s: %s\n", level, msg)
    },
    // check if error can be retried
    RetryableError: func(err error) bool {
      return errors.Is(err, myCustomError)
    },
  }

  err = retry.OnError(ctx, backOff, func() error {
    // create context with some timeout for preventing long requests
    ctx, cancel := context.WithTimeout(ctx, time.Minute)
    defer cancel()

    // call OpenAI API
    resp, err = openAIClient.CreateEmbeddings(ctx,
      openai.EmbeddingRequest{
        Input: []string{text},
        Model: openai.AdaEmbeddingV2,
      })

    return err
  })
  if err != nil {
    return nil, errors.Wrap(err, "error getting embeddings")
  }

  return resp.Data[0].Embedding, nil
}
```

</details>

Issue: #181
