### PR TITLE
Feat Add headers to openai responses

### DIFF
--- a/audio.go
+++ b/audio.go
@@ -63,6 +63,21 @@ type AudioResponse struct {
 		Transient        bool    `json:"transient"`
 	} `json:"segments"`
 	Text string `json:"text"`
+
+	headers
+}
+
+type audioTextResponse struct {
+	Text string `json:"text"`
+
+	headers
+}
+
+func (r *audioTextResponse) ToAudioResponse() AudioResponse {
+	return AudioResponse{
+		Text:    r.Text,
+		headers: r.headers,
+	}
 }
 
 // CreateTranscription — API call to create a transcription. Returns transcribed text.
@@ -104,7 +119,9 @@ func (c *Client) callAudioAPI(
 	if request.HasJSONResponse() {
 		err = c.sendRequest(req, &response)
 	} else {
-		err = c.sendRequest(req, &response.Text)
+		var textResponse audioTextResponse
+		err = c.sendRequest(req, &textResponse)
+		response = textResponse.ToAudioResponse()
 	}
 	if err != nil {
 		return AudioResponse{}, err

--- a/audio.go
+++ b/audio.go
@@ -64,19 +64,19 @@ type AudioResponse struct {
 	} `json:"segments"`
 	Text string `json:"text"`
 
-	headers
+	httpHeader
 }
 
 type audioTextResponse struct {
 	Text string `json:"text"`
 
-	headers
+	httpHeader
 }
 
 func (r *audioTextResponse) ToAudioResponse() AudioResponse {
 	return AudioResponse{
-		Text:    r.Text,
-		headers: r.headers,
+		Text:       r.Text,
+		httpHeader: r.httpHeader,
 	}
 }
 

--- a/chat.go
+++ b/chat.go
@@ -143,7 +143,7 @@ type ChatCompletionResponse struct {
 	Choices []ChatCompletionChoice `json:"choices"`
 	Usage   Usage                  `json:"usage"`
 
-	headers
+	httpHeader
 }
 
 // CreateChatCompletion — API call to Create a completion for the chat message.

--- a/chat.go
+++ b/chat.go
@@ -142,6 +142,8 @@ type ChatCompletionResponse struct {
 	Model   string                 `json:"model"`
 	Choices []ChatCompletionChoice `json:"choices"`
 	Usage   Usage                  `json:"usage"`
+
+	headers
 }
 
 // CreateChatCompletion — API call to Create a completion for the chat message.

--- a/chat_test.go
+++ b/chat_test.go
@@ -90,9 +90,9 @@ func TestChatCompletionsWithHeaders(t *testing.T) {
 	})
 	checks.NoError(t, err, "CreateChatCompletion error")
 
-	a := resp.Headers().Get(xCustomHeader)
+	a := resp.Header().Get(xCustomHeader)
 	_ = a
-	if resp.Headers().Get(xCustomHeader) != xCustomHeaderValue {
+	if resp.Header().Get(xCustomHeader) != xCustomHeaderValue {
 		t.Errorf("expected header %s to be %s", xCustomHeader, xCustomHeaderValue)
 	}
 }

--- a/chat_test.go
+++ b/chat_test.go
@@ -16,6 +16,11 @@ import (
 	"github.com/sashabaranov/go-openai/jsonschema"
 )
 
+const (
+	xCustomHeader      = "X-CUSTOM-HEADER"
+	xCustomHeaderValue = "test"
+)
+
 func TestChatCompletionsWrongModel(t *testing.T) {
 	config := DefaultConfig("whatever")
 	config.BaseURL = "http://localhost/v1"
@@ -66,6 +71,30 @@ func TestChatCompletions(t *testing.T) {
 		},
 	})
 	checks.NoError(t, err, "CreateChatCompletion error")
