### PR TITLE
fix Azure endpoint URL for image creation

### DIFF
--- a/image.go
+++ b/image.go
@@ -68,7 +68,7 @@ type ImageResponseDataInner struct {
 // CreateImage - API call to create an image. This is the main endpoint of the DALL-E API.
 func (c *Client) CreateImage(ctx context.Context, request ImageRequest) (response ImageResponse, err error) {
 	urlSuffix := "/images/generations"
-	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL(urlSuffix), withBody(request))
+	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL(urlSuffix, request.Model), withBody(request))
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
**Describe the change**
Model or deployment name must be included in the generated Azure endpoint URL when using image creation (f.i. with Dall-E).

**Provide OpenAI documentation link**
None

**Describe your solution**
Properly passing deployment/model name when creating the Azure endpoint URL.

**Tests**
URL is now properly generated (just passing the expected/forgotten? parameter).

Issue: #627 
