### PR TITLE
fix test server setup:

### DIFF
--- a/fine_tuning_job_test.go
+++ b/fine_tuning_job_test.go
@@ -42,7 +42,7 @@ func TestFineTuningJob(t *testing.T) {
 	)
 
 	server.RegisterHandler(
-		"/fine_tuning/jobs/"+testFineTuninigJobID+"/cancel",
+		"/v1/fine_tuning/jobs/"+testFineTuninigJobID+"/cancel",
 		func(w http.ResponseWriter, _ *http.Request) {
 			resBytes, _ := json.Marshal(openai.FineTuningJob{})
 			fmt.Fprintln(w, string(resBytes))

--- a/internal/test/server.go
+++ b/internal/test/server.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"strings"
 )
 
 const testAPI = "this-is-my-secure-token-do-not-steal!!"
@@ -23,13 +24,16 @@ func NewTestServer() *ServerTest {
 }
 
 func (ts *ServerTest) RegisterHandler(path string, handler handler) {
+	// to make the registered paths friendlier to a regex match in the route handler
+	// in OpenAITestServer
+	path = strings.ReplaceAll(path, "*", ".*")
 	ts.handlers[path] = handler
 }
 
 // OpenAITestServer Creates a mocked OpenAI server which can pretend to handle requests during testing.
 func (ts *ServerTest) OpenAITestServer() *httptest.Server {
 	return httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		log.Printf("received request at path %q\n", r.URL.Path)
+		log.Printf("received a %s request at path %q\n", r.Method, r.URL.Path)
 
 		// check auth
 		if r.Header.Get("Authorization") != "Bearer "+GetTestToken() && r.Header.Get("api-key") != GetTestToken() {
@@ -38,8 +42,10 @@ func (ts *ServerTest) OpenAITestServer() *httptest.Server {
 		}
 
 		// Handle /path/* routes.
+		// Note: the * is converted to a .* in register handler for proper regex handling
 		for route, handler := range ts.handlers {
-			pattern, _ := regexp.Compile(route)
+			// Adding ^ and $ to make path matching deterministic since go map iteration isn't ordered
+			pattern, _ := regexp.Compile("^" + route + "$")
 			if pattern.MatchString(r.URL.Path) {
 				handler(w, r)
 				return


### PR DESCRIPTION
- go map access is not deterministic
- this can lead to a route: /foo/bar/1 matching /foo/bar before matching /foo/bar/1 if the map iteration go through /foo/bar first since the regex match wasn't bound to start and end anchors
- registering handlers now converts * in routes to .* for proper regex matching
- test server route handling now tries to fully match the handler route

This makes testing less flaky