### PR TITLE
fix: add missing fields in tool_calls

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -66,7 +66,10 @@ type ChatCompletionMessage struct {
 }
 
 type ToolCall struct {
+	// Index is not nil only in chat completion chunk object
+	Index    *int         `json:"index,omitempty"`
 	ID       string       `json:"id"`
+	Type     ToolType     `json:"type"`
 	Function FunctionCall `json:"function"`
 }
 


### PR DESCRIPTION
**Describe the change**
There are [missing fields](https://platform.openai.com/docs/api-reference/chat/streaming) in `tool_calls` object. Following the documentation the [chat completion chunk object](https://platform.openai.com/docs/api-reference/chat/streaming) has the `index` field also.

**Describe your solution**
Just added missing fields


Issue: #555 
