### PR TITLE
Update assistant.go

### DIFF
--- a/assistant.go
+++ b/assistant.go
@@ -115,6 +115,17 @@ func (c *Client) RetrieveAssistant(
 	return
 }
 
+//Convert Assistant to AssistantRequest
+func Assistant2AssistantRequest(assistant Assistant) AssistantRequest {
+	return AssistantRequest{
+		Model:        assistant.Model,
+		Name:         assistant.Name,
+		Description:  assistant.Description,
+		Instructions: assistant.Instructions,
+		Tools:        assistant.Tools,
+	}
+}
+
 // ModifyAssistant modifies an assistant.
 func (c *Client) ModifyAssistant(
 	ctx context.Context,


### PR DESCRIPTION
Wanting to manually update the assistant's properties is too troublesome. Therefore, you can directly request the assistant and then use this method to directly turn the assistant into an assistantrequest, and then modify the assistantrequest for updates.