### PR TITLE
[BREAKING_CHANGES] ChatCompletionRequest in chat.go, chagne data type float32 to float64

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -74,13 +74,13 @@ type ChatCompletionRequest struct {
 	Model            string                  `json:"model"`
 	Messages         []ChatCompletionMessage `json:"messages"`
 	MaxTokens        int                     `json:"max_tokens,omitempty"`
-	Temperature      float32                 `json:"temperature,omitempty"`
-	TopP             float32                 `json:"top_p,omitempty"`
+	Temperature      float64                 `json:"temperature"`
+	TopP             float64                 `json:"top_p"`
 	N                int                     `json:"n,omitempty"`
 	Stream           bool                    `json:"stream,omitempty"`
 	Stop             []string                `json:"stop,omitempty"`
-	PresencePenalty  float32                 `json:"presence_penalty,omitempty"`
-	FrequencyPenalty float32                 `json:"frequency_penalty,omitempty"`
+	PresencePenalty  float64                 `json:"presence_penalty,omitempty"`
+	FrequencyPenalty float64                 `json:"frequency_penalty,omitempty"`
 	// LogitBias is must be a token id string (specified by their token ID in the tokenizer), not a word string.
 	// incorrect: `"logit_bias":{"You": 6}`, correct: `"logit_bias":{"1639": 6}`
 	// refs: https://platform.openai.com/docs/api-reference/chat/create#chat/create-logit_bias


### PR DESCRIPTION
Solve Issue: #9 

**Describe the change**
1) ChatCompletionRequest struct attributes annotation with *omitempty* treats value 0 as not set, for example `temperature`, `top_p` attribute. And this will trigger OpenAI use default value `1`, temperature attribute specifically. [OpenAI Chat Temperature Doc](https://platform.openai.com/docs/api-reference/chat/create#chat-create-temperature)

2) Data type `float32` is not competent for some DBs like MongoDB data type. The only two options to store float data in  MongoDB are `Double` or `Decimal128`, either way will arise error of "float64 can only be truncated to an integer type when truncation is enable" and "cannot decode 128-bit decimal into a float32 or float64 type" respectively in Golang float32.

**Describe your solution**
1) remove some attributes' `omitempty` tag in ChatCompletionRequest.
2) Change `float32` to `float64`.

**Tests**
In MongoDB document, set attribute value data type as `Double` and temperature value to `0` or `0.01`, won't cause error.
