### PR TITLE
Allow user to pass in auth token when using NewClientWithConfig

### DIFF
--- a/client.go
+++ b/client.go
@@ -145,10 +145,10 @@ func (c *Client) setCommonHeaders(req *http.Request) {
 	// https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference#authentication
 	// Azure API Key authentication
 	if c.config.APIType == APITypeAzure {
-		req.Header.Set(AzureAPIKeyHeader, c.config.authToken)
+		req.Header.Set(AzureAPIKeyHeader, c.config.AuthToken)
 	} else {
 		// OpenAI or Azure AD authentication
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.authToken))
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.AuthToken))
 	}
 	if c.config.OrgID != "" {
 		req.Header.Set("OpenAI-Organization", c.config.OrgID)

--- a/client_test.go
+++ b/client_test.go
@@ -23,13 +23,13 @@ func (*failingRequestBuilder) Build(_ context.Context, _, _ string, _ any, _ htt
 func TestClient(t *testing.T) {
 	const mockToken = "mock token"
 	client := NewClient(mockToken)
-	if client.config.authToken != mockToken {
+	if client.config.AuthToken != mockToken {
 		t.Errorf("Client does not contain proper token")
 	}
 
 	const mockOrg = "mock org"
 	client = NewOrgClient(mockToken, mockOrg)
-	if client.config.authToken != mockToken {
+	if client.config.AuthToken != mockToken {
 		t.Errorf("Client does not contain proper token")
 	}
 	if client.config.OrgID != mockOrg {

--- a/config.go
+++ b/config.go
@@ -25,7 +25,7 @@ const AzureAPIKeyHeader = "api-key"
 
 // ClientConfig is a configuration of a client.
 type ClientConfig struct {
-	authToken string
+	AuthToken string
 
 	BaseURL              string
 	OrgID                string
@@ -39,7 +39,7 @@ type ClientConfig struct {
 
 func DefaultConfig(authToken string) ClientConfig {
 	return ClientConfig{
-		authToken: authToken,
+		AuthToken: authToken,
 		BaseURL:   openaiAPIURLv1,
 		APIType:   APITypeOpenAI,
 		OrgID:     "",
@@ -52,7 +52,7 @@ func DefaultConfig(authToken string) ClientConfig {
 
 func DefaultAzureConfig(apiKey, baseURL string) ClientConfig {
 	return ClientConfig{
-		authToken:  apiKey,
+		AuthToken:  apiKey,
 		BaseURL:    baseURL,
 		OrgID:      "",
 		APIType:    APITypeAzure,


### PR DESCRIPTION
**Describe the change**
Some organisations may have their own GPT proxy, so when using this library, they would need to specify their proxy url. In this case, seems `NewClientWithConfig` is the only function that they can use, but right now the `authToken` field in `ClientConfig` is not exposed, so they won't be able to pass in auth token. To make `NewClientWithConfig` usable for the user, we need to change `authToken` into an expose field. 

**Describe your solution**
Change `authToken` in `ClientConfig` into an expose field. 

**Tests**
Just ran the unit tests, no new tests added as there is no logic change.

Issue: 480
