### PR TITLE
Add model field to ImageRequest

### DIFF
--- a/image.go
+++ b/image.go
@@ -27,6 +27,7 @@ type ImageRequest struct {
 	Size           string `json:"size,omitempty"`
 	ResponseFormat string `json:"response_format,omitempty"`
 	User           string `json:"user,omitempty"`
+	Model          string `json:"model,omitempty"`
 }
 
 // ImageResponse represents a response structure for image API.


### PR DESCRIPTION
Model property is needed in order to use image generations with DALLE 3.