### PR TITLE
feat: initial TTS support

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -341,7 +341,7 @@ func TestClientReturnsRequestBuilderErrors(t *testing.T) {
 			return client.ListRunSteps(ctx, "", "", Pagination{})
 		}},
 		{"CreateSpeech", func() (any, error) {
-			return client.CreateSpeech(ctx, CreateSpeechRequest{})
+			return client.CreateSpeech(ctx, CreateSpeechRequest{Model: TTSModel1, Voice: VoiceAlloy})
 		}},
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -340,6 +340,9 @@ func TestClientReturnsRequestBuilderErrors(t *testing.T) {
 		{"ListRunSteps", func() (any, error) {
 			return client.ListRunSteps(ctx, "", "", Pagination{})
 		}},
+		{"CreateSpeech", func() (any, error) {
+			return client.CreateSpeech(ctx, CreateSpeechRequest{})
+		}},
 	}
 
 	for _, testCase := range testCases {

--- a/speech.go
+++ b/speech.go
@@ -34,11 +34,11 @@ const (
 )
 
 type CreateSpeechRequest struct {
-	Model          SpeechModel           `json:"model"`
-	Input          string                `json:"input"`
-	Voice          SpeechVoice           `json:"voice"`
-	ResponseFormat *SpeechResponseFormat `json:"response_format,omitempty"` // Optional, default to mp3
-	Speed          *float64              `json:"speed,omitempty"`           // Optional, default to 1.0
+	Model          SpeechModel          `json:"model"`
+	Input          string               `json:"input"`
+	Voice          SpeechVoice          `json:"voice"`
+	ResponseFormat SpeechResponseFormat `json:"response_format,omitempty"` // Optional, default to mp3
+	Speed          float64              `json:"speed,omitempty"`           // Optional, default to 1.0
 }
 
 func (c *Client) CreateSpeech(ctx context.Context, request CreateSpeechRequest) (response io.ReadCloser, err error) {

--- a/speech.go
+++ b/speech.go
@@ -9,28 +9,28 @@ import (
 type SpeechModel string
 
 const (
-	TTS_MODEL_1    SpeechModel = "tts-1"
-	TTS_MODEL_1_HD SpeechModel = "tts-1-hd"
+	TTSModel1   SpeechModel = "tts-1"
+	TTsModel1HD SpeechModel = "tts-1-hd"
 )
 
 type SpeechVoice string
 
 const (
-	VOICE_ALLOY   SpeechVoice = "alloy"
-	VOICE_ECHO    SpeechVoice = "echo"
-	VOICE_FABLE   SpeechVoice = "fable"
-	VOICE_ONYX    SpeechVoice = "onyx"
-	VOICE_NOVA    SpeechVoice = "nova"
-	VOICE_SHIMMER SpeechVoice = "shimmer"
+	VoiceAlloy   SpeechVoice = "alloy"
+	VoiceEcho    SpeechVoice = "echo"
+	VoiceFable   SpeechVoice = "fable"
+	VoiceOnyx    SpeechVoice = "onyx"
+	VoiceNova    SpeechVoice = "nova"
+	VoiceShimmer SpeechVoice = "shimmer"
 )
 
 type SpeechResponseFormat string
 
 const (
-	SPEECH_RESPONSE_FORMAT_MP3  SpeechResponseFormat = "mp3"
-	SPEECH_RESPONSE_FORMAT_OPUS SpeechResponseFormat = "opus"
-	SPEECH_RESPONSE_FORMAT_AAC  SpeechResponseFormat = "aac"
-	SPEECH_RESPONSE_FORMAT_FLAC SpeechResponseFormat = "flac"
+	SpeechResponseFormatMp3  SpeechResponseFormat = "mp3"
+	SpeechResponseFormatOpus SpeechResponseFormat = "opus"
+	SpeechResponseFormatAac  SpeechResponseFormat = "aac"
+	SpeechResponseFormatFlac SpeechResponseFormat = "flac"
 )
 
 type CreateSpeechRequest struct {
@@ -42,14 +42,6 @@ type CreateSpeechRequest struct {
 }
 
 func (c *Client) CreateSpeech(ctx context.Context, request CreateSpeechRequest) (response io.ReadCloser, err error) {
-	if request.Speed == nil {
-		defaultSpeed := float64(1.0)
-		request.Speed = &defaultSpeed
-	}
-	if request.ResponseFormat == nil {
-		defaultResponseFormat := SPEECH_RESPONSE_FORMAT_MP3
-		request.ResponseFormat = &defaultResponseFormat
-	}
 	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL("/audio/speech", request.Model),
 		withBody(request),
 		withContentType("application/json; charset=utf-8"),

--- a/speech.go
+++ b/speech.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 )
@@ -33,6 +34,11 @@ const (
 	SpeechResponseFormatFlac SpeechResponseFormat = "flac"
 )
 
+var (
+	ErrInvalidSpeechModel = errors.New("invalid speech model")
+	ErrInvalidVoice       = errors.New("invalid voice")
+)
+
 type CreateSpeechRequest struct {
 	Model          SpeechModel          `json:"model"`
 	Input          string               `json:"input"`
@@ -41,7 +47,32 @@ type CreateSpeechRequest struct {
 	Speed          float64              `json:"speed,omitempty"`           // Optional, default to 1.0
 }
 
+func contains[T comparable](s []T, e T) bool {
+	for _, v := range s {
+		if v == e {
+			return true
+		}
+	}
+	return false
+}
+
+func isValidSpeechModel(model SpeechModel) bool {
+	return contains([]SpeechModel{TTSModel1, TTsModel1HD}, model)
+}
+
+func isValidVoice(voice SpeechVoice) bool {
+	return contains([]SpeechVoice{VoiceAlloy, VoiceEcho, VoiceFable, VoiceOnyx, VoiceNova, VoiceShimmer}, voice)
+}
+
 func (c *Client) CreateSpeech(ctx context.Context, request CreateSpeechRequest) (response io.ReadCloser, err error) {
+	if !isValidSpeechModel(request.Model) {
+		err = ErrInvalidSpeechModel
+		return
+	}
+	if !isValidVoice(request.Voice) {
+		err = ErrInvalidVoice
+		return
+	}
 	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL("/audio/speech", request.Model),
 		withBody(request),
 		withContentType("application/json; charset=utf-8"),

--- a/speech.go
+++ b/speech.go
@@ -1,0 +1,64 @@
+package openai
+
+import (
+	"context"
+	"io"
+	"net/http"
+)
+
+type SpeechModel string
+
+const (
+	TTS_MODEL_1    SpeechModel = "tts-1"
+	TTS_MODEL_1_HD SpeechModel = "tts-1-hd"
+)
+
+type SpeechVoice string
+
+const (
+	VOICE_ALLOY   SpeechVoice = "alloy"
+	VOICE_ECHO    SpeechVoice = "echo"
+	VOICE_FABLE   SpeechVoice = "fable"
+	VOICE_ONYX    SpeechVoice = "onyx"
+	VOICE_NOVA    SpeechVoice = "nova"
+	VOICE_SHIMMER SpeechVoice = "shimmer"
+)
+
+type SpeechResponseFormat string
+
+const (
+	SPEECH_RESPONSE_FORMAT_MP3  SpeechResponseFormat = "mp3"
+	SPEECH_RESPONSE_FORMAT_OPUS SpeechResponseFormat = "opus"
+	SPEECH_RESPONSE_FORMAT_AAC  SpeechResponseFormat = "aac"
+	SPEECH_RESPONSE_FORMAT_FLAC SpeechResponseFormat = "flac"
+)
+
+type CreateSpeechRequest struct {
+	Model          SpeechModel           `json:"model"`
+	Input          string                `json:"input"`
+	Voice          SpeechVoice           `json:"voice"`
+	ResponseFormat *SpeechResponseFormat `json:"response_format,omitempty"` // Optional, default to mp3
+	Speed          *float64              `json:"speed,omitempty"`           // Optional, default to 1.0
+}
+
+func (c *Client) CreateSpeech(ctx context.Context, request CreateSpeechRequest) (response io.ReadCloser, err error) {
+	if request.Speed == nil {
+		defaultSpeed := float64(1.0)
+		request.Speed = &defaultSpeed
+	}
+	if request.ResponseFormat == nil {
+		defaultResponseFormat := SPEECH_RESPONSE_FORMAT_MP3
+		request.ResponseFormat = &defaultResponseFormat
+	}
+	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL("/audio/speech", request.Model),
+		withBody(request),
+		withContentType("application/json; charset=utf-8"),
+	)
+	if err != nil {
+		return
+	}
+
+	response, err = c.sendRequestRaw(req)
+
+	return
+}

--- a/speech_test.go
+++ b/speech_test.go
@@ -11,7 +11,69 @@ import (
 )
 
 func TestSpeechIntegration(t *testing.T) {
-	client := openai.NewClient("sk-xyz")
+	client, server, teardown := setupOpenAITestServer()
+	defer teardown()
+
+	server.RegisterHandler("/v1/audio/speech", func(w http.ResponseWriter, r *http.Request) {
+		dir, cleanup := test.CreateTestDirectory(t)
+		path := filepath.Join(dir, "fake.mp3")
+		test.CreateTestFile(t, path)
+		defer cleanup()
+
+		// audio endpoints only accept POST requests
+		if r.Method != "POST" {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if err != nil {
+			http.Error(w, "failed to parse media type", http.StatusBadRequest)
+			return
+		}
+
+		if mediaType != "application/json" {
+			http.Error(w, "request is not json", http.StatusBadRequest)
+			return
+		}
+
+		// Parse the JSON body of the request
+		var params map[string]interface{}
+		err = json.NewDecoder(r.Body).Decode(&params)
+		if err != nil {
+
+			http.Error(w, "failed to parse request body", http.StatusBadRequest)
+			return
+		}
+
+		// Check if each required field is present in the parsed JSON object
+		reqParams := []string{"model", "input", "voice"}
+		for _, param := range reqParams {
+			_, ok := params[param]
+			if !ok {
+				http.Error(w, fmt.Sprintf("no %s in params", param), http.StatusBadRequest)
+				return
+			}
+		}
+
+		// read audio file content
+		audioFile, err := os.ReadFile(path)
+		if err != nil {
+			http.Error(w, "failed to read audio file", http.StatusInternalServerError)
+			return
+		}
+
+		// write audio file content to response
+		w.Header().Set("Content-Type", "audio/mpeg")
+		w.Header().Set("Transfer-Encoding", "chunked")
+		w.Header().Set("Connection", "keep-alive")
+		_, err = w.Write(audioFile)
+		if err != nil {
+			http.Error(w, "failed to write body", http.StatusInternalServerError)
+			return
+		}
+
+	})
 
 	res, err := client.CreateSpeech(context.Background(), openai.CreateSpeechRequest{
 		Model: openai.TTSModel1,

--- a/speech_test.go
+++ b/speech_test.go
@@ -14,9 +14,9 @@ func TestSpeechIntegration(t *testing.T) {
 	client := openai.NewClient("sk-xyz")
 
 	res, err := client.CreateSpeech(context.Background(), openai.CreateSpeechRequest{
-		Model: openai.TTS_MODEL_1,
+		Model: openai.TTSModel1,
 		Input: "Hello!",
-		Voice: openai.VOICE_ALLOY,
+		Voice: openai.VoiceAlloy,
 	})
 	checks.NoError(t, err, "CreateSpeech error")
 	defer res.Close()

--- a/speech_test.go
+++ b/speech_test.go
@@ -2,11 +2,17 @@ package openai_test
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"io"
+	"mime"
+	"net/http"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/sashabaranov/go-openai"
+	"github.com/sashabaranov/go-openai/internal/test"
 	"github.com/sashabaranov/go-openai/internal/test/checks"
 )
 

--- a/speech_test.go
+++ b/speech_test.go
@@ -1,0 +1,30 @@
+package openai_test
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/sashabaranov/go-openai"
+	"github.com/sashabaranov/go-openai/internal/test/checks"
+)
+
+func TestSpeechIntegration(t *testing.T) {
+	client := openai.NewClient("sk-xyz")
+
+	res, err := client.CreateSpeech(context.Background(), openai.CreateSpeechRequest{
+		Model: openai.TTS_MODEL_1,
+		Input: "Hello!",
+		Voice: openai.VOICE_ALLOY,
+	})
+	checks.NoError(t, err, "CreateSpeech error")
+	defer res.Close()
+
+	buf, err := io.ReadAll(res)
+	checks.NoError(t, err, "ReadAll error")
+
+	// save buf to file as mp3
+	err = os.WriteFile("test.mp3", buf, 0644)
+	checks.NoError(t, err, "Create error")
+}

--- a/speech_test.go
+++ b/speech_test.go
@@ -25,6 +25,16 @@ func contains[T comparable](s []T, e T) bool {
 	return false
 }
 
+func isValidSpeechModel(model openai.SpeechModel) bool {
+	return contains([]openai.SpeechModel{openai.TTSModel1, openai.TTsModel1HD}, model)
+}
+
+func isValidVoice(voice openai.SpeechVoice) bool {
+	return contains([]openai.SpeechVoice{openai.VoiceAlloy, openai.VoiceEcho, openai.VoiceFable,
+		openai.VoiceOnyx, openai.VoiceNova, openai.VoiceShimmer}, voice)
+}
+
+//nolint:gocognit
 func TestSpeechIntegration(t *testing.T) {
 	client, server, teardown := setupOpenAITestServer()
 	defer teardown()
@@ -71,15 +81,13 @@ func TestSpeechIntegration(t *testing.T) {
 		}
 
 		// Check if the model is valid
-		if !contains([]string{string(openai.TTSModel1), string(openai.TTsModel1HD)}, params["model"].(string)) {
+		if !isValidSpeechModel(openai.SpeechModel(params["model"].(string))) {
 			http.Error(w, "invalid model", http.StatusBadRequest)
 			return
 		}
 
 		// Check if the voice is valid
-		if !contains([]string{string(openai.VoiceAlloy), string(openai.VoiceEcho), string(openai.VoiceFable),
-			string(openai.VoiceOnyx), string(openai.VoiceNova), string(openai.VoiceShimmer)},
-			params["voice"].(string)) {
+		if !isValidVoice(openai.SpeechVoice(params["voice"].(string))) {
 			http.Error(w, "invalid voice", http.StatusBadRequest)
 			return
 		}

--- a/speech_test.go
+++ b/speech_test.go
@@ -47,7 +47,6 @@ func TestSpeechIntegration(t *testing.T) {
 		var params map[string]interface{}
 		err = json.NewDecoder(r.Body).Decode(&params)
 		if err != nil {
-
 			http.Error(w, "failed to parse request body", http.StatusBadRequest)
 			return
 		}
@@ -78,7 +77,6 @@ func TestSpeechIntegration(t *testing.T) {
 			http.Error(w, "failed to write body", http.StatusInternalServerError)
 			return
 		}
-
 	})
 
 	res, err := client.CreateSpeech(context.Background(), openai.CreateSpeechRequest{


### PR DESCRIPTION
**Describe the change**
Adds very basic support for `create_speech` endpoint. 

See also https://platform.openai.com/docs/api-reference/audio/createSpeech and https://platform.openai.com/docs/guides/text-to-speech.

**Describe your solution**
This is an extremely minimal approach that returns the http body (`io.ReadCloser`). An additional method that saves the result directly to a file is likely to be useful. For streaming, having the raw chunks is most helpful. The test includes an example for saving to file.

I've added the relevant constants, and the basic API should work, could use more tests for sure. 

**Tests**
I likely don't have time to write the necessary tests. I've added a quick and dirty integration test that succeeds - it synthesizes some text and saves to mp3. Listening to the mp3 confirms that the audio is correct.

It would be useful for somebody to write the rest of the mock methods and add a test mp3 file to return.

**Additional context**
Saving to a particular file format is trivial, but streaming particular forms of audio is tricky and I want to leave that to the end user. Most implementations will require additional format-specific libraries, no need for that in this library.

