### PR TITLE
Pagination fields are missing from assistants list beta API

### DIFF
--- a/assistant.go
+++ b/assistant.go
@@ -52,7 +52,9 @@ type AssistantRequest struct {
 // AssistantsList is a list of assistants.
 type AssistantsList struct {
 	Assistants []Assistant `json:"data"`
-
+	LastID     *string     `json:"last_id"`
+	FirstID    *string     `json:"first_id"`
+	HasMore    bool        `json:"has_more"`
 	httpHeader
 }
 

--- a/assistant_test.go
+++ b/assistant_test.go
@@ -142,6 +142,8 @@ When asked a question, write and run Python code to answer the question.`
 				fmt.Fprintln(w, string(resBytes))
 			} else if r.Method == http.MethodGet {
 				resBytes, _ := json.Marshal(openai.AssistantsList{
+					LastID:  &assistantID,
+					FirstID: &assistantID,
 					Assistants: []openai.Assistant{
 						{
 							ID:           assistantID,


### PR DESCRIPTION


**Describe the change**
Missing pagination parameters for new assistants list API

**Describe your solution**
Add missing parameters

**Tests**
Verified against endpoint

**Additional context**
```
curl "https://api.openai.com/v1/assistants?order=desc&limit=20" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -H "OpenAI-Beta: assistants=v1"
{
  "object": "list",
  "data": [],
  "first_id": null,
  "last_id": null,
  "has_more": false
}
```

Issue: #XXXX
