### PR TITLE
Public Authtoken field

### DIFF
--- a/client.go
+++ b/client.go
@@ -168,10 +168,10 @@ func (c *Client) setCommonHeaders(req *http.Request) {
 	// https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference#authentication
 	// Azure API Key authentication
 	if c.config.APIType == APITypeAzure {
-		req.Header.Set(AzureAPIKeyHeader, c.config.authToken)
+		req.Header.Set(AzureAPIKeyHeader, c.config.AuthToken)
 	} else {
 		// OpenAI or Azure AD authentication
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.authToken))
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.AuthToken))
 	}
 	if c.config.OrgID != "" {
 		req.Header.Set("OpenAI-Organization", c.config.OrgID)

--- a/client_test.go
+++ b/client_test.go
@@ -23,13 +23,13 @@ func (*failingRequestBuilder) Build(_ context.Context, _, _ string, _ any, _ htt
 func TestClient(t *testing.T) {
 	const mockToken = "mock token"
 	client := NewClient(mockToken)
-	if client.config.authToken != mockToken {
+	if client.config.AuthToken != mockToken {
 		t.Errorf("Client does not contain proper token")
 	}
 
 	const mockOrg = "mock org"
 	client = NewOrgClient(mockToken, mockOrg)
-	if client.config.authToken != mockToken {
+	if client.config.AuthToken != mockToken {
 		t.Errorf("Client does not contain proper token")
 	}
 	if client.config.OrgID != mockOrg {

--- a/config.go
+++ b/config.go
@@ -25,7 +25,7 @@ const AzureAPIKeyHeader = "api-key"
 
 // ClientConfig is a configuration of a client.
 type ClientConfig struct {
-	authToken string
+	AuthToken string
 
 	BaseURL              string
 	OrgID                string
@@ -39,7 +39,7 @@ type ClientConfig struct {
 
 func DefaultConfig(authToken string) ClientConfig {
 	return ClientConfig{
-		authToken: authToken,
+		AuthToken: authToken,
 		BaseURL:   openaiAPIURLv1,
 		APIType:   APITypeOpenAI,
 		OrgID:     "",
@@ -52,7 +52,7 @@ func DefaultConfig(authToken string) ClientConfig {
 
 func DefaultAzureConfig(apiKey, baseURL string) ClientConfig {
 	return ClientConfig{
-		authToken:  apiKey,
+		AuthToken:  apiKey,
 		BaseURL:    baseURL,
 		OrgID:      "",
 		APIType:    APITypeAzure,

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/sashabaranov/go-openai
+module github.com/rAlexander89/go-openai
 
 go 1.18

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/rAlexander89/go-openai
+module github.com/sashabaranov/go-openai
 
 go 1.18


### PR DESCRIPTION
Makes it possible to use other `baseURL`.

This creates an error:

```
	gptConfig := openai.ClientConfig{
		authToken:          authToken,
		BaseURL:            "https://api.openai.com/v1/chat/completions",
		APIType:            "OPEN_AI",
		OrgID:              "",
		HTTPClient:         &http.Client{},
		EmptyMessagesLimit: 300,
	}
```

because `authToken` isn't a public field.

Would like to use the newer gpt endpoints in one object rather than to set it like this


```
gptConfig := openai.DefaultConfig(authToken)
 gptConfig.BaseURL = "https://api.openai.com/v1/chat/completions"
 ```