### PR TITLE
Add Assistant FileIDs and Metadata

### DIFF
--- a/assistant.go
+++ b/assistant.go
@@ -22,6 +22,8 @@ type Assistant struct {
 	Model        string          `json:"model"`
 	Instructions *string         `json:"instructions,omitempty"`
 	Tools        []AssistantTool `json:"tools,omitempty"`
+	FileIDs      []string        `json:"file_ids,omitempty"`
+	Metadata     map[string]any  `json:"metadata,omitempty"`
 
 	httpHeader
 }


### PR DESCRIPTION
## Describe the change

The [API docs](https://platform.openai.com/docs/api-reference/assistants/object) define the `Assistant` object as:

```json
{
  "id": "asst_abc123",
  "object": "assistant",
  "created_at": 1698984975,
  "name": "Math Tutor",
  "description": null,
  "model": "gpt-4",
  "instructions": "You are a personal math tutor. When asked a question, write and run Python code to answer the question.",
  "tools": [
    {
      "type": "code_interpreter"
    }
  ],
  "file_ids": [],
  "metadata": {}
}
```

However the `Assistant` type in this package does not have the following properties:

- `file_ids`
- `metadata`

## Describe your solution

Add them to the `Assistant` type.

## Additional context**

No issues related to this, I noticed it when wanting to validate the metadata of an existing Assistant. 