### PR TITLE
Add support for vision chat completion models

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ func main() {
 			Messages: []openai.ChatCompletionMessage{
 				{
 					Role:    openai.ChatMessageRoleUser,
-					Content: "Hello!",
+					Content: &openai.ChatMessageContent{
+				    	Type: openai.ChatMessageContentTypeText,
+				    	Text: "Hello!",
+				    },
 				},
 			},
 		},
@@ -93,7 +96,10 @@ func main() {
 		Messages: []openai.ChatCompletionMessage{
 			{
 				Role:    openai.ChatMessageRoleUser,
-				Content: "Lorem ipsum",
+				Content: &openai.ChatMessageContent{
+                    Type: openai.ChatMessageContentTypeText,
+                    Text: "Lorem ipsum",
+                }
 			},
 		},
 		Stream: true,

--- a/api_integration_test.go
+++ b/api_integration_test.go
@@ -54,9 +54,11 @@ func TestAPI(t *testing.T) {
 			Messages: []openai.ChatCompletionMessage{
 				{
 					Role: openai.ChatMessageRoleUser,
-					Content: &openai.ChatMessageContent{
-						Type: openai.ChatMessageContentTypeText,
-						Text: "Hello!",
+					Content: []openai.ChatMessageContent{
+						{
+							Type: openai.ChatMessageContentTypeText,
+							Text: "Hello!",
+						},
 					},
 				},
 			},
@@ -73,9 +75,11 @@ func TestAPI(t *testing.T) {
 				{
 					Role: openai.ChatMessageRoleUser,
 					Name: "John_Doe",
-					Content: &openai.ChatMessageContent{
-						Type: openai.ChatMessageContentTypeText,
-						Text: "Hello!",
+					Content: []openai.ChatMessageContent{
+						{
+							Type: openai.ChatMessageContentTypeText,
+							Text: "Hello!",
+						},
 					},
 				},
 			},

--- a/api_integration_test.go
+++ b/api_integration_test.go
@@ -53,8 +53,11 @@ func TestAPI(t *testing.T) {
 			Model: openai.GPT3Dot5Turbo,
 			Messages: []openai.ChatCompletionMessage{
 				{
-					Role:    openai.ChatMessageRoleUser,
-					Content: "Hello!",
+					Role: openai.ChatMessageRoleUser,
+					Content: &openai.ChatMessageContent{
+						Type: openai.ChatMessageContentTypeText,
+						Text: "Hello!",
+					},
 				},
 			},
 		},
@@ -68,9 +71,12 @@ func TestAPI(t *testing.T) {
 			Model: openai.GPT3Dot5Turbo,
 			Messages: []openai.ChatCompletionMessage{
 				{
-					Role:    openai.ChatMessageRoleUser,
-					Name:    "John_Doe",
-					Content: "Hello!",
+					Role: openai.ChatMessageRoleUser,
+					Name: "John_Doe",
+					Content: &openai.ChatMessageContent{
+						Type: openai.ChatMessageContentTypeText,
+						Text: "Hello!",
+					},
 				},
 			},
 		},

--- a/chat.go
+++ b/chat.go
@@ -67,8 +67,8 @@ type ChatMessageContent struct {
 }
 
 type ChatCompletionMessage struct {
-	Role    string              `json:"role"`
-	Content *ChatMessageContent `json:"content"`
+	Role    string               `json:"role"`
+	Content []ChatMessageContent `json:"content"`
 
 	// This property isn't in the official documentation, but it's in
 	// the documentation for the official library for python:

--- a/chat.go
+++ b/chat.go
@@ -15,6 +15,11 @@ const (
 	ChatMessageRoleTool      = "tool"
 )
 
+const (
+	ChatMessageContentTypeText  = "text"
+	ChatMessageContentTypeImage = "image_url"
+)
+
 const chatCompletionsSuffix = "/chat/completions"
 
 var (
@@ -51,9 +56,19 @@ type PromptAnnotation struct {
 	ContentFilterResults ContentFilterResults `json:"content_filter_results,omitempty"`
 }
 
+type ChatMessageImageURL struct {
+	URL string `json:"url"`
+}
+
+type ChatMessageContent struct {
+	Type     string               `json:"type"`
+	Text     string               `json:"text,omitempty"`
+	ImageURL *ChatMessageImageURL `json:"image_url,omitempty"`
+}
+
 type ChatCompletionMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role    string              `json:"role"`
+	Content *ChatMessageContent `json:"content"`
 
 	// This property isn't in the official documentation, but it's in
 	// the documentation for the official library for python:

--- a/chat.go
+++ b/chat.go
@@ -80,6 +80,35 @@ type ChatCompletionMessage struct {
 	ToolCalls    []ToolCall    `json:"tool_calls,omitempty"`
 }
 
+type ChatCompletionChoiceMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+
+	// This property isn't in the official documentation, but it's in
+	// the documentation for the official library for python:
+	// - https://github.com/openai/openai-python/blob/main/chatml.md
+	// - https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb
+	Name string `json:"name,omitempty"`
+
+	FunctionCall *FunctionCall `json:"function_call,omitempty"`
+	ToolCalls    []ToolCall    `json:"tool_calls,omitempty"`
+}
+
+func (message ChatCompletionChoiceMessage) ToChatCompleteMessage() ChatCompletionMessage {
+	return ChatCompletionMessage{
+		Role: message.Role,
+		Content: []ChatMessageContent{
+			{
+				Type: ChatMessageContentTypeText,
+				Text: message.Content,
+			},
+		},
+		Name:         message.Name,
+		FunctionCall: message.FunctionCall,
+		ToolCalls:    message.ToolCalls,
+	}
+}
+
 type ToolCall struct {
 	ID       string       `json:"id"`
 	Function FunctionCall `json:"function"`
@@ -183,8 +212,8 @@ func (r FinishReason) MarshalJSON() ([]byte, error) {
 }
 
 type ChatCompletionChoice struct {
-	Index   int                   `json:"index"`
-	Message ChatCompletionMessage `json:"message"`
+	Index   int                         `json:"index"`
+	Message ChatCompletionChoiceMessage `json:"message"`
 	// FinishReason
 	// stop: API returned complete message,
 	// or a message terminated by one of the stop sequences provided via the stop parameter

--- a/chat_stream_test.go
+++ b/chat_stream_test.go
@@ -25,8 +25,11 @@ func TestChatCompletionsStreamWrongModel(t *testing.T) {
 		Model:     "ada",
 		Messages: []openai.ChatCompletionMessage{
 			{
-				Role:    openai.ChatMessageRoleUser,
-				Content: "Hello!",
+				Role: openai.ChatMessageRoleUser,
+				Content: &openai.ChatMessageContent{
+					Type: openai.ChatMessageContentTypeText,
+					Text: "Hello!",
+				},
 			},
 		},
 	}
@@ -66,8 +69,11 @@ func TestCreateChatCompletionStream(t *testing.T) {
 		Model:     openai.GPT3Dot5Turbo,
 		Messages: []openai.ChatCompletionMessage{
 			{
-				Role:    openai.ChatMessageRoleUser,
-				Content: "Hello!",
+				Role: openai.ChatMessageRoleUser,
+				Content: &openai.ChatMessageContent{
+					Type: openai.ChatMessageContentTypeText,
+					Text: "Hello!",
+				},
 			},
 		},
 		Stream: true,
@@ -161,8 +167,11 @@ func TestCreateChatCompletionStreamError(t *testing.T) {
 		Model:     openai.GPT3Dot5Turbo,
 		Messages: []openai.ChatCompletionMessage{
 			{
-				Role:    openai.ChatMessageRoleUser,
-				Content: "Hello!",
+				Role: openai.ChatMessageRoleUser,
+				Content: &openai.ChatMessageContent{
+					Type: openai.ChatMessageContentTypeText,
+					Text: "Hello!",
+				},
 			},
 		},
 		Stream: true,
@@ -201,8 +210,11 @@ func TestCreateChatCompletionStreamWithHeaders(t *testing.T) {
 		Model:     openai.GPT3Dot5Turbo,
 		Messages: []openai.ChatCompletionMessage{
 			{
-				Role:    openai.ChatMessageRoleUser,
-				Content: "Hello!",
+				Role: openai.ChatMessageRoleUser,
+				Content: &openai.ChatMessageContent{
+					Type: openai.ChatMessageContentTypeText,
+					Text: "Hello!",
+				},
 			},
 		},
 		Stream: true,
@@ -244,8 +256,11 @@ func TestCreateChatCompletionStreamWithRatelimitHeaders(t *testing.T) {
 		Model:     openai.GPT3Dot5Turbo,
 		Messages: []openai.ChatCompletionMessage{
 			{
-				Role:    openai.ChatMessageRoleUser,
-				Content: "Hello!",
+				Role: openai.ChatMessageRoleUser,
+				Content: &openai.ChatMessageContent{
+					Type: openai.ChatMessageContentTypeText,
+					Text: "Hello!",
+				},
 			},
 		},
 		Stream: true,
@@ -281,8 +296,11 @@ func TestCreateChatCompletionStreamErrorWithDataPrefix(t *testing.T) {
 		Model:     openai.GPT3Dot5Turbo,
 		Messages: []openai.ChatCompletionMessage{
 			{
-				Role:    openai.ChatMessageRoleUser,
-				Content: "Hello!",
+				Role: openai.ChatMessageRoleUser,
+				Content: &openai.ChatMessageContent{
+					Type: openai.ChatMessageContentTypeText,
+					Text: "Hello!",
+				},
 			},
 		},
 		Stream: true,
@@ -322,8 +340,11 @@ func TestCreateChatCompletionStreamRateLimitError(t *testing.T) {
 		Model:     openai.GPT3Dot5Turbo,
 		Messages: []openai.ChatCompletionMessage{
 			{
-				Role:    openai.ChatMessageRoleUser,
-				Content: "Hello!",
+				Role: openai.ChatMessageRoleUser,
+				Content: &openai.ChatMessageContent{
+					Type: openai.ChatMessageContentTypeText,
+					Text: "Hello!",
+				},
 			},
 		},
 		Stream: true,
@@ -361,8 +382,11 @@ func TestAzureCreateChatCompletionStreamRateLimitError(t *testing.T) {
 		Model:     openai.GPT3Dot5Turbo,
 		Messages: []openai.ChatCompletionMessage{
 			{
-				Role:    openai.ChatMessageRoleUser,
-				Content: "Hello!",
+				Role: openai.ChatMessageRoleUser,
+				Content: &openai.ChatMessageContent{
+					Type: openai.ChatMessageContentTypeText,
+					Text: "Hello!",
+				},
 			},
 		},
 		Stream: true,

--- a/chat_stream_test.go
+++ b/chat_stream_test.go
@@ -26,9 +26,11 @@ func TestChatCompletionsStreamWrongModel(t *testing.T) {
 		Messages: []openai.ChatCompletionMessage{
 			{
 				Role: openai.ChatMessageRoleUser,
-				Content: &openai.ChatMessageContent{
-					Type: openai.ChatMessageContentTypeText,
-					Text: "Hello!",
+				Content: []openai.ChatMessageContent{
+					{
+						Type: openai.ChatMessageContentTypeText,
+						Text: "Hello!",
+					},
 				},
 			},
 		},
@@ -70,9 +72,11 @@ func TestCreateChatCompletionStream(t *testing.T) {
 		Messages: []openai.ChatCompletionMessage{
 			{
 				Role: openai.ChatMessageRoleUser,
-				Content: &openai.ChatMessageContent{
-					Type: openai.ChatMessageContentTypeText,
-					Text: "Hello!",
+				Content: []openai.ChatMessageContent{
+					{
+						Type: openai.ChatMessageContentTypeText,
+						Text: "Hello!",
+					},
 				},
 			},
 		},
@@ -168,9 +172,11 @@ func TestCreateChatCompletionStreamError(t *testing.T) {
 		Messages: []openai.ChatCompletionMessage{
 			{
 				Role: openai.ChatMessageRoleUser,
-				Content: &openai.ChatMessageContent{
-					Type: openai.ChatMessageContentTypeText,
-					Text: "Hello!",
+				Content: []openai.ChatMessageContent{
+					{
+						Type: openai.ChatMessageContentTypeText,
+						Text: "Hello!",
+					},
 				},
 			},
 		},
@@ -211,9 +217,11 @@ func TestCreateChatCompletionStreamWithHeaders(t *testing.T) {
 		Messages: []openai.ChatCompletionMessage{
 			{
 				Role: openai.ChatMessageRoleUser,
-				Content: &openai.ChatMessageContent{
-					Type: openai.ChatMessageContentTypeText,
-					Text: "Hello!",
+				Content: []openai.ChatMessageContent{
+					{
+						Type: openai.ChatMessageContentTypeText,
+						Text: "Hello!",
+					},
 				},
 			},
 		},
@@ -257,9 +265,11 @@ func TestCreateChatCompletionStreamWithRatelimitHeaders(t *testing.T) {
 		Messages: []openai.ChatCompletionMessage{
 			{
 				Role: openai.ChatMessageRoleUser,
-				Content: &openai.ChatMessageContent{
-					Type: openai.ChatMessageContentTypeText,
-					Text: "Hello!",
+				Content: []openai.ChatMessageContent{
+					{
+						Type: openai.ChatMessageContentTypeText,
+						Text: "Hello!",
+					},
 				},
 			},
 		},
@@ -297,9 +307,11 @@ func TestCreateChatCompletionStreamErrorWithDataPrefix(t *testing.T) {
 		Messages: []openai.ChatCompletionMessage{
 			{
 				Role: openai.ChatMessageRoleUser,
-				Content: &openai.ChatMessageContent{
-					Type: openai.ChatMessageContentTypeText,
-					Text: "Hello!",
+				Content: []openai.ChatMessageContent{
+					{
+						Type: openai.ChatMessageContentTypeText,
+						Text: "Hello!",
+					},
 				},
 			},
 		},
@@ -341,9 +353,11 @@ func TestCreateChatCompletionStreamRateLimitError(t *testing.T) {
 		Messages: []openai.ChatCompletionMessage{
 			{
 				Role: openai.ChatMessageRoleUser,
-				Content: &openai.ChatMessageContent{
-					Type: openai.ChatMessageContentTypeText,
-					Text: "Hello!",
+				Content: []openai.ChatMessageContent{
+					{
+						Type: openai.ChatMessageContentTypeText,
+						Text: "Hello!",
+					},
 				},
 			},
 		},
@@ -383,9 +397,11 @@ func TestAzureCreateChatCompletionStreamRateLimitError(t *testing.T) {
 		Messages: []openai.ChatCompletionMessage{
 			{
 				Role: openai.ChatMessageRoleUser,
-				Content: &openai.ChatMessageContent{
-					Type: openai.ChatMessageContentTypeText,
-					Text: "Hello!",
+				Content: []openai.ChatMessageContent{
+					{
+						Type: openai.ChatMessageContentTypeText,
+						Text: "Hello!",
+					},
 				},
 			},
 		},

--- a/chat_test.go
+++ b/chat_test.go
@@ -363,7 +363,7 @@ func handleChatCompletionEndpoint(w http.ResponseWriter, r *http.Request) {
 			}
 
 			res.Choices = append(res.Choices, openai.ChatCompletionChoice{
-				Message: openai.ChatCompletionMessage{
+				Message: openai.ChatCompletionChoiceMessage{
 					Role: openai.ChatMessageRoleFunction,
 					// this is valid json so it should be fine
 					FunctionCall: &openai.FunctionCall{
@@ -379,14 +379,9 @@ func handleChatCompletionEndpoint(w http.ResponseWriter, r *http.Request) {
 		completionStr := strings.Repeat("a", completionReq.MaxTokens)
 
 		res.Choices = append(res.Choices, openai.ChatCompletionChoice{
-			Message: openai.ChatCompletionMessage{
-				Role: openai.ChatMessageRoleAssistant,
-				Content: []openai.ChatMessageContent{
-					{
-						Type: openai.ChatMessageContentTypeText,
-						Text: completionStr,
-					},
-				},
+			Message: openai.ChatCompletionChoiceMessage{
+				Role:    openai.ChatMessageRoleAssistant,
+				Content: completionStr,
 			},
 			Index: i,
 		})

--- a/chat_test.go
+++ b/chat_test.go
@@ -41,8 +41,11 @@ func TestChatCompletionsWrongModel(t *testing.T) {
 		Model:     "ada",
 		Messages: []openai.ChatCompletionMessage{
 			{
-				Role:    openai.ChatMessageRoleUser,
-				Content: "Hello!",
+				Role: openai.ChatMessageRoleUser,
+				Content: &openai.ChatMessageContent{
+					Type: openai.ChatMessageContentTypeText,
+					Text: "Hello!",
+				},
 			},
 		},
 	}
@@ -74,8 +77,11 @@ func TestChatCompletions(t *testing.T) {
 		Model:     openai.GPT3Dot5Turbo,
 		Messages: []openai.ChatCompletionMessage{
 			{
-				Role:    openai.ChatMessageRoleUser,
-				Content: "Hello!",
+				Role: openai.ChatMessageRoleUser,
+				Content: &openai.ChatMessageContent{
+					Type: openai.ChatMessageContentTypeText,
+					Text: "Hello!",
+				},
 			},
 		},
 	})
@@ -92,8 +98,11 @@ func TestChatCompletionsWithHeaders(t *testing.T) {
 		Model:     openai.GPT3Dot5Turbo,
 		Messages: []openai.ChatCompletionMessage{
 			{
-				Role:    openai.ChatMessageRoleUser,
-				Content: "Hello!",
+				Role: openai.ChatMessageRoleUser,
+				Content: &openai.ChatMessageContent{
+					Type: openai.ChatMessageContentTypeText,
+					Text: "Hello!",
+				},
 			},
 		},
 	})
@@ -116,8 +125,11 @@ func TestChatCompletionsWithRateLimitHeaders(t *testing.T) {
 		Model:     openai.GPT3Dot5Turbo,
 		Messages: []openai.ChatCompletionMessage{
 			{
-				Role:    openai.ChatMessageRoleUser,
-				Content: "Hello!",
+				Role: openai.ChatMessageRoleUser,
+				Content: &openai.ChatMessageContent{
+					Type: openai.ChatMessageContentTypeText,
+					Text: "Hello!",
+				},
 			},
 		},
 	})
@@ -153,8 +165,11 @@ func TestChatCompletionsFunctions(t *testing.T) {
 			Model:     openai.GPT3Dot5Turbo0613,
 			Messages: []openai.ChatCompletionMessage{
 				{
-					Role:    openai.ChatMessageRoleUser,
-					Content: "Hello!",
+					Role: openai.ChatMessageRoleUser,
+					Content: &openai.ChatMessageContent{
+						Type: openai.ChatMessageContentTypeText,
+						Text: "Hello!",
+					},
 				},
 			},
 			Functions: []openai.FunctionDefinition{{
@@ -178,8 +193,11 @@ func TestChatCompletionsFunctions(t *testing.T) {
 			Model:     openai.GPT3Dot5Turbo0613,
 			Messages: []openai.ChatCompletionMessage{
 				{
-					Role:    openai.ChatMessageRoleUser,
-					Content: "Hello!",
+					Role: openai.ChatMessageRoleUser,
+					Content: &openai.ChatMessageContent{
+						Type: openai.ChatMessageContentTypeText,
+						Text: "Hello!",
+					},
 				},
 			},
 			Functions: []openai.FunctionDefinition{{
@@ -195,8 +213,11 @@ func TestChatCompletionsFunctions(t *testing.T) {
 			Model:     openai.GPT3Dot5Turbo0613,
 			Messages: []openai.ChatCompletionMessage{
 				{
-					Role:    openai.ChatMessageRoleUser,
-					Content: "Hello!",
+					Role: openai.ChatMessageRoleUser,
+					Content: &openai.ChatMessageContent{
+						Type: openai.ChatMessageContentTypeText,
+						Text: "Hello!",
+					},
 				},
 			},
 			Functions: []openai.FunctionDefinition{{
@@ -232,8 +253,11 @@ func TestChatCompletionsFunctions(t *testing.T) {
 			Model:     openai.GPT3Dot5Turbo0613,
 			Messages: []openai.ChatCompletionMessage{
 				{
-					Role:    openai.ChatMessageRoleUser,
-					Content: "Hello!",
+					Role: openai.ChatMessageRoleUser,
+					Content: &openai.ChatMessageContent{
+						Type: openai.ChatMessageContentTypeText,
+						Text: "Hello!",
+					},
 				},
 			},
 			Functions: []openai.FunctionDefine{{
@@ -274,8 +298,11 @@ func TestAzureChatCompletions(t *testing.T) {
 		Model:     openai.GPT3Dot5Turbo,
 		Messages: []openai.ChatCompletionMessage{
 			{
-				Role:    openai.ChatMessageRoleUser,
-				Content: "Hello!",
+				Role: openai.ChatMessageRoleUser,
+				Content: &openai.ChatMessageContent{
+					Type: openai.ChatMessageContentTypeText,
+					Text: "Hello!",
+				},
 			},
 		},
 	})
@@ -339,13 +366,16 @@ func handleChatCompletionEndpoint(w http.ResponseWriter, r *http.Request) {
 
 		res.Choices = append(res.Choices, openai.ChatCompletionChoice{
 			Message: openai.ChatCompletionMessage{
-				Role:    openai.ChatMessageRoleAssistant,
-				Content: completionStr,
+				Role: openai.ChatMessageRoleAssistant,
+				Content: &openai.ChatMessageContent{
+					Type: openai.ChatMessageContentTypeText,
+					Text: completionStr,
+				},
 			},
 			Index: i,
 		})
 	}
-	inputTokens := numTokens(completionReq.Messages[0].Content) * n
+	inputTokens := numTokens(completionReq.Messages[0].Content.Text) * n
 	completionTokens := completionReq.MaxTokens * n
 	res.Usage = openai.Usage{
 		PromptTokens:     inputTokens,

--- a/chat_test.go
+++ b/chat_test.go
@@ -42,9 +42,11 @@ func TestChatCompletionsWrongModel(t *testing.T) {
 		Messages: []openai.ChatCompletionMessage{
 			{
 				Role: openai.ChatMessageRoleUser,
-				Content: &openai.ChatMessageContent{
-					Type: openai.ChatMessageContentTypeText,
-					Text: "Hello!",
+				Content: []openai.ChatMessageContent{
+					{
+						Type: openai.ChatMessageContentTypeText,
+						Text: "Hello!",
+					},
 				},
 			},
 		},
@@ -78,9 +80,11 @@ func TestChatCompletions(t *testing.T) {
 		Messages: []openai.ChatCompletionMessage{
 			{
 				Role: openai.ChatMessageRoleUser,
-				Content: &openai.ChatMessageContent{
-					Type: openai.ChatMessageContentTypeText,
-					Text: "Hello!",
+				Content: []openai.ChatMessageContent{
+					{
+						Type: openai.ChatMessageContentTypeText,
+						Text: "Hello!",
+					},
 				},
 			},
 		},
@@ -99,9 +103,11 @@ func TestChatCompletionsWithHeaders(t *testing.T) {
 		Messages: []openai.ChatCompletionMessage{
 			{
 				Role: openai.ChatMessageRoleUser,
-				Content: &openai.ChatMessageContent{
-					Type: openai.ChatMessageContentTypeText,
-					Text: "Hello!",
+				Content: []openai.ChatMessageContent{
+					{
+						Type: openai.ChatMessageContentTypeText,
+						Text: "Hello!",
+					},
 				},
 			},
 		},
@@ -126,9 +132,9 @@ func TestChatCompletionsWithRateLimitHeaders(t *testing.T) {
 		Messages: []openai.ChatCompletionMessage{
 			{
 				Role: openai.ChatMessageRoleUser,
-				Content: &openai.ChatMessageContent{
-					Type: openai.ChatMessageContentTypeText,
-					Text: "Hello!",
+				Content: []openai.ChatMessageContent{
+					{Type: openai.ChatMessageContentTypeText,
+						Text: "Hello!"},
 				},
 			},
 		},
@@ -166,9 +172,11 @@ func TestChatCompletionsFunctions(t *testing.T) {
 			Messages: []openai.ChatCompletionMessage{
 				{
 					Role: openai.ChatMessageRoleUser,
-					Content: &openai.ChatMessageContent{
-						Type: openai.ChatMessageContentTypeText,
-						Text: "Hello!",
+					Content: []openai.ChatMessageContent{
+						{
+							Type: openai.ChatMessageContentTypeText,
+							Text: "Hello!",
+						},
 					},
 				},
 			},
@@ -194,9 +202,11 @@ func TestChatCompletionsFunctions(t *testing.T) {
 			Messages: []openai.ChatCompletionMessage{
 				{
 					Role: openai.ChatMessageRoleUser,
-					Content: &openai.ChatMessageContent{
-						Type: openai.ChatMessageContentTypeText,
-						Text: "Hello!",
+					Content: []openai.ChatMessageContent{
+						{
+							Type: openai.ChatMessageContentTypeText,
+							Text: "Hello!",
+						},
 					},
 				},
 			},
@@ -214,9 +224,11 @@ func TestChatCompletionsFunctions(t *testing.T) {
 			Messages: []openai.ChatCompletionMessage{
 				{
 					Role: openai.ChatMessageRoleUser,
-					Content: &openai.ChatMessageContent{
-						Type: openai.ChatMessageContentTypeText,
-						Text: "Hello!",
+					Content: []openai.ChatMessageContent{
+						{
+							Type: openai.ChatMessageContentTypeText,
+							Text: "Hello!",
+						},
 					},
 				},
 			},
@@ -254,9 +266,11 @@ func TestChatCompletionsFunctions(t *testing.T) {
 			Messages: []openai.ChatCompletionMessage{
 				{
 					Role: openai.ChatMessageRoleUser,
-					Content: &openai.ChatMessageContent{
-						Type: openai.ChatMessageContentTypeText,
-						Text: "Hello!",
+					Content: []openai.ChatMessageContent{
+						{
+							Type: openai.ChatMessageContentTypeText,
+							Text: "Hello!",
+						},
 					},
 				},
 			},
@@ -299,9 +313,9 @@ func TestAzureChatCompletions(t *testing.T) {
 		Messages: []openai.ChatCompletionMessage{
 			{
 				Role: openai.ChatMessageRoleUser,
-				Content: &openai.ChatMessageContent{
-					Type: openai.ChatMessageContentTypeText,
-					Text: "Hello!",
+				Content: []openai.ChatMessageContent{
+					{Type: openai.ChatMessageContentTypeText,
+						Text: "Hello!"},
 				},
 			},
 		},
@@ -367,15 +381,17 @@ func handleChatCompletionEndpoint(w http.ResponseWriter, r *http.Request) {
 		res.Choices = append(res.Choices, openai.ChatCompletionChoice{
 			Message: openai.ChatCompletionMessage{
 				Role: openai.ChatMessageRoleAssistant,
-				Content: &openai.ChatMessageContent{
-					Type: openai.ChatMessageContentTypeText,
-					Text: completionStr,
+				Content: []openai.ChatMessageContent{
+					{
+						Type: openai.ChatMessageContentTypeText,
+						Text: completionStr,
+					},
 				},
 			},
 			Index: i,
 		})
 	}
-	inputTokens := numTokens(completionReq.Messages[0].Content.Text) * n
+	inputTokens := numTokens(completionReq.Messages[0].Content[0].Text) * n
 	completionTokens := completionReq.MaxTokens * n
 	res.Usage = openai.Usage{
 		PromptTokens:     inputTokens,

--- a/example_test.go
+++ b/example_test.go
@@ -23,9 +23,11 @@ func Example() {
 			Messages: []openai.ChatCompletionMessage{
 				{
 					Role: openai.ChatMessageRoleUser,
-					Content: &openai.ChatMessageContent{
-						Type: openai.ChatMessageContentTypeText,
-						Text: "Hello!",
+					Content: []openai.ChatMessageContent{
+						{
+							Type: openai.ChatMessageContentTypeText,
+							Text: "Hello!",
+						},
 					},
 				},
 			},
@@ -50,9 +52,11 @@ func ExampleClient_CreateChatCompletionStream() {
 			Messages: []openai.ChatCompletionMessage{
 				{
 					Role: openai.ChatMessageRoleUser,
-					Content: &openai.ChatMessageContent{
-						Type: openai.ChatMessageContentTypeText,
-						Text: "Lorem ipsum",
+					Content: []openai.ChatMessageContent{
+						{
+							Type: openai.ChatMessageContentTypeText,
+							Text: "Lorem ipsum",
+						},
 					},
 				},
 			},
@@ -283,9 +287,11 @@ func Example_chatbot() {
 		Messages: []openai.ChatCompletionMessage{
 			{
 				Role: openai.ChatMessageRoleSystem,
-				Content: &openai.ChatMessageContent{
-					Type: openai.ChatMessageContentTypeText,
-					Text: "you are a helpful chatbot",
+				Content: []openai.ChatMessageContent{
+					{
+						Type: openai.ChatMessageContentTypeText,
+						Text: "you are a helpful chatbot",
+					},
 				},
 			},
 		},
@@ -296,15 +302,20 @@ func Example_chatbot() {
 	s := bufio.NewScanner(os.Stdin)
 	for s.Scan() {
 		req.Messages = append(req.Messages, openai.ChatCompletionMessage{
-			Role:    openai.ChatMessageRoleUser,
-			Content: &openai.ChatMessageContent{Type: openai.ChatMessageContentTypeText, Text: s.Text()},
+			Role: openai.ChatMessageRoleUser,
+			Content: []openai.ChatMessageContent{
+				{
+					Type: openai.ChatMessageContentTypeText,
+					Text: s.Text(),
+				},
+			},
 		})
 		resp, err := client.CreateChatCompletion(context.Background(), req)
 		if err != nil {
 			fmt.Printf("ChatCompletion error: %v\n", err)
 			continue
 		}
-		fmt.Printf("%s\n\n", resp.Choices[0].Message.Content.Text)
+		fmt.Printf("%s\n\n", resp.Choices[0].Message.Content[0].Text)
 		req.Messages = append(req.Messages, resp.Choices[0].Message)
 		fmt.Print("> ")
 	}
@@ -321,8 +332,13 @@ func ExampleDefaultAzureConfig() {
 			Model: openai.GPT3Dot5Turbo,
 			Messages: []openai.ChatCompletionMessage{
 				{
-					Role:    openai.ChatMessageRoleUser,
-					Content: &openai.ChatMessageContent{Type: openai.ChatMessageContentTypeText, Text: "Hello Azure OpenAI!"},
+					Role: openai.ChatMessageRoleUser,
+					Content: []openai.ChatMessageContent{
+						{
+							Type: openai.ChatMessageContentTypeText,
+							Text: "Hello Azure OpenAI!",
+						},
+					},
 				},
 			},
 		},

--- a/example_test.go
+++ b/example_test.go
@@ -315,8 +315,8 @@ func Example_chatbot() {
 			fmt.Printf("ChatCompletion error: %v\n", err)
 			continue
 		}
-		fmt.Printf("%s\n\n", resp.Choices[0].Message.Content[0].Text)
-		req.Messages = append(req.Messages, resp.Choices[0].Message)
+		fmt.Printf("%s\n\n", resp.Choices[0].Message.Content)
+		req.Messages = append(req.Messages, resp.Choices[0].Message.ToChatCompleteMessage())
 		fmt.Print("> ")
 	}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -22,8 +22,11 @@ func Example() {
 			Model: openai.GPT3Dot5Turbo,
 			Messages: []openai.ChatCompletionMessage{
 				{
-					Role:    openai.ChatMessageRoleUser,
-					Content: "Hello!",
+					Role: openai.ChatMessageRoleUser,
+					Content: &openai.ChatMessageContent{
+						Type: openai.ChatMessageContentTypeText,
+						Text: "Hello!",
+					},
 				},
 			},
 		},
@@ -46,8 +49,11 @@ func ExampleClient_CreateChatCompletionStream() {
 			MaxTokens: 20,
 			Messages: []openai.ChatCompletionMessage{
 				{
-					Role:    openai.ChatMessageRoleUser,
-					Content: "Lorem ipsum",
+					Role: openai.ChatMessageRoleUser,
+					Content: &openai.ChatMessageContent{
+						Type: openai.ChatMessageContentTypeText,
+						Text: "Lorem ipsum",
+					},
 				},
 			},
 			Stream: true,
@@ -276,8 +282,11 @@ func Example_chatbot() {
 		Model: openai.GPT3Dot5Turbo,
 		Messages: []openai.ChatCompletionMessage{
 			{
-				Role:    openai.ChatMessageRoleSystem,
-				Content: "you are a helpful chatbot",
+				Role: openai.ChatMessageRoleSystem,
+				Content: &openai.ChatMessageContent{
+					Type: openai.ChatMessageContentTypeText,
+					Text: "you are a helpful chatbot",
+				},
 			},
 		},
 	}
@@ -288,14 +297,14 @@ func Example_chatbot() {
 	for s.Scan() {
 		req.Messages = append(req.Messages, openai.ChatCompletionMessage{
 			Role:    openai.ChatMessageRoleUser,
-			Content: s.Text(),
+			Content: &openai.ChatMessageContent{Type: openai.ChatMessageContentTypeText, Text: s.Text()},
 		})
 		resp, err := client.CreateChatCompletion(context.Background(), req)
 		if err != nil {
 			fmt.Printf("ChatCompletion error: %v\n", err)
 			continue
 		}
-		fmt.Printf("%s\n\n", resp.Choices[0].Message.Content)
+		fmt.Printf("%s\n\n", resp.Choices[0].Message.Content.Text)
 		req.Messages = append(req.Messages, resp.Choices[0].Message)
 		fmt.Print("> ")
 	}
@@ -313,7 +322,7 @@ func ExampleDefaultAzureConfig() {
 			Messages: []openai.ChatCompletionMessage{
 				{
 					Role:    openai.ChatMessageRoleUser,
-					Content: "Hello Azure OpenAI!",
+					Content: &openai.ChatMessageContent{Type: openai.ChatMessageContentTypeText, Text: "Hello Azure OpenAI!"},
 				},
 			},
 		},

--- a/examples/chatbot/main.go
+++ b/examples/chatbot/main.go
@@ -45,8 +45,8 @@ func main() {
 			fmt.Printf("ChatCompletion error: %v\n", err)
 			continue
 		}
-		fmt.Printf("%s\n\n", resp.Choices[0].Message.Content[0].Text)
-		req.Messages = append(req.Messages, resp.Choices[0].Message)
+		fmt.Printf("%s\n\n", resp.Choices[0].Message.Content)
+		req.Messages = append(req.Messages, resp.Choices[0].Message.ToChatCompleteMessage())
 		fmt.Print("> ")
 	}
 }

--- a/examples/chatbot/main.go
+++ b/examples/chatbot/main.go
@@ -16,8 +16,11 @@ func main() {
 		Model: openai.GPT3Dot5Turbo,
 		Messages: []openai.ChatCompletionMessage{
 			{
-				Role:    openai.ChatMessageRoleSystem,
-				Content: "you are a helpful chatbot",
+				Role: openai.ChatMessageRoleSystem,
+				Content: &openai.ChatMessageContent{
+					Type: openai.ChatMessageContentTypeText,
+					Text: "you are a helpful chatbot",
+				},
 			},
 		},
 	}
@@ -27,15 +30,18 @@ func main() {
 	s := bufio.NewScanner(os.Stdin)
 	for s.Scan() {
 		req.Messages = append(req.Messages, openai.ChatCompletionMessage{
-			Role:    openai.ChatMessageRoleUser,
-			Content: s.Text(),
+			Role: openai.ChatMessageRoleUser,
+			Content: &openai.ChatMessageContent{
+				Type: openai.ChatMessageContentTypeText,
+				Text: s.Text(),
+			},
 		})
 		resp, err := client.CreateChatCompletion(context.Background(), req)
 		if err != nil {
 			fmt.Printf("ChatCompletion error: %v\n", err)
 			continue
 		}
-		fmt.Printf("%s\n\n", resp.Choices[0].Message.Content)
+		fmt.Printf("%s\n\n", resp.Choices[0].Message.Content.Text)
 		req.Messages = append(req.Messages, resp.Choices[0].Message)
 		fmt.Print("> ")
 	}

--- a/examples/chatbot/main.go
+++ b/examples/chatbot/main.go
@@ -17,9 +17,11 @@ func main() {
 		Messages: []openai.ChatCompletionMessage{
 			{
 				Role: openai.ChatMessageRoleSystem,
-				Content: &openai.ChatMessageContent{
-					Type: openai.ChatMessageContentTypeText,
-					Text: "you are a helpful chatbot",
+				Content: []openai.ChatMessageContent{
+					{
+						Type: openai.ChatMessageContentTypeText,
+						Text: "you are a helpful chatbot",
+					},
 				},
 			},
 		},
@@ -31,9 +33,11 @@ func main() {
 	for s.Scan() {
 		req.Messages = append(req.Messages, openai.ChatCompletionMessage{
 			Role: openai.ChatMessageRoleUser,
-			Content: &openai.ChatMessageContent{
-				Type: openai.ChatMessageContentTypeText,
-				Text: s.Text(),
+			Content: []openai.ChatMessageContent{
+				{
+					Type: openai.ChatMessageContentTypeText,
+					Text: s.Text(),
+				},
 			},
 		})
 		resp, err := client.CreateChatCompletion(context.Background(), req)
@@ -41,7 +45,7 @@ func main() {
 			fmt.Printf("ChatCompletion error: %v\n", err)
 			continue
 		}
-		fmt.Printf("%s\n\n", resp.Choices[0].Message.Content.Text)
+		fmt.Printf("%s\n\n", resp.Choices[0].Message.Content[0].Text)
 		req.Messages = append(req.Messages, resp.Choices[0].Message)
 		fmt.Print("> ")
 	}

--- a/examples/chatvision/main.go
+++ b/examples/chatvision/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+func main() {
+	client := openai.NewClient(os.Getenv("OPENAI_API_KEY"))
+
+	req := openai.ChatCompletionRequest{
+		Model: openai.GPT4VisionPreview,
+		Messages: []openai.ChatCompletionMessage{
+			{
+				Role: openai.ChatMessageRoleUser,
+				Content: []openai.ChatMessageContent{
+					{
+						Type: openai.ChatMessageContentTypeText,
+						Text: "What's in this image",
+					},
+					{
+						Type: openai.ChatMessageContentTypeImage,
+						ImageURL: &openai.ChatMessageImageURL{
+							URL: "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := client.CreateChatCompletion(context.Background(), req)
+	if err != nil {
+		fmt.Printf("ChatCompletion error: %v\n", err)
+		return
+	}
+	fmt.Printf("%s\n\n", resp.Choices[0].Message.Content)
+}


### PR DESCRIPTION
**Describe the change**
This PR let's you pass in `image_url` so we can pass in images to vision models like `gpt-4-vision-preview`

**Describe your solution**
The definition of `ChatCompletionMessage` is changed such that we can pass in a struct containing text and images for `Content` instead of a string.

**Tests**
This PR has been tested in `example/chatvision`

Issue: #539 