+}
+
+// TestCompletions Tests the completions endpoint of the API using the mocked server.
+func TestChatCompletionsWithHeaders(t *testing.T) {
+	client, server, teardown := setupOpenAITestServer()
+	defer teardown()
+	server.RegisterHandler("/v1/chat/completions", handleChatCompletionEndpoint)
+	resp, err := client.CreateChatCompletion(context.Background(), ChatCompletionRequest{
+		MaxTokens: 5,
+		Model:     GPT3Dot5Turbo,
+		Messages: []ChatCompletionMessage{
+			{
+				Role:    ChatMessageRoleUser,
+				Content: "Hello!",
+			},
+		},
+	})
+	checks.NoError(t, err, "CreateChatCompletion error")
+
+	a := resp.Headers().Get(xCustomHeader)
+	_ = a
+	if resp.Headers().Get(xCustomHeader) != xCustomHeaderValue {
+		t.Errorf("expected header %s to be %s", xCustomHeader, xCustomHeaderValue)
+	}
 }
 
 // TestChatCompletionsFunctions tests including a function call.
@@ -281,6 +310,7 @@ func handleChatCompletionEndpoint(w http.ResponseWriter, r *http.Request) {
 		TotalTokens:      inputTokens + completionTokens,
 	}
 	resBytes, _ = json.Marshal(res)
+	w.Header().Set(xCustomHeader, xCustomHeaderValue)
 	fmt.Fprintln(w, string(resBytes))
 }
 

--- a/client.go
+++ b/client.go
@@ -20,6 +20,20 @@ type Client struct {
 	createFormBuilder func(io.Writer) utils.FormBuilder
 }
 
