### PR TITLE
Update client.go - allow to skip Authorization header

### DIFF
--- a/client.go
+++ b/client.go
@@ -177,7 +177,9 @@ func (c *Client) setCommonHeaders(req *http.Request) {
 		req.Header.Set(AzureAPIKeyHeader, c.config.authToken)
 	} else {
 		// OpenAI or Azure AD authentication
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.authToken))
+		if c.config.authToken != "" {
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.authToken))
+		}
 	}
 	if c.config.OrgID != "" {
 		req.Header.Set("OpenAI-Organization", c.config.OrgID)

--- a/client.go
+++ b/client.go
@@ -175,11 +175,9 @@ func (c *Client) setCommonHeaders(req *http.Request) {
 	// Azure API Key authentication
 	if c.config.APIType == APITypeAzure {
 		req.Header.Set(AzureAPIKeyHeader, c.config.authToken)
-	} else {
+	} else if c.config.authToken != "" {
 		// OpenAI or Azure AD authentication
-		if c.config.authToken != "" {
-			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.authToken))
-		}
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.authToken))
 	}
 	if c.config.OrgID != "" {
 		req.Header.Set("OpenAI-Organization", c.config.OrgID)


### PR DESCRIPTION
Currently I am hosting my LiteLLM proxy with no Authorization and trying to connect with go-openai like this:

```
	config := openai.DefaultConfig("")
	config.BaseURL = "https://my-service/v1"
	aiClient := openai.NewClientWithConfig(config)
```

It shows an error because I am passing empty token but it still appends Bearer header

```
2024/02/12 12:51:54 Failed to create chat stream: error, status code: 401, message: Authentication Error,
^Csignal: interrupt
```

While not passing any authorization header works for my proxy server