### PR TITLE
feat: add method convert str to embedding model enum

### DIFF
--- a/embeddings.go
+++ b/embeddings.go
@@ -12,9 +12,19 @@ import (
 // to generate Embedding vectors.
 type EmbeddingModel int
 
+func ConvertStr2EmbeddingModel(modelName string) EmbeddingModel {
+	if val, ok := stringToEnum[modelName]; ok {
+		return val
+	}
+	return Unknown
+}
+
 // String implements the fmt.Stringer interface.
 func (e EmbeddingModel) String() string {
-	return enumToString[e]
+	if val, ok := enumToString[e]; ok {
+		return val
+	}
+	return "Unknown"
 }
 
 // MarshalText implements the encoding.TextMarshaler interface.


### PR DESCRIPTION
**Describe the change**
Use go-openai as part of my application, params passed to application may be string, but there is no method to convert model name to enum for embedding, so i add this helper method for convenient. 

**Describe your solution**
Reuse the implementation of `stringToEnum`. If the target mapping is found in the `stringToEnum` mapping, use it directly. Otherwise, return the Unknown enumeration type.

**Tests**
ConvertStr2EmbeddingModel("text-embedding-ada-002")  should return AdaEmbeddingV2

**Additional context**
Nop

Issue: #503
