### PR TITLE
Add RunRequest field AdditionalInstructions

### DIFF
--- a/run.go
+++ b/run.go
@@ -72,11 +72,12 @@ const (
 )
 
 type RunRequest struct {
-	AssistantID  string         `json:"assistant_id"`
-	Model        *string        `json:"model,omitempty"`
-	Instructions *string        `json:"instructions,omitempty"`
-	Tools        []Tool         `json:"tools,omitempty"`
-	Metadata     map[string]any `json:"metadata,omitempty"`
+	AssistantID            string         `json:"assistant_id"`
+	Model                  string         `json:"model,omitempty"`
+	Instructions           string         `json:"instructions,omitempty"`
+	AdditionalInstructions string         `json:"additional_instructions,omitempty"`
+	Tools                  []Tool         `json:"tools,omitempty"`
+	Metadata               map[string]any `json:"metadata,omitempty"`
 }
 
 type RunModifyRequest struct {


### PR DESCRIPTION
**Describe the change**
AdditionalInstructions is an optional string field used to append additional instructions at the end of the instructions for the run. This is useful for modifying the behavior on a per-run basis without overriding other instructions.

**Provide OpenAI documentation link**
https://platform.openai.com/docs/api-reference/runs/createRun#runs-createrun-additional_instructions
