### PR TITLE
fix: when no Assistant Tools are specified, an empty list should be sent

### DIFF
--- a/assistant.go
+++ b/assistant.go
@@ -46,7 +46,7 @@ type AssistantRequest struct {
 	Name         *string         `json:"name,omitempty"`
 	Description  *string         `json:"description,omitempty"`
 	Instructions *string         `json:"instructions,omitempty"`
-	Tools        []AssistantTool `json:"tools,omitempty"`
+	Tools        []AssistantTool `json:"tools"`
 	FileIDs      []string        `json:"file_ids,omitempty"`
 	Metadata     map[string]any  `json:"metadata,omitempty"`
 }


### PR DESCRIPTION
**Describe the change**
Currently, it is not possible to remove all tools when modifying an assistant because the field will be omitted if empty. With this change, it will now be possible.

**Provide OpenAI documentation link**
https://platform.openai.com/docs/api-reference/assistants/modifyAssistant#assistants-modifyassistant-tools

**Describe your solution**
When creating or modifying an assistant, an empty list of tools will be sent instead of omitting the field.

**Tests**
- Created an assistant with no tools
- Created an assistant with tools
- Updated an assistant with tools to remove all tools
- Updated an assistant with tools to remove some tools
- Updated an assistant without tools to add some tools
- Ran unit tests

