### PR TITLE
fix: Missing Beta assistant Header in CreateMessage

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -71,7 +71,7 @@ type MessageFilesList struct {
 // CreateMessage creates a new message.
 func (c *Client) CreateMessage(ctx context.Context, threadID string, request MessageRequest) (msg Message, err error) {
 	urlSuffix := fmt.Sprintf("/threads/%s/%s", threadID, messagesSuffix)
-	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL(urlSuffix), withBody(request))
+	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL(urlSuffix), withBody(request), withBetaAssistantV1())
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
**Describe the change**
Using CreateMessage currently returns this error: `You must provide the 'OpenAI-Beta' header to access the Assistants API. Please try again by setting the header 'OpenAI-Beta: assistants=v1'.`
It seems this was overlooked in #546

**Describe your solution**
I added the missing `withBetaAssistantV1()` 

**Tests**
Manual tests

**Additional context**
N/A
