### PR TITLE
feat: support direct bytes for file upload

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -247,6 +247,9 @@ func TestClientReturnsRequestBuilderErrors(t *testing.T) {
 		{"CreateImage", func() (any, error) {
 			return client.CreateImage(ctx, ImageRequest{})
 		}},
+		{"CreateFileBytes", func() (any, error) {
+			return client.CreateFileBytes(ctx, FileBytesRequest{})
+		}},
 		{"DeleteFile", func() (any, error) {
 			return nil, client.DeleteFile(ctx, "")
 		}},

--- a/files_api_test.go
+++ b/files_api_test.go
@@ -16,6 +16,19 @@ import (
 	"github.com/sashabaranov/go-openai/internal/test/checks"
 )
 
+func TestFileBytesUpload(t *testing.T) {
+	client, server, teardown := setupOpenAITestServer()
+	defer teardown()
+	server.RegisterHandler("/v1/files", handleCreateFile)
+	req := openai.FileBytesRequest{
+		Name:    "foo",
+		Bytes:   []byte("foo"),
+		Purpose: openai.PurposeFineTune,
+	}
+	_, err := client.CreateFileBytes(context.Background(), req)
+	checks.NoError(t, err, "CreateFile error")
+}
+
 func TestFileUpload(t *testing.T) {
 	client, server, teardown := setupOpenAITestServer()
 	defer teardown()

--- a/files_test.go
+++ b/files_test.go
@@ -48,7 +48,7 @@ func TestFileBytesUploadWithFailingFormBuilder(t *testing.T) {
 	mockBuilder.mockWriteField = func(string, string) error {
 		return nil
 	}
-	mockBuilder.mockCreateFormFile = func(string, *os.File) error {
+	mockBuilder.mockCreateFormFileReader = func(string, io.Reader, string) error {
 		return nil
 	}
 	mockBuilder.mockClose = func() error {
@@ -102,6 +102,9 @@ func TestFileUploadWithFailingFormBuilder(t *testing.T) {
 		return mockError
 	}
 	_, err = client.CreateFile(ctx, req)
+	if err == nil {
+		t.Fatal("CreateFile should return error if form builder fails")
+	}
 	checks.ErrorIs(t, err, mockError, "CreateFile should return error if form builder fails")
 }
 


### PR DESCRIPTION
**Describe the change**
`CreateFile` currently requires a "local" file which it reads from the filesystem and uploads.  For various reasons, we require uploading bytes directly rather than relying on local filesystem.

**Describe your solution**
Add `CreateFileBytes` which takes a `FileBytesRequest` that allows directly passing a `[]byte`.  This reuses the exsting `CreateFormFileReader` passing a `*bytes.Reader` directly.


**Tests**
Added a test case to `files_api_test.go`.   Also validated that it works in a separate app.
