### PR TITLE
Updates the tool call struct

### DIFF
--- a/run.go
+++ b/run.go
@@ -142,15 +142,11 @@ const (
 type StepDetails struct {
 	Type            RunStepType                 `json:"type"`
 	MessageCreation *StepDetailsMessageCreation `json:"message_creation,omitempty"`
-	ToolCalls       *StepDetailsToolCalls       `json:"tool_calls,omitempty"`
+	ToolCalls       []ToolCall                  `json:"tool_calls,omitempty"`
 }
 
 type StepDetailsMessageCreation struct {
 	MessageID string `json:"message_id"`
-}
-
-type StepDetailsToolCalls struct {
-	ToolCalls []ToolCall `json:"tool_calls"`
 }
 
 // RunStepList is a list of steps.


### PR DESCRIPTION
A similar PR may already be submitted!
Please search among the [Pull request](https://github.com/sashabaranov/go-openai/pulls) before creating one.

If your changes introduce breaking changes, please prefix the title of your pull request with "[BREAKING_CHANGES]". This allows for clear identification of such changes in the 'What's Changed' section on the release page, making it developer-friendly.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.

**Describe the change**

Querying run steps will create marshalling error like: 
`json: cannot unmarshal array into Go struct field StepDetails.data.step_details.tool_calls of type openai.StepDetailsToolCalls`

<img width="733" alt="Screenshot 2023-11-17 at 8 25 16 PM" src="https://github.com/sashabaranov/go-openai/assets/14824254/768f4966-2059-4736-9d5b-631ecf16454a">

The [official docs](https://platform.openai.com/docs/api-reference/runs/step-object#runs/step-object-step_details) of the run steps points to using arrays instead of wrapping `tool_calls` in an object. 

Here's the actual response of fetching run step:

<img width="733" alt="Screenshot 2023-11-17 at 8 25 16 PM" src="https://github.com/sashabaranov/go-openai/assets/14824254/a30a86ac-98d5-4099-99b7-29c841f65f00">


**Describe your solution**
This PR addresses this by removing the extra wrapping object around `tool_calls` property.

**Tests**
N/A

**Additional context**

Issue: No issues created yet, should I create one? 🤔 