+type Response interface {
+	SetHeaders(http.Header)
+}
+
+type headers http.Header
+
+func (h *headers) SetHeaders(httpHeader http.Header) {
+	*h = headers(httpHeader)
+}
+
+func (h headers) Headers() http.Header {
+	return http.Header(h)
+}
+
 // NewClient creates new OpenAI API client.
 func NewClient(authToken string) *Client {
 	config := DefaultConfig(authToken)
@@ -82,7 +96,7 @@ func (c *Client) newRequest(ctx context.Context, method, url string, setters ...
 	return req, nil
 }
 
-func (c *Client) sendRequest(req *http.Request, v any) error {
+func (c *Client) sendRequest(req *http.Request, v Response) error {
 	req.Header.Set("Accept", "application/json; charset=utf-8")
 
 	// Check whether Content-Type is already set, Upload Files API requires
@@ -101,6 +115,10 @@ func (c *Client) sendRequest(req *http.Request, v any) error {
 
 	if isFailureStatusCode(res) {
 		return c.handleErrorResp(res)
+	}
+
+	if v != nil {
+		v.SetHeaders(res.Header)
 	}
 
 	return decodeResponse(res.Body, v)

--- a/client.go
+++ b/client.go
@@ -21,16 +21,16 @@ type Client struct {
 }
 
 type Response interface {
-	SetHeaders(http.Header)
+	SetHeader(http.Header)
 }
 
-type headers http.Header
+type httpHeader http.Header
 
-func (h *headers) SetHeaders(httpHeader http.Header) {
-	*h = headers(httpHeader)
+func (h *httpHeader) SetHeader(header http.Header) {
+	*h = httpHeader(header)
 }
 
-func (h headers) Headers() http.Header {
+func (h httpHeader) Header() http.Header {
 	return http.Header(h)
 }
 
@@ -118,7 +118,7 @@ func (c *Client) sendRequest(req *http.Request, v Response) error {
 	}
 
 	if v != nil {
-		v.SetHeaders(res.Header)
+		v.SetHeader(res.Header)
 	}
 
 	return decodeResponse(res.Body, v)

--- a/completion.go
+++ b/completion.go
@@ -155,7 +155,7 @@ type CompletionResponse struct {
 	Choices []CompletionChoice `json:"choices"`
 	Usage   Usage              `json:"usage"`
 
-	headers
+	httpHeader
 }
 
 // CreateCompletion — API call to create a completion. This is the main endpoint of the API. Returns new text as well

--- a/completion.go
+++ b/completion.go
@@ -154,6 +154,8 @@ type CompletionResponse struct {
 	Model   string             `json:"model"`
 	Choices []CompletionChoice `json:"choices"`
 	Usage   Usage              `json:"usage"`
+
+	headers
 }
 
 // CreateCompletion — API call to create a completion. This is the main endpoint of the API. Returns new text as well

--- a/edits.go
+++ b/edits.go
@@ -29,7 +29,7 @@ type EditsResponse struct {
 	Usage   Usage         `json:"usage"`
 	Choices []EditsChoice `json:"choices"`
 
-	headers
+	httpHeader
 }
 
 // Edits Perform an API call to the Edits endpoint.

--- a/edits.go
+++ b/edits.go
@@ -28,6 +28,8 @@ type EditsResponse struct {
 	Created int64         `json:"created"`
 	Usage   Usage         `json:"usage"`
 	Choices []EditsChoice `json:"choices"`
+
+	headers
 }
 
 // Edits Perform an API call to the Edits endpoint.

--- a/embeddings.go
+++ b/embeddings.go
@@ -151,7 +151,7 @@ type EmbeddingResponse struct {
 	Model  EmbeddingModel `json:"model"`
 	Usage  Usage          `json:"usage"`
 
-	headers
+	httpHeader
 }
 
 type base64String string
@@ -185,7 +185,7 @@ type EmbeddingResponseBase64 struct {
 	Model  EmbeddingModel    `json:"model"`
 	Usage  Usage             `json:"usage"`
 
-	headers
+	httpHeader
 }
 
 // ToEmbeddingResponse converts an embeddingResponseBase64 to an EmbeddingResponse.

--- a/embeddings.go
+++ b/embeddings.go
@@ -150,6 +150,8 @@ type EmbeddingResponse struct {
 	Data   []Embedding    `json:"data"`
 	Model  EmbeddingModel `json:"model"`
 	Usage  Usage          `json:"usage"`
+
+	headers
 }
 
 type base64String string
@@ -182,6 +184,8 @@ type EmbeddingResponseBase64 struct {
 	Data   []Base64Embedding `json:"data"`
 	Model  EmbeddingModel    `json:"model"`
 	Usage  Usage             `json:"usage"`
+
+	headers
 }
 
 // ToEmbeddingResponse converts an embeddingResponseBase64 to an EmbeddingResponse.

--- a/engines.go
+++ b/engines.go
@@ -12,11 +12,15 @@ type Engine struct {
 	Object string `json:"object"`
 	Owner  string `json:"owner"`
 	Ready  bool   `json:"ready"`
+
+	headers
 }
 
 // EnginesList is a list of engines.
 type EnginesList struct {
 	Engines []Engine `json:"data"`
+
+	headers
 }
 
 // ListEngines Lists the currently available engines, and provides basic

--- a/engines.go
+++ b/engines.go
@@ -13,14 +13,14 @@ type Engine struct {
 	Owner  string `json:"owner"`
 	Ready  bool   `json:"ready"`
 
-	headers
+	httpHeader
 }
 
 // EnginesList is a list of engines.
 type EnginesList struct {
 	Engines []Engine `json:"data"`
 
-	headers
+	httpHeader
 }
 
 // ListEngines Lists the currently available engines, and provides basic

--- a/files.go
+++ b/files.go
@@ -26,14 +26,14 @@ type File struct {
 	Purpose       string `json:"purpose"`
 	StatusDetails string `json:"status_details"`
 
-	headers
+	httpHeader
 }
 
 // FilesList is a list of files that belong to the user or organization.
 type FilesList struct {
 	Files []File `json:"data"`
 
-	headers
+	httpHeader
 }
 
 // CreateFile uploads a jsonl file to GPT3

--- a/files.go
+++ b/files.go
@@ -25,11 +25,15 @@ type File struct {
 	Status        string `json:"status"`
 	Purpose       string `json:"purpose"`
 	StatusDetails string `json:"status_details"`
+
+	headers
 }
 
 // FilesList is a list of files that belong to the user or organization.
 type FilesList struct {
 	Files []File `json:"data"`
+
+	headers
 }
 
 // CreateFile uploads a jsonl file to GPT3

--- a/fine_tunes.go
+++ b/fine_tunes.go
@@ -42,7 +42,7 @@ type FineTune struct {
 	TrainingFiles     []File              `json:"training_files"`
 	UpdatedAt         int64               `json:"updated_at"`
 
-	headers
+	httpHeader
 }
 
 // Deprecated: On August 22nd, 2023, OpenAI announced the deprecation of the /v1/fine-tunes API.
@@ -72,7 +72,7 @@ type FineTuneList struct {
 	Object string     `json:"object"`
 	Data   []FineTune `json:"data"`
 
-	headers
+	httpHeader
 }
 
 // Deprecated: On August 22nd, 2023, OpenAI announced the deprecation of the /v1/fine-tunes API.
@@ -82,7 +82,7 @@ type FineTuneEventList struct {
 	Object string          `json:"object"`
 	Data   []FineTuneEvent `json:"data"`
 
-	headers
+	httpHeader
 }
 
 // Deprecated: On August 22nd, 2023, OpenAI announced the deprecation of the /v1/fine-tunes API.
@@ -93,7 +93,7 @@ type FineTuneDeleteResponse struct {
 	Object  string `json:"object"`
 	Deleted bool   `json:"deleted"`
 
-	headers
+	httpHeader
 }
 
 // Deprecated: On August 22nd, 2023, OpenAI announced the deprecation of the /v1/fine-tunes API.

--- a/fine_tunes.go
+++ b/fine_tunes.go
@@ -41,6 +41,8 @@ type FineTune struct {
 	ValidationFiles   []File              `json:"validation_files"`
 	TrainingFiles     []File              `json:"training_files"`
 	UpdatedAt         int64               `json:"updated_at"`
+
+	headers
 }
 
 // Deprecated: On August 22nd, 2023, OpenAI announced the deprecation of the /v1/fine-tunes API.
@@ -69,6 +71,8 @@ type FineTuneHyperParams struct {
 type FineTuneList struct {
 	Object string     `json:"object"`
 	Data   []FineTune `json:"data"`
+
+	headers
 }
 
 // Deprecated: On August 22nd, 2023, OpenAI announced the deprecation of the /v1/fine-tunes API.
@@ -77,6 +81,8 @@ type FineTuneList struct {
 type FineTuneEventList struct {
 	Object string          `json:"object"`
 	Data   []FineTuneEvent `json:"data"`
+
+	headers
 }
 
 // Deprecated: On August 22nd, 2023, OpenAI announced the deprecation of the /v1/fine-tunes API.
@@ -86,6 +92,8 @@ type FineTuneDeleteResponse struct {
 	ID      string `json:"id"`
 	Object  string `json:"object"`
 	Deleted bool   `json:"deleted"`
+
+	headers
 }
 
 // Deprecated: On August 22nd, 2023, OpenAI announced the deprecation of the /v1/fine-tunes API.

--- a/fine_tuning_job.go
+++ b/fine_tuning_job.go
@@ -22,7 +22,7 @@ type FineTuningJob struct {
 	ResultFiles     []string        `json:"result_files"`
 	TrainedTokens   int             `json:"trained_tokens"`
 
-	headers
+	httpHeader
 }
 
 type Hyperparameters struct {
@@ -42,7 +42,7 @@ type FineTuningJobEventList struct {
 	Data    []FineTuneEvent `json:"data"`
 	HasMore bool            `json:"has_more"`
 
-	headers
+	httpHeader
 }
 
 type FineTuningJobEvent struct {

--- a/fine_tuning_job.go
+++ b/fine_tuning_job.go
@@ -21,6 +21,8 @@ type FineTuningJob struct {
 	ValidationFile  string          `json:"validation_file,omitempty"`
 	ResultFiles     []string        `json:"result_files"`
 	TrainedTokens   int             `json:"trained_tokens"`
+
+	headers
 }
 
 type Hyperparameters struct {
@@ -39,6 +41,8 @@ type FineTuningJobEventList struct {
 	Object  string          `json:"object"`
 	Data    []FineTuneEvent `json:"data"`
 	HasMore bool            `json:"has_more"`
+
+	headers
 }
 
 type FineTuningJobEvent struct {

--- a/image.go
+++ b/image.go
@@ -34,7 +34,7 @@ type ImageResponse struct {
 	Created int64                    `json:"created,omitempty"`
 	Data    []ImageResponseDataInner `json:"data,omitempty"`
 
-	headers
+	httpHeader
 }
 
 // ImageResponseDataInner represents a response data structure for image API.

--- a/image.go
+++ b/image.go
@@ -33,6 +33,8 @@ type ImageRequest struct {
 type ImageResponse struct {
 	Created int64                    `json:"created,omitempty"`
 	Data    []ImageResponseDataInner `json:"data,omitempty"`
+
+	headers
 }
 
 // ImageResponseDataInner represents a response data structure for image API.

--- a/models.go
+++ b/models.go
@@ -16,7 +16,7 @@ type Model struct {
 	Root       string       `json:"root"`
 	Parent     string       `json:"parent"`
 
-	headers
+	httpHeader
 }
 
 // Permission struct represents an OpenAPI permission.
@@ -41,14 +41,14 @@ type FineTuneModelDeleteResponse struct {
 	Object  string `json:"object"`
 	Deleted bool   `json:"deleted"`
 
-	headers
+	httpHeader
 }
 
 // ModelsList is a list of models, including those that belong to the user or organization.
 type ModelsList struct {
 	Models []Model `json:"data"`
 
-	headers
+	httpHeader
 }
 
 // ListModels Lists the currently available models,

--- a/models.go
+++ b/models.go
@@ -15,6 +15,8 @@ type Model struct {
 	Permission []Permission `json:"permission"`
 	Root       string       `json:"root"`
 	Parent     string       `json:"parent"`
+
+	headers
 }
 
 // Permission struct represents an OpenAPI permission.
@@ -38,11 +40,15 @@ type FineTuneModelDeleteResponse struct {
 	ID      string `json:"id"`
 	Object  string `json:"object"`
 	Deleted bool   `json:"deleted"`
+
+	headers
 }
 
 // ModelsList is a list of models, including those that belong to the user or organization.
 type ModelsList struct {
 	Models []Model `json:"data"`
+
+	headers
 }
 
 // ListModels Lists the currently available models,

--- a/moderation.go
+++ b/moderation.go
@@ -70,7 +70,7 @@ type ModerationResponse struct {
 	Model   string   `json:"model"`
 	Results []Result `json:"results"`
 
-	headers
+	httpHeader
 }
 
 // Moderations — perform a moderation api call over a string.

--- a/moderation.go
+++ b/moderation.go
@@ -69,6 +69,8 @@ type ModerationResponse struct {
 	ID      string   `json:"id"`
 	Model   string   `json:"model"`
 	Results []Result `json:"results"`
+
+	headers
 }
 
 // Moderations — perform a moderation api call over a string.


### PR DESCRIPTION
**Describe the change**
This branch adds headers to all opeanai http responses.

**Describe your solution**
This was done embedding a struct `httpHeader` to each response struct. The `httpHeader` type has attached methods to set and get `http.Header`. The low level `sendRequest` uses a `Response` interface defining the `SetHeader` method of `httpHeader`.

**Tests**
`TestChatCompletionsWithHeaders` has been added to check a test header. 
