### PR TITLE
Fix Use pointer for ChatCompletionResponseFormat

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -89,18 +89,18 @@ type ChatCompletionResponseFormat struct {
 
 // ChatCompletionRequest represents a request structure for chat completion API.
 type ChatCompletionRequest struct {
-	Model            string                       `json:"model"`
-	Messages         []ChatCompletionMessage      `json:"messages"`
-	MaxTokens        int                          `json:"max_tokens,omitempty"`
-	Temperature      float32                      `json:"temperature,omitempty"`
-	TopP             float32                      `json:"top_p,omitempty"`
-	N                int                          `json:"n,omitempty"`
-	Stream           bool                         `json:"stream,omitempty"`
-	Stop             []string                     `json:"stop,omitempty"`
-	PresencePenalty  float32                      `json:"presence_penalty,omitempty"`
-	ResponseFormat   ChatCompletionResponseFormat `json:"response_format,omitempty"`
-	Seed             *int                         `json:"seed,omitempty"`
-	FrequencyPenalty float32                      `json:"frequency_penalty,omitempty"`
+	Model            string                        `json:"model"`
+	Messages         []ChatCompletionMessage       `json:"messages"`
+	MaxTokens        int                           `json:"max_tokens,omitempty"`
+	Temperature      float32                       `json:"temperature,omitempty"`
+	TopP             float32                       `json:"top_p,omitempty"`
+	N                int                           `json:"n,omitempty"`
+	Stream           bool                          `json:"stream,omitempty"`
+	Stop             []string                      `json:"stop,omitempty"`
+	PresencePenalty  float32                       `json:"presence_penalty,omitempty"`
+	ResponseFormat   *ChatCompletionResponseFormat `json:"response_format,omitempty"`
+	Seed             *int                          `json:"seed,omitempty"`
+	FrequencyPenalty float32                       `json:"frequency_penalty,omitempty"`
 	// LogitBias is must be a token id string (specified by their token ID in the tokenizer), not a word string.
 	// incorrect: `"logit_bias":{"You": 6}`, correct: `"logit_bias":{"1639": 6}`
 	// refs: https://platform.openai.com/docs/api-reference/chat/create#chat/create-logit_bias


### PR DESCRIPTION
**Describe the change**
The field `ChatCompletionResponseFormat` must be a pointer
 
Issue: #541 
