### PR TITLE
Add File purposes as constants

### DIFF
--- a/files.go
+++ b/files.go
@@ -20,9 +20,9 @@ type PurposeType string
 
 const (
 	PurposeFineTune         PurposeType = "fine-tune"
-  PurposeFineTuneResults  PurposeType  = "fine-tune-results"
+	PurposeFineTuneResults  PurposeType = "fine-tune-results"
 	PurposeAssistants       PurposeType = "assistants"
-  PurposeAssistantsOutput PurposeType = "assistants_output"
+	PurposeAssistantsOutput PurposeType = "assistants_output"
 )
 
 // FileBytesRequest represents a file upload request.

--- a/files.go
+++ b/files.go
@@ -15,6 +15,14 @@ type FileRequest struct {
 	Purpose  string `json:"purpose"`
 }
 
+// File purposes defined by the OpenAI API.
+const (
+	FilePurposeFineTune         = "fine-tune"
+	FilePurposeFineTuneResults  = "fine-tune-results"
+	FilePurposeAssistants       = "assistants"
+	FilePurposeAssistantsOutput = "assistants_output"
+)
+
 // File struct represents an OpenAPI file.
 type File struct {
 	Bytes         int    `json:"bytes"`


### PR DESCRIPTION
## Describe the change

- When uploading a `File`, you need to define a `.Purpose`
- Currently this is a `string` that is passed to the `FileRequest` type
- It would be nicer to have these as constants

<img width="529" alt="image" src="https://github.com/sashabaranov/go-openai/assets/2796074/135711b0-9dab-4131-94dc-e61c7164e401">

> See: https://platform.openai.com/docs/api-reference/files

## Describe your solution

Add a constant for each supported purpose as defined in the OpenAI API.

## Tests

No tests needed.

## Additional context

Not related to an issue, just something I saw when using the new Assistants API.

