### PR TITLE
[BREAKING_CHANGES] converted ResultCategoryScores struct to map

### DIFF
--- a/moderation.go
+++ b/moderation.go
@@ -20,6 +20,20 @@ const (
 	ModerationText001 = "text-moderation-001"
 )
 
+const (
+	ModerationCategoryHate                  = "hate"
+	ModerationCategoryHateThreatening       = "hate/threatening"
+	ModerationCategoryHarassment            = "harassment"
+	ModerationCategoryHarassmentThreatening = "harassment/threatening"
+	ModerationCategorySelfHarm              = "self-harm"
+	ModerationCategorySelfHarmIntent        = "self-harm/intent"
+	ModerationCategorySelfHarmInstructions  = "self-harm/instructions"
+	ModerationCategorySexual                = "sexual"
+	ModerationCategorySexualMinors          = "sexual/minors"
+	ModerationCategoryViolence              = "violence"
+	ModerationCategoryViolenceGraphic       = "violence/graphic"
+)
+
 var (
 	ErrModerationInvalidModel = errors.New("this model is not supported with moderation, please use text-moderation-stable or text-moderation-latest instead") //nolint:lll
 )
@@ -44,25 +58,21 @@ type Result struct {
 
 // ResultCategories represents Categories of Result.
 type ResultCategories struct {
-	Hate            bool `json:"hate"`
-	HateThreatening bool `json:"hate/threatening"`
-	SelfHarm        bool `json:"self-harm"`
-	Sexual          bool `json:"sexual"`
-	SexualMinors    bool `json:"sexual/minors"`
-	Violence        bool `json:"violence"`
-	ViolenceGraphic bool `json:"violence/graphic"`
+	Hate                  bool `json:"hate"`
+	HateThreatening       bool `json:"hate/threatening"`
+	Harassment            bool `json:"harassment"`
+	HarassmentThreatening bool `json:"harassment/threatening"`
+	SelfHarm              bool `json:"self-harm"`
+	SelfHarmIntent        bool `json:"self-harm/intent"`
+	SelfHarmInstructions  bool `json:"self-harm/instructions"`
+	Sexual                bool `json:"sexual"`
+	SexualMinors          bool `json:"sexual/minors"`
+	Violence              bool `json:"violence"`
+	ViolenceGraphic       bool `json:"violence/graphic"`
 }
 
 // ResultCategoryScores represents CategoryScores of Result.
-type ResultCategoryScores struct {
-	Hate            float32 `json:"hate"`
-	HateThreatening float32 `json:"hate/threatening"`
-	SelfHarm        float32 `json:"self-harm"`
-	Sexual          float32 `json:"sexual"`
-	SexualMinors    float32 `json:"sexual/minors"`
-	Violence        float32 `json:"violence"`
-	ViolenceGraphic float32 `json:"violence/graphic"`
-}
+type ResultCategoryScores map[string]float32
 
 // ModerationResponse represents a response structure for moderation API.
 type ModerationResponse struct {

--- a/moderation_test.go
+++ b/moderation_test.go
@@ -80,18 +80,49 @@ func handleModerationEndpoint(w http.ResponseWriter, r *http.Request) {
 	resCat := openai.ResultCategories{}
 	resCatScore := openai.ResultCategoryScores{}
 	switch {
-	case strings.Contains(moderationReq.Input, "kill"):
-		resCat = openai.ResultCategories{Violence: true}
-		resCatScore = openai.ResultCategoryScores{Violence: 1}
 	case strings.Contains(moderationReq.Input, "hate"):
 		resCat = openai.ResultCategories{Hate: true}
-		resCatScore = openai.ResultCategoryScores{Hate: 1}
+		resCatScore = openai.ResultCategoryScores{openai.ModerationCategoryHate: 1}
+
+	case strings.Contains(moderationReq.Input, "hate more"):
+		resCat = openai.ResultCategories{HateThreatening: true}
+		resCatScore = openai.ResultCategoryScores{openai.ModerationCategoryHate: 1}
+
+	case strings.Contains(moderationReq.Input, "harass"):
+		resCat = openai.ResultCategories{Harassment: true}
+		resCatScore = openai.ResultCategoryScores{openai.ModerationCategoryHarassment: 1}
+
+	case strings.Contains(moderationReq.Input, "harass hard"):
+		resCat = openai.ResultCategories{Harassment: true}
+		resCatScore = openai.ResultCategoryScores{openai.ModerationCategoryHarassmentThreatening: 1}
+
 	case strings.Contains(moderationReq.Input, "suicide"):
 		resCat = openai.ResultCategories{SelfHarm: true}
-		resCatScore = openai.ResultCategoryScores{SelfHarm: 1}
+		resCatScore = openai.ResultCategoryScores{openai.ModerationCategorySelfHarm: 1}
+
+	case strings.Contains(moderationReq.Input, "wanna suicide"):
+		resCat = openai.ResultCategories{SelfHarmIntent: true}
+		resCatScore = openai.ResultCategoryScores{openai.ModerationCategorySelfHarm: 1}
+
+	case strings.Contains(moderationReq.Input, "drink bleach"):
+		resCat = openai.ResultCategories{SelfHarmInstructions: true}
+		resCatScore = openai.ResultCategoryScores{openai.ModerationCategorySelfHarmInstructions: 1}
+
 	case strings.Contains(moderationReq.Input, "porn"):
 		resCat = openai.ResultCategories{Sexual: true}
-		resCatScore = openai.ResultCategoryScores{Sexual: 1}
+		resCatScore = openai.ResultCategoryScores{openai.ModerationCategorySexual: 1}
+
+	case strings.Contains(moderationReq.Input, "child porn"):
+		resCat = openai.ResultCategories{SexualMinors: true}
+		resCatScore = openai.ResultCategoryScores{openai.ModerationCategorySexualMinors: 1}
+
+	case strings.Contains(moderationReq.Input, "kill"):
+		resCat = openai.ResultCategories{Violence: true}
+		resCatScore = openai.ResultCategoryScores{openai.ModerationCategoryViolence: 1}
+
+	case strings.Contains(moderationReq.Input, "corpse"):
+		resCat = openai.ResultCategories{ViolenceGraphic: true}
+		resCatScore = openai.ResultCategoryScores{openai.ModerationCategoryViolenceGraphic: 1}
 	}
 
 	result := openai.Result{Categories: resCat, CategoryScores: resCatScore, Flagged: true}


### PR DESCRIPTION
**Describe the change**
I converted the `ResultCategoriesScores` struct into a `map[string]float32`. 
This change has been discussed in issue #633 .

**Provide OpenAI documentation link**
https://platform.openai.com/docs/guides/moderation/overview

**Describe your solution**
I just converted the struct into a map to allow more categories to be accessible without the need of changing the code everytime

**Tests**
I simply adapted the existing tests to the new data structure with more test cases 

Issue: #633
