### PR TITLE
Add canary-tts to speech models

### DIFF
--- a/speech.go
+++ b/speech.go
@@ -10,8 +10,9 @@ import (
 type SpeechModel string
 
 const (
-	TTSModel1   SpeechModel = "tts-1"
-	TTsModel1HD SpeechModel = "tts-1-hd"
+	TTSModel1      SpeechModel = "tts-1"
+	TTSModel1HD    SpeechModel = "tts-1-hd"
+	TTSModelCanary SpeechModel = "canary-tts"
 )
 
 type SpeechVoice string
@@ -57,7 +58,7 @@ func contains[T comparable](s []T, e T) bool {
 }
 
 func isValidSpeechModel(model SpeechModel) bool {
-	return contains([]SpeechModel{TTSModel1, TTsModel1HD}, model)
+	return contains([]SpeechModel{TTSModel1, TTSModel1HD, TTSModelCanary}, model)
 }
 
 func isValidVoice(voice SpeechVoice) bool {


### PR DESCRIPTION
There is an additional text-to-speech model called "canary-tts", which is not advertised on OpenAI's API documentation page, nevertheless it appears among the allowed models, and it seems to work with exactly the same voices as the main tts-1 models in exactly the same way.

The only important difference is that it is currently not rate limited as aggressively as the tts-1 models, which may be useful for those on the free tier.

It's entirely possible that the mere existence of this model is a mistake on OpenAI's part, but as long as it is available, we might as well use it.

The commit also fixes a typo in one of the existing constants. This is technically a breaking change, but it seemed like the proper thing to fix it.

