### PR TITLE
omit empty values with Image API clients

### DIFF
--- a/image.go
+++ b/image.go
@@ -161,19 +161,25 @@ func (c *Client) CreateVariImage(ctx context.Context, request ImageVariRequest) 
 		return
 	}
 
-	err = builder.WriteField("n", strconv.Itoa(request.N))
-	if err != nil {
-		return
+	if request.N != 0 {
+		err = builder.WriteField("n", strconv.Itoa(request.N))
+		if err != nil {
+			return
+		}
 	}
 
-	err = builder.WriteField("size", request.Size)
-	if err != nil {
-		return
+	if request.Size != "" {
+		err = builder.WriteField("size", request.Size)
+		if err != nil {
+			return
+		}
 	}
 
-	err = builder.WriteField("response_format", request.ResponseFormat)
-	if err != nil {
-		return
+	if request.Size != "" {
+		err = builder.WriteField("response_format", request.ResponseFormat)
+		if err != nil {
+			return
+		}
 	}
 
 	err = builder.Close()


### PR DESCRIPTION
**Issue**

HI, I came across this project and I tried to use Image APIs. Then, I found that some optional parameters must be specify to call APIs, or it returns 400 error. 

For example, according to the API specification of [Create image variation](https://platform.openai.com/docs/api-reference/images/createVariation) API, the parameters `n`, `response_format`, and `size` are optional, and if those parameters aren't specified, the API applies default values.
However, in `go-openai` client, if those parameter aren't specified explicitly, it sends zero values and gets 400 response.

if I make a request like this:

```
	resp, err := client.CreateVariImage(
		context.Background(), openai.ImageVariRequest{
			Image: file,
		})
```

then, I got a response like this:

```
error, status code: 400, message: 0 is less than the minimum of 1 - 'n'
```

because client actually send a request like this:

```bash
curl https://api.openai.com/v1/images/variations \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -F image="foo.png" \
  -F n=0 \  # <- zero value for int
  -F size="" # <- zero value for string
```

Although [the request structs](https://github.com/sashabaranov/go-openai/blob/master/image.go#L145-L150) have fields with json struct tag and seemingly intend to `omitempty`, actually this `omitempty` doesn't work because those API accept `multipart/form-data` so request aren't marshaled to json.

**Describe the change**

Then, I made image API client work even if optional parameters aren't set in request structs.

**Provide OpenAI documentation link**

- [Create image variation](https://platform.openai.com/docs/api-reference/images/createVariation)

**Describe your solution**

I just wrote `if` to check zero values. This change will work same as `omitempty`. As discussed #9 , it cannot express the difference between zero value and intended zero or empty string though. Another alternative might be using a null structs like `NullInt` or `NullString` but it would make breaking changes though.

If my changes would be acceptable, I'd make changes in other image API clients that request with `multipart/form-data` format and write tests. If it was already argued or you don't need this changes, please close it. Thanks😃 