### PR TITLE
Add new struct filed dimensions for embedding API

### DIFF
--- a/embeddings.go
+++ b/embeddings.go
@@ -159,7 +159,7 @@ type EmbeddingRequest struct {
 	EncodingFormat EmbeddingEncodingFormat `json:"encoding_format,omitempty"`
 	// Dimensions The number of dimensions the resulting output embeddings should have.
 	// Only supported in text-embedding-3 and later models.
-	Dimensions *int `json:"dimensions,omitempty"`
+	Dimensions int `json:"dimensions,omitempty"`
 }
 
 func (r EmbeddingRequest) Convert() EmbeddingRequest {
@@ -186,7 +186,7 @@ type EmbeddingRequestStrings struct {
 	EncodingFormat EmbeddingEncodingFormat `json:"encoding_format,omitempty"`
 	// Dimensions The number of dimensions the resulting output embeddings should have.
 	// Only supported in text-embedding-3 and later models.
-	Dimensions *int `json:"dimensions,omitempty"`
+	Dimensions int `json:"dimensions,omitempty"`
 }
 
 func (r EmbeddingRequestStrings) Convert() EmbeddingRequest {
@@ -218,7 +218,7 @@ type EmbeddingRequestTokens struct {
 	EncodingFormat EmbeddingEncodingFormat `json:"encoding_format,omitempty"`
 	// Dimensions The number of dimensions the resulting output embeddings should have.
 	// Only supported in text-embedding-3 and later models.
-	Dimensions *int `json:"dimensions,omitempty"`
+	Dimensions int `json:"dimensions,omitempty"`
 }
 
 func (r EmbeddingRequestTokens) Convert() EmbeddingRequest {

--- a/embeddings.go
+++ b/embeddings.go
@@ -157,6 +157,8 @@ type EmbeddingRequest struct {
 	Model          EmbeddingModel          `json:"model"`
 	User           string                  `json:"user"`
 	EncodingFormat EmbeddingEncodingFormat `json:"encoding_format,omitempty"`
+	// Dimensions The number of dimensions the resulting output embeddings should have. Only supported in text-embedding-3 and later models.
+	Dimensions *int `json:"dimensions,omitempty"`
 }
 
 func (r EmbeddingRequest) Convert() EmbeddingRequest {
@@ -181,6 +183,8 @@ type EmbeddingRequestStrings struct {
 	// Currently, only "float" and "base64" are supported, however, "base64" is not officially documented.
 	// If not specified OpenAI will use "float".
 	EncodingFormat EmbeddingEncodingFormat `json:"encoding_format,omitempty"`
+	// Dimensions The number of dimensions the resulting output embeddings should have. Only supported in text-embedding-3 and later models.
+	Dimensions *int `json:"dimensions,omitempty"`
 }
 
 func (r EmbeddingRequestStrings) Convert() EmbeddingRequest {
@@ -189,6 +193,7 @@ func (r EmbeddingRequestStrings) Convert() EmbeddingRequest {
 		Model:          r.Model,
 		User:           r.User,
 		EncodingFormat: r.EncodingFormat,
+		Dimensions:     r.Dimensions,
 	}
 }
 
@@ -209,6 +214,8 @@ type EmbeddingRequestTokens struct {
 	// Currently, only "float" and "base64" are supported, however, "base64" is not officially documented.
 	// If not specified OpenAI will use "float".
 	EncodingFormat EmbeddingEncodingFormat `json:"encoding_format,omitempty"`
+	// Dimensions The number of dimensions the resulting output embeddings should have. Only supported in text-embedding-3 and later models.
+	Dimensions *int `json:"dimensions,omitempty"`
 }
 
 func (r EmbeddingRequestTokens) Convert() EmbeddingRequest {
@@ -217,6 +224,7 @@ func (r EmbeddingRequestTokens) Convert() EmbeddingRequest {
 		Model:          r.Model,
 		User:           r.User,
 		EncodingFormat: r.EncodingFormat,
+		Dimensions:     r.Dimensions,
 	}
 }
 

--- a/embeddings.go
+++ b/embeddings.go
@@ -157,7 +157,8 @@ type EmbeddingRequest struct {
 	Model          EmbeddingModel          `json:"model"`
 	User           string                  `json:"user"`
 	EncodingFormat EmbeddingEncodingFormat `json:"encoding_format,omitempty"`
-	// Dimensions The number of dimensions the resulting output embeddings should have. Only supported in text-embedding-3 and later models.
+	// Dimensions The number of dimensions the resulting output embeddings should have.
+	// Only supported in text-embedding-3 and later models.
 	Dimensions *int `json:"dimensions,omitempty"`
 }
 
@@ -183,7 +184,8 @@ type EmbeddingRequestStrings struct {
 	// Currently, only "float" and "base64" are supported, however, "base64" is not officially documented.
 	// If not specified OpenAI will use "float".
 	EncodingFormat EmbeddingEncodingFormat `json:"encoding_format,omitempty"`
-	// Dimensions The number of dimensions the resulting output embeddings should have. Only supported in text-embedding-3 and later models.
+	// Dimensions The number of dimensions the resulting output embeddings should have.
+	// Only supported in text-embedding-3 and later models.
 	Dimensions *int `json:"dimensions,omitempty"`
 }
 
@@ -214,7 +216,8 @@ type EmbeddingRequestTokens struct {
 	// Currently, only "float" and "base64" are supported, however, "base64" is not officially documented.
 	// If not specified OpenAI will use "float".
 	EncodingFormat EmbeddingEncodingFormat `json:"encoding_format,omitempty"`
-	// Dimensions The number of dimensions the resulting output embeddings should have. Only supported in text-embedding-3 and later models.
+	// Dimensions The number of dimensions the resulting output embeddings should have.
+	// Only supported in text-embedding-3 and later models.
 	Dimensions *int `json:"dimensions,omitempty"`
 }
 


### PR DESCRIPTION


**Describe the change**
Add new struct field `dimensions`  that support for shortening embeddings. Release in January 25, 2024

**Provide OpenAI documentation link**
* [New embedding models and API updates](https://openai.com/blog/new-embedding-models-and-api-updates)
* [Embedding API Reference](https://platform.openai.com/docs/api-reference/embeddings)

**Describe your solution**
Add new struct filed

**Tests**
manual


