### PR TITLE
Content-type fix

### DIFF
--- a/client.go
+++ b/client.go
@@ -107,13 +107,13 @@ func (c *Client) newRequest(ctx context.Context, method, url string, setters ...
 }
 
 func (c *Client) sendRequest(req *http.Request, v Response) error {
-	req.Header.Set("Accept", "application/json; charset=utf-8")
+	req.Header.Set("Accept", "application/json")
 
 	// Check whether Content-Type is already set, Upload Files API requires
 	// Content-Type == multipart/form-data
 	contentType := req.Header.Get("Content-Type")
 	if contentType == "" {
-		req.Header.Set("Content-Type", "application/json; charset=utf-8")
+		req.Header.Set("Content-Type", "application/json")
 	}
 
 	res, err := c.config.HTTPClient.Do(req)

--- a/embeddings_test.go
+++ b/embeddings_test.go
@@ -169,7 +169,7 @@ func TestAzureEmbeddingEndpoint(t *testing.T) {
 
 	server.RegisterHandler(
 		"/openai/deployments/text-embedding-ada-002/embeddings",
-		func(w http.ResponseWriter, r *http.Request) {
+		func(w http.ResponseWriter, _ *http.Request) {
 			resBytes, _ := json.Marshal(openai.EmbeddingResponse{Data: sampleEmbeddings})
 			fmt.Fprintln(w, string(resBytes))
 		},

--- a/files_api_test.go
+++ b/files_api_test.go
@@ -86,7 +86,7 @@ func handleCreateFile(w http.ResponseWriter, r *http.Request) {
 func TestDeleteFile(t *testing.T) {
 	client, server, teardown := setupOpenAITestServer()
 	defer teardown()
-	server.RegisterHandler("/v1/files/deadbeef", func(w http.ResponseWriter, r *http.Request) {})
+	server.RegisterHandler("/v1/files/deadbeef", func(http.ResponseWriter, *http.Request) {})
 	err := client.DeleteFile(context.Background(), "deadbeef")
 	checks.NoError(t, err, "DeleteFile error")
 }
@@ -94,7 +94,7 @@ func TestDeleteFile(t *testing.T) {
 func TestListFile(t *testing.T) {
 	client, server, teardown := setupOpenAITestServer()
 	defer teardown()
-	server.RegisterHandler("/v1/files", func(w http.ResponseWriter, r *http.Request) {
+	server.RegisterHandler("/v1/files", func(w http.ResponseWriter, _ *http.Request) {
 		resBytes, _ := json.Marshal(openai.FilesList{})
 		fmt.Fprintln(w, string(resBytes))
 	})
@@ -105,7 +105,7 @@ func TestListFile(t *testing.T) {
 func TestGetFile(t *testing.T) {
 	client, server, teardown := setupOpenAITestServer()
 	defer teardown()
-	server.RegisterHandler("/v1/files/deadbeef", func(w http.ResponseWriter, r *http.Request) {
+	server.RegisterHandler("/v1/files/deadbeef", func(w http.ResponseWriter, _ *http.Request) {
 		resBytes, _ := json.Marshal(openai.File{})
 		fmt.Fprintln(w, string(resBytes))
 	})
@@ -151,7 +151,7 @@ func TestGetFileContentReturnError(t *testing.T) {
 }`
 	client, server, teardown := setupOpenAITestServer()
 	defer teardown()
-	server.RegisterHandler("/v1/files/deadbeef/content", func(w http.ResponseWriter, r *http.Request) {
+	server.RegisterHandler("/v1/files/deadbeef/content", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(w, wantErrorResp)
 	})
@@ -178,7 +178,7 @@ func TestGetFileContentReturnError(t *testing.T) {
 func TestGetFileContentReturnTimeoutError(t *testing.T) {
 	client, server, teardown := setupOpenAITestServer()
 	defer teardown()
-	server.RegisterHandler("/v1/files/deadbeef/content", func(w http.ResponseWriter, r *http.Request) {
+	server.RegisterHandler("/v1/files/deadbeef/content", func(http.ResponseWriter, *http.Request) {
 		time.Sleep(10 * time.Nanosecond)
 	})
 	ctx := context.Background()

--- a/image_test.go
+++ b/image_test.go
@@ -60,7 +60,7 @@ func TestImageFormBuilderFailures(t *testing.T) {
 	_, err := client.CreateEditImage(ctx, req)
 	checks.ErrorIs(t, err, mockFailedErr, "CreateImage should return error if form builder fails")
 
-	mockBuilder.mockCreateFormFile = func(name string, file *os.File) error {
+	mockBuilder.mockCreateFormFile = func(name string, _ *os.File) error {
 		if name == "mask" {
 			return mockFailedErr
 		}
@@ -69,12 +69,12 @@ func TestImageFormBuilderFailures(t *testing.T) {
 	_, err = client.CreateEditImage(ctx, req)
 	checks.ErrorIs(t, err, mockFailedErr, "CreateImage should return error if form builder fails")
 
-	mockBuilder.mockCreateFormFile = func(name string, file *os.File) error {
+	mockBuilder.mockCreateFormFile = func(string, *os.File) error {
 		return nil
 	}
 
 	var failForField string
-	mockBuilder.mockWriteField = func(fieldname, value string) error {
+	mockBuilder.mockWriteField = func(fieldname, _ string) error {
 		if fieldname == failForField {
 			return mockFailedErr
 		}
@@ -125,12 +125,12 @@ func TestVariImageFormBuilderFailures(t *testing.T) {
 	_, err := client.CreateVariImage(ctx, req)
 	checks.ErrorIs(t, err, mockFailedErr, "CreateVariImage should return error if form builder fails")
 
-	mockBuilder.mockCreateFormFile = func(name string, file *os.File) error {
+	mockBuilder.mockCreateFormFile = func(string, *os.File) error {
 		return nil
 	}
 
 	var failForField string
-	mockBuilder.mockWriteField = func(fieldname, value string) error {
+	mockBuilder.mockWriteField = func(fieldname, _ string) error {
 		if fieldname == failForField {
 			return mockFailedErr
 		}

--- a/messages.go
+++ b/messages.go
@@ -18,7 +18,7 @@ type Message struct {
 	ThreadID    string           `json:"thread_id"`
 	Role        string           `json:"role"`
 	Content     []MessageContent `json:"content"`
-	FileIds     []string         `json:"file_ids"`
+	FileIds     []string         `json:"file_ids"` //nolint:revive //backwards-compatibility
 	AssistantID *string          `json:"assistant_id,omitempty"`
 	RunID       *string          `json:"run_id,omitempty"`
 	Metadata    map[string]any   `json:"metadata"`
@@ -54,7 +54,7 @@ type ImageFile struct {
 type MessageRequest struct {
 	Role     string         `json:"role"`
 	Content  string         `json:"content"`
-	FileIds  []string       `json:"file_ids,omitempty"`
+	FileIds  []string       `json:"file_ids,omitempty"` //nolint:revive // backwards-compatibility
 	Metadata map[string]any `json:"metadata,omitempty"`
 }
 

--- a/models_test.go
+++ b/models_test.go
@@ -64,7 +64,7 @@ func handleGetModelEndpoint(w http.ResponseWriter, _ *http.Request) {
 func TestGetModelReturnTimeoutError(t *testing.T) {
 	client, server, teardown := setupOpenAITestServer()
 	defer teardown()
-	server.RegisterHandler("/v1/models/text-davinci-003", func(w http.ResponseWriter, r *http.Request) {
+	server.RegisterHandler("/v1/models/text-davinci-003", func(http.ResponseWriter, *http.Request) {
 		time.Sleep(10 * time.Nanosecond)
 	})
 	ctx := context.Background()

--- a/run.go
+++ b/run.go
@@ -24,7 +24,7 @@ type Run struct {
 	Model          string             `json:"model"`
 	Instructions   string             `json:"instructions,omitempty"`
 	Tools          []Tool             `json:"tools"`
-	FileIDS        []string           `json:"file_ids"`
+	FileIDS        []string           `json:"file_ids"` //nolint:revive // backwards-compatibility
 	Metadata       map[string]any     `json:"metadata"`
 	Usage          Usage              `json:"usage,omitempty"`
 

--- a/speech.go
+++ b/speech.go
@@ -76,7 +76,7 @@ func (c *Client) CreateSpeech(ctx context.Context, request CreateSpeechRequest) 
 	}
 	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL("/audio/speech", string(request.Model)),
 		withBody(request),
-		withContentType("application/json; charset=utf-8"),
+		withContentType("application/json"),
 	)
 	if err != nil {
 		return

--- a/stream_test.go
+++ b/stream_test.go
@@ -34,7 +34,7 @@ func TestCompletionsStreamWrongModel(t *testing.T) {
 func TestCreateCompletionStream(t *testing.T) {
 	client, server, teardown := setupOpenAITestServer()
 	defer teardown()
-	server.RegisterHandler("/v1/completions", func(w http.ResponseWriter, r *http.Request) {
+	server.RegisterHandler("/v1/completions", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 
 		// Send test responses
@@ -106,7 +106,7 @@ func TestCreateCompletionStream(t *testing.T) {
 func TestCreateCompletionStreamError(t *testing.T) {
 	client, server, teardown := setupOpenAITestServer()
 	defer teardown()
-	server.RegisterHandler("/v1/completions", func(w http.ResponseWriter, r *http.Request) {
+	server.RegisterHandler("/v1/completions", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 
 		// Send test responses
@@ -151,7 +151,7 @@ func TestCreateCompletionStreamError(t *testing.T) {
 func TestCreateCompletionStreamRateLimitError(t *testing.T) {
 	client, server, teardown := setupOpenAITestServer()
 	defer teardown()
-	server.RegisterHandler("/v1/completions", func(w http.ResponseWriter, r *http.Request) {
+	server.RegisterHandler("/v1/completions", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(429)
 
@@ -182,7 +182,7 @@ func TestCreateCompletionStreamRateLimitError(t *testing.T) {
 func TestCreateCompletionStreamTooManyEmptyStreamMessagesError(t *testing.T) {
 	client, server, teardown := setupOpenAITestServer()
 	defer teardown()
-	server.RegisterHandler("/v1/completions", func(w http.ResponseWriter, r *http.Request) {
+	server.RegisterHandler("/v1/completions", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 
 		// Send test responses
@@ -228,7 +228,7 @@ func TestCreateCompletionStreamTooManyEmptyStreamMessagesError(t *testing.T) {
 func TestCreateCompletionStreamUnexpectedTerminatedError(t *testing.T) {
 	client, server, teardown := setupOpenAITestServer()
 	defer teardown()
-	server.RegisterHandler("/v1/completions", func(w http.ResponseWriter, r *http.Request) {
+	server.RegisterHandler("/v1/completions", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 
 		// Send test responses
@@ -263,7 +263,7 @@ func TestCreateCompletionStreamUnexpectedTerminatedError(t *testing.T) {
 func TestCreateCompletionStreamBrokenJSONError(t *testing.T) {
 	client, server, teardown := setupOpenAITestServer()
 	defer teardown()
-	server.RegisterHandler("/v1/completions", func(w http.ResponseWriter, r *http.Request) {
+	server.RegisterHandler("/v1/completions", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 
 		// Send test responses
@@ -305,7 +305,7 @@ func TestCreateCompletionStreamBrokenJSONError(t *testing.T) {
 func TestCreateCompletionStreamReturnTimeoutError(t *testing.T) {
 	client, server, teardown := setupOpenAITestServer()
 	defer teardown()
-	server.RegisterHandler("/v1/completions", func(w http.ResponseWriter, r *http.Request) {
+	server.RegisterHandler("/v1/completions", func(http.ResponseWriter, *http.Request) {
 		time.Sleep(10 * time.Nanosecond)
 	})
 	ctx := context.Background()


### PR DESCRIPTION
Sometimes I get answer for all request:
`{
  "error": {
    "message": "Unsupported content type: 'application/json; charset=utf-8'. This API method only accepts 'application/json' requests, but you specified the header 'Content-Type: application/json; charset=utf-8'. Please try again with a supported content type.",
    "type": "invalid_request_error",
    "param": null,
    "code": "unsupported_content_type"
  }
}`

It depends of account.
There is no such header "charset:utf-8" in the official library on python