### PR TITLE
Add assistant role to ThreadMessageRole type

### DIFF
--- a/thread.go
+++ b/thread.go
@@ -30,7 +30,8 @@ type ModifyThreadRequest struct {
 type ThreadMessageRole string
 
 const (
-	ThreadMessageRoleUser ThreadMessageRole = "user"
+	ThreadMessageRoleUser      ThreadMessageRole = "user"
+	ThreadMessageRoleAssistant ThreadMessageRole = "assistant"
 )
 
 type ThreadMessage struct {

--- a/thread_test.go
+++ b/thread_test.go
@@ -76,6 +76,10 @@ func TestThread(t *testing.T) {
 				Role:    openai.ThreadMessageRoleUser,
 				Content: "Hello, World!",
 			},
+			{
+				Role:    openai.ThreadMessageRoleAssistant,
+				Content: "Hey there.",
+			},
 		},
 	})
 	checks.NoError(t, err, "CreateThread error")


### PR DESCRIPTION
**Describe the change**
Add  `assistant` option for ThreadMessageRole type as per https://platform.openai.com/docs/api-reference/messages/object

**Describe your solution**
Added new value.

**Tests**
Used the new type in unit test to validate that we can post the value.

