### PR TITLE
fix:fix open ai original validation. modify Tool's Function to pointer

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -225,8 +225,8 @@ const (
 )
 
 type Tool struct {
-	Type     ToolType           `json:"type"`
-	Function FunctionDefinition `json:"function,omitempty"`
+	Type     ToolType            `json:"type"`
+	Function *FunctionDefinition `json:"function,omitempty"`
 }
 
 type ToolChoice struct {

--- a/examples/completion-with-tool/main.go
+++ b/examples/completion-with-tool/main.go
@@ -35,7 +35,7 @@ func main() {
 	}
 	t := openai.Tool{
 		Type:     openai.ToolTypeFunction,
-		Function: f,
+		Function: &f,
 	}
 
 	// simulate user asking a question that requires the function


### PR DESCRIPTION
**Describe the change**
modify Tool's Function to pointer

**Provide OpenAI documentation link**
https://community.openai.com/t/retrievals-tool-not-permitted/628664

**Describe your solution**
using pointer，Avoiding 'null' values for the 'function' field when serializing to JSON

Issue: #663 
