### PR TITLE
Add DotProduct Method and README Example for Embedding Similarity Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ func main() {
 </details>
 
 <detail>
-<summary>Embedding Similarity Search</summary>
+<summary>Embedding Semantic Similarity</summary>
 
 ```go
 package main

--- a/README.md
+++ b/README.md
@@ -483,6 +483,62 @@ func main() {
 ```
 </details>
 
+<detail>
+<summary>Embedding Similarity Search</summary>
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+	openai "github.com/sashabaranov/go-openai"
+
+)
+
+func main() {
+	client := openai.NewClient("your-token")
+
+	// Create an EmbeddingRequest for the user query
+	queryReq := openai.EmbeddingRequest{
+		Input: []string{"How many chucks would a woodchuck chuck"},
+		Model: openai.AdaEmbeddingv2,
+	}
+
+	// Create an embedding for the user query
+	queryResponse, err := client.CreateEmbeddings(context.Background(), queryReq)
+	if err != nil {
+		log.Fatal("Error creating query embedding:", err)
+	}
+
+	// Create an EmbeddingRequest for the target text
+	targetReq := openai.EmbeddingRequest{
+		Input: []string{"How many chucks would a woodchuck chuck if the woodchuck could chuck wood"},
+		Model: openai.AdaEmbeddingv2,
+	}
+
+	// Create an embedding for the target text
+	targetResponse, err := client.CreateEmbeddings(context.Background(), targetReq)
+	if err != nil {
+		log.Fatal("Error creating target embedding:", err)
+	}
+
+	// Now that we have the embeddings for the user query and the target text, we
+	// can calculate their similarity.
+	queryEmbedding := queryResponse.Data[0]
+	targetEmbedding := targetResponse.Data[0]
+
+	similarity, err := queryEmbedding.DotProduct(&targetEmbedding)
+	if err != nil {
+		log.Fatal("Error calculating dot product:", err)
+	}
+
+	log.Printf("The similarity score between the query and the target is %f", similarity)
+}
+
+```
+</detail>
+
 <details>
 <summary>Azure OpenAI Embeddings</summary>
 

--- a/embeddings.go
+++ b/embeddings.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/binary"
+	"errors"
 	"math"
 	"net/http"
 )
+
+var ErrVectorLengthMismatch = errors.New("vector length mismatch")
 
 // EmbeddingModel enumerates the models which can be used
 // to generate Embedding vectors.
@@ -122,6 +125,23 @@ type Embedding struct {
 	Object    string    `json:"object"`
 	Embedding []float32 `json:"embedding"`
 	Index     int       `json:"index"`
+}
+
+// DotProduct calculates the dot product of the embedding vector with another
+// embedding vector. Both vectors must have the same length; otherwise, an
+// ErrVectorLengthMismatch is returned. The method returns the calculated dot
+// product as a float32 value.
+func (e *Embedding) DotProduct(other *Embedding) (float32, error) {
+	if len(e.Embedding) != len(other.Embedding) {
+		return 0, ErrVectorLengthMismatch
+	}
+
+	var dotProduct float32
+	for i := range e.Embedding {
+		dotProduct += e.Embedding[i] * other.Embedding[i]
+	}
+
+	return dotProduct, nil
 }
 
 // EmbeddingResponse is the response from a Create embeddings request.


### PR DESCRIPTION
**Describe the change**
- Implement a DotProduct() method for the Embedding struct to calculate the dot product between two embeddings.
- Add a custom error type for vector length mismatch.

**Describe your solution**
- Finish implementing the following requested changes from @sashabaranov:

```
We don't need two huge examples [see](https://github.com/sashabaranov/go-openai/pull/274/files#r1232058195) — Please make one small example without encoding/gob etc.
I'm not sure this change is relevant [here](https://github.com/sashabaranov/go-openai/pull/274/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L596)
Let's make DotProduct a method of Embedding struct [see](https://github.com/sashabaranov/go-openai/pull/274/files#r1232242888)
```

**Tests**
- Add unit tests to validate the new DotProduct() method and error handling.

**Additional context**
- Update README.md with a complete example demonstrating how to perform an embedding similarity search for user queries.

Issue: #XXXX
