### PR TITLE
To facilitate the update of the message, a method is provided to conv…

### DIFF
--- a/assistant.go
+++ b/assistant.go
@@ -114,7 +114,16 @@ func (c *Client) RetrieveAssistant(
 	err = c.sendRequest(req, &response)
 	return
 }
-
+//Assistant2AssistantRequest 
+func (c *Client) Assistant2AssistantRequest(assistant Assistant) AssistantRequest {
+	return AssistantRequest{
+		Model:        assistant.Model,
+		Name:         assistant.Name,
+		Description:  assistant.Description,
+		Instructions: assistant.Instructions,
+		Tools:        assistant.Tools,
+	}
+}
 // ModifyAssistant modifies an assistant.
 func (c *Client) ModifyAssistant(
 	ctx context.Context,


### PR DESCRIPTION
Wanting to manually update the assistant's properties is too troublesome. Therefore, you can directly request the assistant and then use this method to directly turn the assistant into an assistantrequest, and then modify the assistantrequest for updates.