### PR TITLE
Fix Azure embeddings model detection by passing string to `fullURL`

### DIFF
--- a/embeddings.go
+++ b/embeddings.go
@@ -228,7 +228,7 @@ func (c *Client) CreateEmbeddings(
 	conv EmbeddingRequestConverter,
 ) (res EmbeddingResponse, err error) {
 	baseReq := conv.Convert()
-	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL("/embeddings", baseReq.Model), withBody(baseReq))
+	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL("/embeddings", string(baseReq.Model)), withBody(baseReq))
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
A [recent pull request](https://github.com/sashabaranov/go-openai/pull/629) broke support for the Azure OpenAI embeddings endpoint by [passing a variable of type `EmbeddingModel` to `client.fullURL`](https://github.com/sashabaranov/go-openai/pull/629/files#diff-0fdd78c64708f1e3c576725363d6d7accb8b43590810436765198e7a5522770fR231). This breaks the [Azure deployment name lookup](https://github.com/sashabaranov/go-openai/blob/09f6920ad04666f65dd86ed542e5ebf8bffc93a8/client.go#L223-L229).

This pull request fixes Azure embeddings support by casting the type to `string`.

**Tests**
Added tests for generating Azure embeddings 

Note: I'm not a great Go programmer. If there's a better way to do this I'm all ears!