### PR TITLE
Fix Refactor assistant api

### DIFF
--- a/assistant.go
+++ b/assistant.go
@@ -56,6 +56,14 @@ type AssistantsList struct {
 	httpHeader
 }
 
+type AssistantDeleteResponse struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Deleted bool   `json:"deleted"`
+
+	httpHeader
+}
+
 type AssistantFile struct {
 	ID          string `json:"id"`
 	Object      string `json:"object"`
@@ -124,7 +132,7 @@ func (c *Client) ModifyAssistant(
 func (c *Client) DeleteAssistant(
 	ctx context.Context,
 	assistantID string,
-) (response Assistant, err error) {
+) (response AssistantDeleteResponse, err error) {
 	urlSuffix := fmt.Sprintf("%s/%s", assistantsSuffix, assistantID)
 	req, err := c.newRequest(ctx, http.MethodDelete, c.fullURL(urlSuffix),
 		withBetaAssistantV1())

--- a/assistant.go
+++ b/assistant.go
@@ -10,7 +10,6 @@ import (
 const (
 	assistantsSuffix      = "/assistants"
 	assistantsFilesSuffix = "/files"
-	openaiBetaHeader      = "OpenAI-Beta"
 	openaiAssistantsV1    = "assistants=v1"
 )
 
@@ -79,7 +78,7 @@ type AssistantFilesList struct {
 // CreateAssistant creates a new assistant.
 func (c *Client) CreateAssistant(ctx context.Context, request AssistantRequest) (response Assistant, err error) {
 	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL(assistantsSuffix), withBody(request),
-		withHeader(openaiBetaHeader, openaiAssistantsV1))
+		withBetaAssistantV1())
 	if err != nil {
 		return
 	}
@@ -95,7 +94,7 @@ func (c *Client) RetrieveAssistant(
 ) (response Assistant, err error) {
 	urlSuffix := fmt.Sprintf("%s/%s", assistantsSuffix, assistantID)
 	req, err := c.newRequest(ctx, http.MethodGet, c.fullURL(urlSuffix),
-		withHeader(openaiBetaHeader, openaiAssistantsV1))
+		withBetaAssistantV1())
 	if err != nil {
 		return
 	}
@@ -112,7 +111,7 @@ func (c *Client) ModifyAssistant(
 ) (response Assistant, err error) {
 	urlSuffix := fmt.Sprintf("%s/%s", assistantsSuffix, assistantID)
 	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL(urlSuffix), withBody(request),
-		withHeader(openaiBetaHeader, openaiAssistantsV1))
+		withBetaAssistantV1())
 	if err != nil {
 		return
 	}
@@ -128,7 +127,7 @@ func (c *Client) DeleteAssistant(
 ) (response Assistant, err error) {
 	urlSuffix := fmt.Sprintf("%s/%s", assistantsSuffix, assistantID)
 	req, err := c.newRequest(ctx, http.MethodDelete, c.fullURL(urlSuffix),
-		withHeader(openaiBetaHeader, openaiAssistantsV1))
+		withBetaAssistantV1())
 	if err != nil {
 		return
 	}
@@ -166,7 +165,7 @@ func (c *Client) ListAssistants(
 
 	urlSuffix := fmt.Sprintf("%s%s", assistantsSuffix, encodedValues)
 	req, err := c.newRequest(ctx, http.MethodGet, c.fullURL(urlSuffix),
-		withHeader(openaiBetaHeader, openaiAssistantsV1))
+		withBetaAssistantV1())
 	if err != nil {
 		return
 	}
@@ -184,7 +183,7 @@ func (c *Client) CreateAssistantFile(
 	urlSuffix := fmt.Sprintf("%s/%s%s", assistantsSuffix, assistantID, assistantsFilesSuffix)
 	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL(urlSuffix),
 		withBody(request),
-		withHeader(openaiBetaHeader, openaiAssistantsV1))
+		withBetaAssistantV1())
 	if err != nil {
 		return
 	}
@@ -201,7 +200,7 @@ func (c *Client) RetrieveAssistantFile(
 ) (response AssistantFile, err error) {
 	urlSuffix := fmt.Sprintf("%s/%s%s/%s", assistantsSuffix, assistantID, assistantsFilesSuffix, fileID)
 	req, err := c.newRequest(ctx, http.MethodGet, c.fullURL(urlSuffix),
-		withHeader(openaiBetaHeader, openaiAssistantsV1))
+		withBetaAssistantV1())
 	if err != nil {
 		return
 	}
@@ -218,7 +217,7 @@ func (c *Client) DeleteAssistantFile(
 ) (err error) {
 	urlSuffix := fmt.Sprintf("%s/%s%s/%s", assistantsSuffix, assistantID, assistantsFilesSuffix, fileID)
 	req, err := c.newRequest(ctx, http.MethodDelete, c.fullURL(urlSuffix),
-		withHeader(openaiBetaHeader, openaiAssistantsV1))
+		withBetaAssistantV1())
 	if err != nil {
 		return
 	}
@@ -257,7 +256,7 @@ func (c *Client) ListAssistantFiles(
 
 	urlSuffix := fmt.Sprintf("%s/%s%s%s", assistantsSuffix, assistantID, assistantsFilesSuffix, encodedValues)
 	req, err := c.newRequest(ctx, http.MethodGet, c.fullURL(urlSuffix),
-		withHeader(openaiBetaHeader, openaiAssistantsV1))
+		withBetaAssistantV1())
 	if err != nil {
 		return
 	}

--- a/assistant.go
+++ b/assistant.go
@@ -10,46 +10,44 @@ import (
 const (
 	assistantsSuffix      = "/assistants"
 	assistantsFilesSuffix = "/files"
+	openaiBetaHeader      = "OpenAI-Beta"
+	openaiAssistantsV1    = "assistants=v1"
 )
 
 type Assistant struct {
-	ID           string  `json:"id"`
-	Object       string  `json:"object"`
-	CreatedAt    int64   `json:"created_at"`
-	Name         *string `json:"name,omitempty"`
-	Description  *string `json:"description,omitempty"`
-	Model        string  `json:"model"`
-	Instructions *string `json:"instructions,omitempty"`
-	Tools        []any   `json:"tools,omitempty"`
+	ID           string          `json:"id"`
+	Object       string          `json:"object"`
+	CreatedAt    int64           `json:"created_at"`
+	Name         *string         `json:"name,omitempty"`
+	Description  *string         `json:"description,omitempty"`
+	Model        string          `json:"model"`
+	Instructions *string         `json:"instructions,omitempty"`
+	Tools        []AssistantTool `json:"tools,omitempty"`
 
 	httpHeader
 }
 
+type AssistantToolType string
+
+const (
+	AssistantToolTypeCodeInterpreter AssistantToolType = "code_interpreter"
+	AssistantToolTypeRetrieval       AssistantToolType = "retrieval"
+	AssistantToolTypeFunction        AssistantToolType = "function"
+)
+
 type AssistantTool struct {
-	Type string `json:"type"`
-}
-
-type AssistantToolCodeInterpreter struct {
-	AssistantTool
-}
-
-type AssistantToolRetrieval struct {
-	AssistantTool
-}
-
-type AssistantToolFunction struct {
-	AssistantTool
-	Function FunctionDefinition `json:"function"`
+	Type     AssistantToolType   `json:"type"`
+	Function *FunctionDefinition `json:"function,omitempty"`
 }
 
 type AssistantRequest struct {
-	Model        string         `json:"model"`
-	Name         *string        `json:"name,omitempty"`
-	Description  *string        `json:"description,omitempty"`
-	Instructions *string        `json:"instructions,omitempty"`
-	Tools        []any          `json:"tools,omitempty"`
-	FileIDs      []string       `json:"file_ids,omitempty"`
-	Metadata     map[string]any `json:"metadata,omitempty"`
+	Model        string          `json:"model"`
+	Name         *string         `json:"name,omitempty"`
+	Description  *string         `json:"description,omitempty"`
+	Instructions *string         `json:"instructions,omitempty"`
+	Tools        []AssistantTool `json:"tools,omitempty"`
+	FileIDs      []string        `json:"file_ids,omitempty"`
+	Metadata     map[string]any  `json:"metadata,omitempty"`
 }
 
 // AssistantsList is a list of assistants.
@@ -80,7 +78,8 @@ type AssistantFilesList struct {
 
 // CreateAssistant creates a new assistant.
 func (c *Client) CreateAssistant(ctx context.Context, request AssistantRequest) (response Assistant, err error) {
-	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL(assistantsSuffix), withBody(request))
+	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL(assistantsSuffix), withBody(request),
+		withHeader(openaiBetaHeader, openaiAssistantsV1))
 	if err != nil {
 		return
 	}
@@ -95,7 +94,8 @@ func (c *Client) RetrieveAssistant(
 	assistantID string,
 ) (response Assistant, err error) {
 	urlSuffix := fmt.Sprintf("%s/%s", assistantsSuffix, assistantID)
-	req, err := c.newRequest(ctx, http.MethodGet, c.fullURL(urlSuffix))
+	req, err := c.newRequest(ctx, http.MethodGet, c.fullURL(urlSuffix),
+		withHeader(openaiBetaHeader, openaiAssistantsV1))
 	if err != nil {
 		return
 	}
@@ -111,7 +111,8 @@ func (c *Client) ModifyAssistant(
 	request AssistantRequest,
 ) (response Assistant, err error) {
 	urlSuffix := fmt.Sprintf("%s/%s", assistantsSuffix, assistantID)
-	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL(urlSuffix), withBody(request))
+	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL(urlSuffix), withBody(request),
+		withHeader(openaiBetaHeader, openaiAssistantsV1))
 	if err != nil {
 		return
 	}
@@ -126,7 +127,8 @@ func (c *Client) DeleteAssistant(
 	assistantID string,
 ) (response Assistant, err error) {
 	urlSuffix := fmt.Sprintf("%s/%s", assistantsSuffix, assistantID)
-	req, err := c.newRequest(ctx, http.MethodDelete, c.fullURL(urlSuffix))
+	req, err := c.newRequest(ctx, http.MethodDelete, c.fullURL(urlSuffix),
+		withHeader(openaiBetaHeader, openaiAssistantsV1))
 	if err != nil {
 		return
 	}
@@ -163,7 +165,8 @@ func (c *Client) ListAssistants(
 	}
 
 	urlSuffix := fmt.Sprintf("%s%s", assistantsSuffix, encodedValues)
-	req, err := c.newRequest(ctx, http.MethodGet, c.fullURL(urlSuffix))
+	req, err := c.newRequest(ctx, http.MethodGet, c.fullURL(urlSuffix),
+		withHeader(openaiBetaHeader, openaiAssistantsV1))
 	if err != nil {
 		return
 	}
@@ -180,7 +183,8 @@ func (c *Client) CreateAssistantFile(
 ) (response AssistantFile, err error) {
 	urlSuffix := fmt.Sprintf("%s/%s%s", assistantsSuffix, assistantID, assistantsFilesSuffix)
 	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL(urlSuffix),
-		withBody(request))
+		withBody(request),
+		withHeader(openaiBetaHeader, openaiAssistantsV1))
 	if err != nil {
 		return
 	}
@@ -196,7 +200,8 @@ func (c *Client) RetrieveAssistantFile(
 	fileID string,
 ) (response AssistantFile, err error) {
 	urlSuffix := fmt.Sprintf("%s/%s%s/%s", assistantsSuffix, assistantID, assistantsFilesSuffix, fileID)
-	req, err := c.newRequest(ctx, http.MethodGet, c.fullURL(urlSuffix))
+	req, err := c.newRequest(ctx, http.MethodGet, c.fullURL(urlSuffix),
+		withHeader(openaiBetaHeader, openaiAssistantsV1))
 	if err != nil {
 		return
 	}
@@ -212,7 +217,8 @@ func (c *Client) DeleteAssistantFile(
 	fileID string,
 ) (err error) {
 	urlSuffix := fmt.Sprintf("%s/%s%s/%s", assistantsSuffix, assistantID, assistantsFilesSuffix, fileID)
-	req, err := c.newRequest(ctx, http.MethodDelete, c.fullURL(urlSuffix))
+	req, err := c.newRequest(ctx, http.MethodDelete, c.fullURL(urlSuffix),
+		withHeader(openaiBetaHeader, openaiAssistantsV1))
 	if err != nil {
 		return
 	}
@@ -250,7 +256,8 @@ func (c *Client) ListAssistantFiles(
 	}
 
 	urlSuffix := fmt.Sprintf("%s/%s%s%s", assistantsSuffix, assistantID, assistantsFilesSuffix, encodedValues)
-	req, err := c.newRequest(ctx, http.MethodGet, c.fullURL(urlSuffix))
+	req, err := c.newRequest(ctx, http.MethodGet, c.fullURL(urlSuffix),
+		withHeader(openaiBetaHeader, openaiAssistantsV1))
 	if err != nil {
 		return
 	}

--- a/client.go
+++ b/client.go
@@ -83,6 +83,12 @@ func withContentType(contentType string) requestOption {
 	}
 }
 
+func withHeader(key, value string) requestOption {
+	return func(args *requestOptions) {
+		args.header.Set(key, value)
+	}
+}
+
 func (c *Client) newRequest(ctx context.Context, method, url string, setters ...requestOption) (*http.Request, error) {
 	// Default Options
 	args := &requestOptions{

--- a/client.go
+++ b/client.go
@@ -83,9 +83,9 @@ func withContentType(contentType string) requestOption {
 	}
 }
 
-func withHeader(key, value string) requestOption {
+func withBetaAssistantV1() requestOption {
 	return func(args *requestOptions) {
-		args.header.Set(key, value)
+		args.header.Set("OpenAI-Beta", "assistants=v1")
 	}
 }
 


### PR DESCRIPTION
**Describe the change**
- OpenAI Assistant API needs a [Beta header](https://platform.openai.com/docs/assistants/overview/step-1-create-an-assistant)
- AssistantTool types can be simplified

**Describe your solution**
- Add the header on Assistant APIs
- use only `AssistantTool` type with optional sub fields.
