### PR TITLE
files: CreateFile adds backwards-compatible io.Reader input, Purpose const

### DIFF
--- a/files_test.go
+++ b/files_test.go
@@ -24,33 +24,35 @@ func TestFileUploadWithFailingFormBuilder(t *testing.T) {
 	req := FileRequest{
 		FileName: "test.go",
 		FilePath: "client.go",
-		Purpose:  "fine-tune",
+		Purpose:  PurposeAssistants,
 	}
 
-	mockError := fmt.Errorf("mockWriteField error")
-	mockBuilder.mockWriteField = func(string, string) error {
-		return mockError
+	// mock WriteFiled with given error
+	fieldWith := func(err error) func(string, string) error {
+		return func(string, string) error {
+			return err
+		}
 	}
+	// mock CreateFormFileReader with given error
+	ffrWith := func(err error) func(string, io.Reader, string) error {
+		return func(string, io.Reader, string) error {
+			return err
+		}
+	}
+	mockError := fmt.Errorf("mockWriteField error")
+	mockBuilder.mockWriteField = fieldWith(mockError)
 	_, err := client.CreateFile(ctx, req)
 	checks.ErrorIs(t, err, mockError, "CreateFile should return error if form builder fails")
 
 	mockError = fmt.Errorf("mockCreateFormFile error")
-	mockBuilder.mockWriteField = func(string, string) error {
-		return nil
-	}
-	mockBuilder.mockCreateFormFile = func(string, *os.File) error {
-		return mockError
-	}
+	mockBuilder.mockWriteField = fieldWith(nil)
+	mockBuilder.mockCreateFormFileReader = ffrWith(mockError)
 	_, err = client.CreateFile(ctx, req)
 	checks.ErrorIs(t, err, mockError, "CreateFile should return error if form builder fails")
 
 	mockError = fmt.Errorf("mockClose error")
-	mockBuilder.mockWriteField = func(string, string) error {
-		return nil
-	}
-	mockBuilder.mockCreateFormFile = func(string, *os.File) error {
-		return nil
-	}
+	mockBuilder.mockWriteField = fieldWith(nil)
+	mockBuilder.mockCreateFormFileReader = ffrWith(nil)
 	mockBuilder.mockClose = func() error {
 		return mockError
 	}
@@ -66,6 +68,7 @@ func TestFileUploadWithNonExistentPath(t *testing.T) {
 	ctx := context.Background()
 	req := FileRequest{
 		FilePath: "some non existent file path/F616FD18-589E-44A8-BF0C-891EAE69C455",
+		Purpose:  PurposeAssistants,
 	}
 
 	_, err := client.CreateFile(ctx, req)


### PR DESCRIPTION
This PR supersedes #577 coincidentally.

**Describe the change**
I have re-implemented `FileRequest` and `CreateFile` so as to support arbitrary `io.Reader` inputs which must have priority over `FilePath` and also fixed some errors in the implementation. I've also took the liberty of adding a `Purpose` enum and testing for it, as fine-tuning requires a particular file format. Perhaps it's worthwhile getting rid of `CreateFormFile` semantics altogether at some later stage as it's, frankly, short-sighted and embarrassing. Thankfully, it hasn't touched the API boundary.

Also: I've made some other adjustments in streaming API that have not been included part of this PR. I'm eager to hear feedback on this [commit](https://github.com/sashabaranov/go-openai/commit/03b95e81a6e0ec7d243479dc67717f05f0271988) as it's implementing "teeing" of streaming response so as to make proxying so much easier. I reckon a great deal of go-openai use cases will revolve around proxying, in fact that's our primary use-case & if you're supposed to forward the response as well as parse it, then this type of change will be very favourable. My implementation takes advantage of `io.Pipe` and `io.TeeReader` and hence the server code is quite straightforward:

```go
// passthrough is re-directing the output of tee buffer
func passthrough(c *fiber.Ctx, r io.Reader) error {
	var ctx = c.Context()
	ctx.SetContentType("text/event-stream")
	ctx.Response.Header.Set("Cache-Control", "no-cache")
	ctx.Response.Header.Set("Connection", "keep-alive")
	ctx.Response.Header.Set("Transfer-Encoding", "chunked")
	ctx.Response.Header.Set("Access-Control-Allow-Origin", "*")
	ctx.Response.Header.Set("Access-Control-Allow-Headers", "Cache-Control")
	ctx.Response.Header.Set("Access-Control-Allow-Credentials", "true")
	ctx.SetBodyStreamWriter(fasthttp.StreamWriter(func(w *bufio.Writer) {
		io.Copy(w, r)
		w.Flush()
	}))
	return nil
}

//v1/completions
func completions(c *fiber.Ctx) error {
	var req openai.CompletionRequest
	api, err := parseRequest(c, &req)
	if err != nil {
		return err
	}
	if req.Stream {
		stream, err := api.CreateCompletionStream(ctx, req)
		if err != nil {
			return err
		}
		tee := stream.Tee()
		go func() {
			defer stream.Close()
			defer tee.Close()
			for chunk, err := stream.Recv(); err != io.EOF; {
				if err != nil {
					api.Errorln(err)
					return
				}
				// process streaming chunk normally...
			}
		}()
		return passthrough(c, tee)
	}
	resp, err := api.CreateCompletion(ctx, req)
	if err != nil {
		return err
	}
	return c.JSON(resp)
}
```