### PR TITLE
fix: add beta assistant header to CreateMessage call

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -71,7 +71,7 @@ type MessageFilesList struct {
 // CreateMessage creates a new message.
 func (c *Client) CreateMessage(ctx context.Context, threadID string, request MessageRequest) (msg Message, err error) {
 	urlSuffix := fmt.Sprintf("/threads/%s/%s", threadID, messagesSuffix)
-	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL(urlSuffix), withBody(request))
+	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL(urlSuffix), withBody(request), withBetaAssistantV1())
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
**Describe the change**
Calling the `CreateMessage` method currently fails with the following error message: `You must provide the 'OpenAI-Beta' header to access the Assistants API. Please try again by setting the header 'OpenAI-Beta: assistants=v1'.`

**Describe your solution**
I've updated the `CreateMessage` call in `messages.go` to include the `withBetaAssistantV1()` request option.

**Tests**
It was unclear how to update the tests as I didn't see a way to test the header was set.  I have tested that the call succeeds in my application now.
