### PR TITLE
fix: repair json decoding of moderation response

### DIFF
--- a/moderation.go
+++ b/moderation.go
@@ -59,17 +59,17 @@ type ResultCategories struct {
 
 // ResultCategoryScores represents CategoryScores of Result.
 type ResultCategoryScores struct {
-	Hate                  bool `json:"hate"`
-	HateThreatening       bool `json:"hate/threatening"`
-	Harassment            bool `json:"harassment"`
-	HarassmentThreatening bool `json:"harassment/threatening"`
-	SelfHarm              bool `json:"self-harm"`
-	SelfHarmIntent        bool `json:"self-harm/intent"`
-	SelfHarmInstructions  bool `json:"self-harm/instructions"`
-	Sexual                bool `json:"sexual"`
-	SexualMinors          bool `json:"sexual/minors"`
-	Violence              bool `json:"violence"`
-	ViolenceGraphic       bool `json:"violence/graphic"`
+	Hate                  float32 `json:"hate"`
+	HateThreatening       float32 `json:"hate/threatening"`
+	Harassment            float32 `json:"harassment"`
+	HarassmentThreatening float32 `json:"harassment/threatening"`
+	SelfHarm              float32 `json:"self-harm"`
+	SelfHarmIntent        float32 `json:"self-harm/intent"`
+	SelfHarmInstructions  float32 `json:"self-harm/instructions"`
+	Sexual                float32 `json:"sexual"`
+	SexualMinors          float32 `json:"sexual/minors"`
+	Violence              float32 `json:"violence"`
+	ViolenceGraphic       float32 `json:"violence/graphic"`
 }
 
 // ModerationResponse represents a response structure for moderation API.

--- a/moderation_test.go
+++ b/moderation_test.go
@@ -82,47 +82,47 @@ func handleModerationEndpoint(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case strings.Contains(moderationReq.Input, "hate"):
 		resCat = openai.ResultCategories{Hate: true}
-		resCatScore = openai.ResultCategoryScores{Hate: true}
+		resCatScore = openai.ResultCategoryScores{Hate: 1}
 
 	case strings.Contains(moderationReq.Input, "hate more"):
 		resCat = openai.ResultCategories{HateThreatening: true}
-		resCatScore = openai.ResultCategoryScores{HateThreatening: true}
+		resCatScore = openai.ResultCategoryScores{HateThreatening: 1}
 
 	case strings.Contains(moderationReq.Input, "harass"):
 		resCat = openai.ResultCategories{Harassment: true}
-		resCatScore = openai.ResultCategoryScores{Harassment: true}
+		resCatScore = openai.ResultCategoryScores{Harassment: 1}
 
 	case strings.Contains(moderationReq.Input, "harass hard"):
 		resCat = openai.ResultCategories{Harassment: true}
-		resCatScore = openai.ResultCategoryScores{HarassmentThreatening: true}
+		resCatScore = openai.ResultCategoryScores{HarassmentThreatening: 1}
 
 	case strings.Contains(moderationReq.Input, "suicide"):
 		resCat = openai.ResultCategories{SelfHarm: true}
-		resCatScore = openai.ResultCategoryScores{SelfHarm: true}
+		resCatScore = openai.ResultCategoryScores{SelfHarm: 1}
 
 	case strings.Contains(moderationReq.Input, "wanna suicide"):
 		resCat = openai.ResultCategories{SelfHarmIntent: true}
-		resCatScore = openai.ResultCategoryScores{SelfHarm: true}
+		resCatScore = openai.ResultCategoryScores{SelfHarm: 1}
 
 	case strings.Contains(moderationReq.Input, "drink bleach"):
 		resCat = openai.ResultCategories{SelfHarmInstructions: true}
-		resCatScore = openai.ResultCategoryScores{SelfHarmInstructions: true}
+		resCatScore = openai.ResultCategoryScores{SelfHarmInstructions: 1}
 
 	case strings.Contains(moderationReq.Input, "porn"):
 		resCat = openai.ResultCategories{Sexual: true}
-		resCatScore = openai.ResultCategoryScores{Sexual: true}
+		resCatScore = openai.ResultCategoryScores{Sexual: 1}
 
 	case strings.Contains(moderationReq.Input, "child porn"):
 		resCat = openai.ResultCategories{SexualMinors: true}
-		resCatScore = openai.ResultCategoryScores{SexualMinors: true}
+		resCatScore = openai.ResultCategoryScores{SexualMinors: 1}
 
 	case strings.Contains(moderationReq.Input, "kill"):
 		resCat = openai.ResultCategories{Violence: true}
-		resCatScore = openai.ResultCategoryScores{Violence: true}
+		resCatScore = openai.ResultCategoryScores{Violence: 1}
 
 	case strings.Contains(moderationReq.Input, "corpse"):
 		resCat = openai.ResultCategories{ViolenceGraphic: true}
-		resCatScore = openai.ResultCategoryScores{ViolenceGraphic: true}
+		resCatScore = openai.ResultCategoryScores{ViolenceGraphic: 1}
 	}
 
 	result := openai.Result{Categories: resCat, CategoryScores: resCatScore, Flagged: true}


### PR DESCRIPTION
PR #662 has broken the json decoding of moderation responses by changing the type of score values from float32 to bool. This commit fixes that problem.