### PR TITLE
added delete fine tune model endpoint

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -271,6 +271,9 @@ func TestClientReturnsRequestBuilderErrors(t *testing.T) {
 		{"GetModel", func() (any, error) {
 			return client.GetModel(ctx, "text-davinci-003")
 		}},
+		{"DeleteFineTuneModel", func() (any, error) {
+			return client.DeleteFineTuneModel(ctx, "")
+		}},
 	}
 
 	for _, testCase := range testCases {

--- a/models.go
+++ b/models.go
@@ -33,6 +33,13 @@ type Permission struct {
 	IsBlocking         bool        `json:"is_blocking"`
 }
 
+// FineTuneModelDeleteResponse represents the deletion status of a fine-tuned model.
+type FineTuneModelDeleteResponse struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Deleted bool   `json:"deleted"`
+}
+
 // ModelsList is a list of models, including those that belong to the user or organization.
 type ModelsList struct {
 	Models []Model `json:"data"`
@@ -60,5 +67,18 @@ func (c *Client) GetModel(ctx context.Context, modelID string) (model Model, err
 	}
 
 	err = c.sendRequest(req, &model)
+	return
+}
+
+// DeleteFineTuneModel Deletes a fine-tune model. You must have the Owner
+// role in your organization to delete a model.
+func (c *Client) DeleteFineTuneModel(ctx context.Context, modelID string) (
+	response FineTuneModelDeleteResponse, err error) {
+	req, err := c.newRequest(ctx, http.MethodDelete, c.fullURL("/models/"+modelID))
+	if err != nil {
+		return
+	}
+
+	err = c.sendRequest(req, &response)
 	return
 }

--- a/models_test.go
+++ b/models_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 )
 
+const testFineTuneModelID = "fine-tune-model-id"
+
 // TestListModels Tests the list models endpoint of the API using the mocked server.
 func TestListModels(t *testing.T) {
 	client, server, teardown := setupOpenAITestServer()
@@ -77,4 +79,17 @@ func TestGetModelReturnTimeoutError(t *testing.T) {
 	if !os.IsTimeout(err) {
 		t.Fatal("Did not return timeout error")
 	}
+}
+
+func TestDeleteFineTuneModel(t *testing.T) {
+	client, server, teardown := setupOpenAITestServer()
+	defer teardown()
+	server.RegisterHandler("/v1/models/"+testFineTuneModelID, handleDeleteFineTuneModelEndpoint)
+	_, err := client.DeleteFineTuneModel(context.Background(), testFineTuneModelID)
+	checks.NoError(t, err, "DeleteFineTuneModel error")
+}
+
+func handleDeleteFineTuneModelEndpoint(w http.ResponseWriter, _ *http.Request) {
+	resBytes, _ := json.Marshal(FineTuneModelDeleteResponse{})
+	fmt.Fprintln(w, string(resBytes))
 }


### PR DESCRIPTION
**Describe the change**
With the deprecation of the fine-tunes endpoint, OpenAI moved the deletion of fine-tuned models to `DELETE /models/{model}`. This PR adds this new endpoint in `models.go`.

**Describe your solution**
I reworked the code present in `fine_tunes.go` that was already written for deleting fine-tuned models. Because OpenAI organized the new delete under the "models" prefix, this code is now located in the `models.go` file.

**Tests**
The tests used for the previous fine-tune model delete were reworked to use the new endpoint.
