### PR TITLE
Support new fields for /v1/images/generation API

### DIFF
--- a/image.go
+++ b/image.go
@@ -13,7 +13,7 @@ const (
 	CreateImageSize256x256   = "256x256"
 	CreateImageSize512x512   = "512x512"
 	CreateImageSize1024x1024 = "1024x1024"
-	// dall-e-3 supported only
+	// dall-e-3 supported only.
 	CreateImageSize1792x1024 = "1792x1024"
 	CreateImageSize1024x1792 = "1024x1792"
 )

--- a/image.go
+++ b/image.go
@@ -13,6 +13,9 @@ const (
 	CreateImageSize256x256   = "256x256"
 	CreateImageSize512x512   = "512x512"
 	CreateImageSize1024x1024 = "1024x1024"
+	// dall-e-3 supported only
+	CreateImageSize1792x1024 = "1792x1024"
+	CreateImageSize1024x1792 = "1024x1792"
 )
 
 const (
@@ -20,11 +23,28 @@ const (
 	CreateImageResponseFormatB64JSON = "b64_json"
 )
 
+const (
+	CreateImageModelDallE2 = "dall-e-2"
+	CreateImageModelDallE3 = "dall-e-3"
+)
+
+const (
+	CreateImageQualityHD = "hd"
+)
+
+const (
+	CreateImageStyleVivid   = "vivid"
+	CreateImageStyleNatural = "natural"
+)
+
 // ImageRequest represents the request structure for the image API.
 type ImageRequest struct {
 	Prompt         string `json:"prompt,omitempty"`
+	Model          string `json:"model,omitempty"`
 	N              int    `json:"n,omitempty"`
+	Quality        string `json:"quality,omitempty"`
 	Size           string `json:"size,omitempty"`
+	Style          string `json:"style,omitempty"`
 	ResponseFormat string `json:"response_format,omitempty"`
 	User           string `json:"user,omitempty"`
 }

--- a/image.go
+++ b/image.go
@@ -59,8 +59,9 @@ type ImageResponse struct {
 
 // ImageResponseDataInner represents a response data structure for image API.
 type ImageResponseDataInner struct {
-	URL     string `json:"url,omitempty"`
-	B64JSON string `json:"b64_json,omitempty"`
+	URL           string `json:"url,omitempty"`
+	B64JSON       string `json:"b64_json,omitempty"`
+	RevisedPrompt string `json:"revised_prompt,omitempty"`
 }
 
 // CreateImage - API call to create an image. This is the main endpoint of the DALL-E API.

--- a/image.go
+++ b/image.go
@@ -29,7 +29,8 @@ const (
 )
 
 const (
-	CreateImageQualityHD = "hd"
+	CreateImageQualityHD       = "hd"
+	CreateImageQualityStandard = "standard"
 )
 
 const (

--- a/image_api_test.go
+++ b/image_api_test.go
@@ -19,7 +19,14 @@ func TestImages(t *testing.T) {
 	defer teardown()
 	server.RegisterHandler("/v1/images/generations", handleImageEndpoint)
 	_, err := client.CreateImage(context.Background(), ImageRequest{
-		Prompt: "Lorem ipsum",
+		Prompt:         "Lorem ipsum",
+		Model:          CreateImageModelDallE3,
+		N:              1,
+		Quality:        CreateImageQualityHD,
+		Size:           CreateImageSize1024x1024,
+		Style:          CreateImageStyleVivid,
+		ResponseFormat: CreateImageResponseFormatURL,
+		User:           "user",
 	})
 	checks.NoError(t, err, "CreateImage error")
 }

--- a/image_api_test.go
+++ b/image_api_test.go
@@ -20,12 +20,12 @@ func TestImages(t *testing.T) {
 	server.RegisterHandler("/v1/images/generations", handleImageEndpoint)
 	_, err := client.CreateImage(context.Background(), openai.ImageRequest{
 		Prompt:         "Lorem ipsum",
-		Model:          CreateImageModelDallE3,
+		Model:          openai.CreateImageModelDallE3,
 		N:              1,
-		Quality:        CreateImageQualityHD,
-		Size:           CreateImageSize1024x1024,
-		Style:          CreateImageStyleVivid,
-		ResponseFormat: CreateImageResponseFormatURL,
+		Quality:        openai.CreateImageQualityHD,
+		Size:           openai.CreateImageSize1024x1024,
+		Style:          openai.CreateImageStyleVivid,
+		ResponseFormat: openai.CreateImageResponseFormatURL,
 		User:           "user",
 	})
 	checks.NoError(t, err, "CreateImage error")


### PR DESCRIPTION
**Describe the change**
Updating the [/v1/images/generation](https://platform.openai.com/docs/api-reference/images/create) api with the new changes announced at [devday](https://openai.com/blog/new-models-and-developer-products-announced-at-devday).

**Describe your solution**
Simply add new fields to `ImageRequest` & `ImageResponseDataInner` as well a bunch of new const's for supported options.

**Tests**
Added more fields to the existing `TestImages` test, as these are later unmarshaled. Although if you would like to see tests that simply assert marshalling I could add some, let me know.

Issue: https://github.com/sashabaranov/go-openai/issues/529
