### PR TITLE
Chore Deprecate legacy fine tunes API

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,10 +631,15 @@ func main() {
 	client := openai.NewClient("your token")
 	ctx := context.Background()
 
-	// create a .jsonl file with your training data
+	// create a .jsonl file with your training data for conversational model
 	// {"prompt": "<prompt text>", "completion": "<ideal generated text>"}
 	// {"prompt": "<prompt text>", "completion": "<ideal generated text>"}
 	// {"prompt": "<prompt text>", "completion": "<ideal generated text>"}
+
+	// chat models are trained using the following file format:
+	// {"messages": [{"role": "system", "content": "Marv is a factual chatbot that is also sarcastic."}, {"role": "user", "content": "What's the capital of France?"}, {"role": "assistant", "content": "Paris, as if everyone doesn't know that already."}]}
+	// {"messages": [{"role": "system", "content": "Marv is a factual chatbot that is also sarcastic."}, {"role": "user", "content": "Who wrote 'Romeo and Juliet'?"}, {"role": "assistant", "content": "Oh, just some guy named William Shakespeare. Ever heard of him?"}]}
+	// {"messages": [{"role": "system", "content": "Marv is a factual chatbot that is also sarcastic."}, {"role": "user", "content": "How far is the Moon from Earth?"}, {"role": "assistant", "content": "Around 384,400 kilometers. Give or take a few, like that really matters."}]}
 
 	// you can use openai cli tool to validate the data
 	// For more info - https://platform.openai.com/docs/guides/fine-tuning
@@ -648,29 +653,29 @@ func main() {
 		return
 	}
 
-	// create a fine tune job
+	// create a fine tuning job
 	// Streams events until the job is done (this often takes minutes, but can take hours if there are many jobs in the queue or your dataset is large)
 	// use below get method to know the status of your model
-	tune, err := client.CreateFineTune(ctx, openai.FineTuneRequest{
+	fineTuningJob, err := client.CreateFineTuningJob(ctx, openai.FineTuningJobRequest{
 		TrainingFile: file.ID,
-		Model:        "ada", // babbage, curie, davinci, or a fine-tuned model created after 2022-04-21.
+		Model:        "davinci-002", // gpt-3.5-turbo-0613, babbage-002.
 	})
 	if err != nil {
 		fmt.Printf("Creating new fine tune model error: %v\n", err)
 		return
 	}
 
-	getTune, err := client.GetFineTune(ctx, tune.ID)
+	fineTuningJob, err = client.RetrieveFineTuningJob(ctx, fineTuningJob.ID)
 	if err != nil {
 		fmt.Printf("Getting fine tune model error: %v\n", err)
 		return
 	}
-	fmt.Println(getTune.FineTunedModel)
+	fmt.Println(fineTuningJob.FineTunedModel)
 
-	// once the status of getTune is `succeeded`, you can use your fine tune model in Completion Request
+	// once the status of fineTuningJob is `succeeded`, you can use your fine tune model in Completion Request or Chat Completion Request
 
 	// resp, err := client.CreateCompletion(ctx, openai.CompletionRequest{
-	//	 Model:  getTune.FineTunedModel,
+	//	 Model:  fineTuningJob.FineTunedModel,
 	//	 Prompt: "your prompt",
 	// })
 	// if err != nil {

--- a/fine_tunes.go
+++ b/fine_tunes.go
@@ -6,6 +6,9 @@ import (
 	"net/http"
 )
 
+// Deprecated: On August 22nd, 2023, OpenAI announced the deprecation of the /v1/fine-tunes API.
+// This API will be officially deprecated on January 4th, 2024.
+// OpenAI recommends to migrate to the new fine tuning API implemented in fine_tuning_job.go.
 type FineTuneRequest struct {
 	TrainingFile                 string    `json:"training_file"`
 	ValidationFile               string    `json:"validation_file,omitempty"`
@@ -21,6 +24,9 @@ type FineTuneRequest struct {
 	Suffix                       string    `json:"suffix,omitempty"`
 }
 
+// Deprecated: On August 22nd, 2023, OpenAI announced the deprecation of the /v1/fine-tunes API.
+// This API will be officially deprecated on January 4th, 2024.
+// OpenAI recommends to migrate to the new fine tuning API implemented in fine_tuning_job.go.
 type FineTune struct {
 	ID                string              `json:"id"`
 	Object            string              `json:"object"`
@@ -37,6 +43,9 @@ type FineTune struct {
 	UpdatedAt         int64               `json:"updated_at"`
 }
 
+// Deprecated: On August 22nd, 2023, OpenAI announced the deprecation of the /v1/fine-tunes API.
+// This API will be officially deprecated on January 4th, 2024.
+// OpenAI recommends to migrate to the new fine tuning API implemented in fine_tuning_job.go.
 type FineTuneEvent struct {
 	Object    string `json:"object"`
 	CreatedAt int64  `json:"created_at"`
@@ -44,6 +53,9 @@ type FineTuneEvent struct {
 	Message   string `json:"message"`
 }
 
+// Deprecated: On August 22nd, 2023, OpenAI announced the deprecation of the /v1/fine-tunes API.
+// This API will be officially deprecated on January 4th, 2024.
+// OpenAI recommends to migrate to the new fine tuning API implemented in fine_tuning_job.go.
 type FineTuneHyperParams struct {
 	BatchSize              int     `json:"batch_size"`
 	LearningRateMultiplier float64 `json:"learning_rate_multiplier"`
@@ -51,21 +63,34 @@ type FineTuneHyperParams struct {
 	PromptLossWeight       float64 `json:"prompt_loss_weight"`
 }
 
+// Deprecated: On August 22nd, 2023, OpenAI announced the deprecation of the /v1/fine-tunes API.
+// This API will be officially deprecated on January 4th, 2024.
+// OpenAI recommends to migrate to the new fine tuning API implemented in fine_tuning_job.go.
 type FineTuneList struct {
 	Object string     `json:"object"`
 	Data   []FineTune `json:"data"`
 }
+
+// Deprecated: On August 22nd, 2023, OpenAI announced the deprecation of the /v1/fine-tunes API.
+// This API will be officially deprecated on January 4th, 2024.
+// OpenAI recommends to migrate to the new fine tuning API implemented in fine_tuning_job.go.
 type FineTuneEventList struct {
 	Object string          `json:"object"`
 	Data   []FineTuneEvent `json:"data"`
 }
 
+// Deprecated: On August 22nd, 2023, OpenAI announced the deprecation of the /v1/fine-tunes API.
+// This API will be officially deprecated on January 4th, 2024.
+// OpenAI recommends to migrate to the new fine tuning API implemented in fine_tuning_job.go.
 type FineTuneDeleteResponse struct {
 	ID      string `json:"id"`
 	Object  string `json:"object"`
 	Deleted bool   `json:"deleted"`
 }
 
+// Deprecated: On August 22nd, 2023, OpenAI announced the deprecation of the /v1/fine-tunes API.
+// This API will be officially deprecated on January 4th, 2024.
+// OpenAI recommends to migrate to the new fine tuning API implemented in fine_tuning_job.go.
 func (c *Client) CreateFineTune(ctx context.Context, request FineTuneRequest) (response FineTune, err error) {
 	urlSuffix := "/fine-tunes"
 	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL(urlSuffix), withBody(request))
@@ -78,6 +103,9 @@ func (c *Client) CreateFineTune(ctx context.Context, request FineTuneRequest) (r
 }
 
 // CancelFineTune cancel a fine-tune job.
+// Deprecated: On August 22nd, 2023, OpenAI announced the deprecation of the /v1/fine-tunes API.
+// This API will be officially deprecated on January 4th, 2024.
+// OpenAI recommends to migrate to the new fine tuning API implemented in fine_tuning_job.go.
 func (c *Client) CancelFineTune(ctx context.Context, fineTuneID string) (response FineTune, err error) {
 	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL("/fine-tunes/"+fineTuneID+"/cancel"))
 	if err != nil {
@@ -88,6 +116,9 @@ func (c *Client) CancelFineTune(ctx context.Context, fineTuneID string) (respons
 	return
 }
 
+// Deprecated: On August 22nd, 2023, OpenAI announced the deprecation of the /v1/fine-tunes API.
+// This API will be officially deprecated on January 4th, 2024.
+// OpenAI recommends to migrate to the new fine tuning API implemented in fine_tuning_job.go.
 func (c *Client) ListFineTunes(ctx context.Context) (response FineTuneList, err error) {
 	req, err := c.newRequest(ctx, http.MethodGet, c.fullURL("/fine-tunes"))
 	if err != nil {
@@ -98,6 +129,9 @@ func (c *Client) ListFineTunes(ctx context.Context) (response FineTuneList, err 
 	return
 }
 
+// Deprecated: On August 22nd, 2023, OpenAI announced the deprecation of the /v1/fine-tunes API.
+// This API will be officially deprecated on January 4th, 2024.
+// OpenAI recommends to migrate to the new fine tuning API implemented in fine_tuning_job.go.
 func (c *Client) GetFineTune(ctx context.Context, fineTuneID string) (response FineTune, err error) {
 	urlSuffix := fmt.Sprintf("/fine-tunes/%s", fineTuneID)
 	req, err := c.newRequest(ctx, http.MethodGet, c.fullURL(urlSuffix))
@@ -109,6 +143,9 @@ func (c *Client) GetFineTune(ctx context.Context, fineTuneID string) (response F
 	return
 }
 
+// Deprecated: On August 22nd, 2023, OpenAI announced the deprecation of the /v1/fine-tunes API.
+// This API will be officially deprecated on January 4th, 2024.
+// OpenAI recommends to migrate to the new fine tuning API implemented in fine_tuning_job.go.
 func (c *Client) DeleteFineTune(ctx context.Context, fineTuneID string) (response FineTuneDeleteResponse, err error) {
 	req, err := c.newRequest(ctx, http.MethodDelete, c.fullURL("/fine-tunes/"+fineTuneID))
 	if err != nil {
@@ -119,6 +156,9 @@ func (c *Client) DeleteFineTune(ctx context.Context, fineTuneID string) (respons
 	return
 }
 
+// Deprecated: On August 22nd, 2023, OpenAI announced the deprecation of the /v1/fine-tunes API.
+// This API will be officially deprecated on January 4th, 2024.
+// OpenAI recommends to migrate to the new fine tuning API implemented in fine_tuning_job.go.
 func (c *Client) ListFineTuneEvents(ctx context.Context, fineTuneID string) (response FineTuneEventList, err error) {
 	req, err := c.newRequest(ctx, http.MethodGet, c.fullURL("/fine-tunes/"+fineTuneID+"/events"))
 	if err != nil {


### PR DESCRIPTION
On August 22nd, 2023, OpenAI [announced](https://openai.com/blog/gpt-3-5-turbo-fine-tuning-and-api-updates) the deprecation of the `/v1/fine-tunes` API will take place on January 4th, 2024. OpenAI [recommends](https://platform.openai.com/docs/guides/legacy-fine-tuning) all users migrate to the new `/v1/fine_tuning/jobs` API. The old API is now [legacy](https://platform.openai.com/docs/guides/legacy-fine-tuning).

New `FineTuningJob` API has been implemented in `fine_tuning_job.go`

This PR deprecates `FineTunes` API implementation and updates README documentation example.