### PR TITLE
Fix support for non json speech to text

### DIFF
--- a/audio.go
+++ b/audio.go
@@ -68,9 +68,13 @@ type AudioResponse struct {
 }
 
 type audioTextResponse struct {
-	Text string `json:"text"`
+	Text string
 
 	httpHeader
+}
+
+func (r *audioTextResponse) SetText(text string) {
+	r.Text = text
 }
 
 func (r *audioTextResponse) ToAudioResponse() AudioResponse {

--- a/client.go
+++ b/client.go
@@ -24,6 +24,10 @@ type Response interface {
 	SetHeader(http.Header)
 }
 
+type TextResponse interface {
+	SetText(string)
+}
+
 type httpHeader http.Header
 
 func (h *httpHeader) SetHeader(header http.Header) {
@@ -195,6 +199,13 @@ func decodeResponse(body io.Reader, v any) error {
 
 	if result, ok := v.(*string); ok {
 		return decodeString(body, result)
+	} else if result, ok := v.(TextResponse); ok {
+		var text string
+		if err := decodeString(body, &text); err != nil {
+			return err
+		}
+		result.SetText(text)
+		return nil
 	}
 	return json.NewDecoder(body).Decode(v)
 }


### PR DESCRIPTION
Fixes issue when using non audio formats:

Transcription error: json: cannot unmarshal number into Go value of type openai.audioTextResponse

Fixes: 8e165dc9aadc ("Feat Add headers to openai responses (#506)")


