### PR TITLE
Add missing response fields for pagination

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -29,6 +29,11 @@ type Message struct {
 type MessagesList struct {
 	Messages []Message `json:"data"`
 
+	Object  string  `json:"object"`
+	FirstID *string `json:"first_id"`
+	LastID  *string `json:"last_id"`
+	HasMore bool    `json:"has_more"`
+
 	httpHeader
 }
 

--- a/messages_test.go
+++ b/messages_test.go
@@ -142,6 +142,7 @@ func TestMessages(t *testing.T) {
 				fmt.Fprintln(w, string(resBytes))
 			case http.MethodGet:
 				resBytes, _ := json.Marshal(openai.MessagesList{
+					Object: "list",
 					Messages: []openai.Message{{
 						ID:        messageID,
 						Object:    "thread.message",
@@ -159,7 +160,11 @@ func TestMessages(t *testing.T) {
 						AssistantID: &emptyStr,
 						RunID:       &emptyStr,
 						Metadata:    nil,
-					}}})
+					}},
+					FirstID: &messageID,
+					LastID:  &messageID,
+					HasMore: false,
+				})
 				fmt.Fprintln(w, string(resBytes))
 			default:
 				t.Fatalf("unsupported messages http method: %s", r.Method)


### PR DESCRIPTION
Describe the change
Missing pagination parameters for new assistants list API

Describe your solution
Add missing parameters

Tests
Verified against endpoint

Additional context

```
curl https://api.openai.com/v1/threads/thread_abc123/messages \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -H "OpenAI-Beta: assistants=v1"
{
  "object": "list",
  "data": [],
  "first_id": "msg_abc123",
  "last_id": "msg_abc456",
  "has_more": false
}
```

Issue: resolves #583 
Similar PR: https://github.com/sashabaranov/go-openai/pull/571