### PR TITLE
Added 'wav' and 'pcm' Audio Formats

### DIFF
--- a/speech.go
+++ b/speech.go
@@ -35,7 +35,6 @@ const (
 	SpeechResponseFormatFlac SpeechResponseFormat = "flac"
 	SpeechResponseFormatWav SpeechResponseFormat = "wav"
 	SpeechResponseFormatPcm SpeechResponseFormat = "pcm"
-
 )
 
 var (

--- a/speech.go
+++ b/speech.go
@@ -33,8 +33,8 @@ const (
 	SpeechResponseFormatOpus SpeechResponseFormat = "opus"
 	SpeechResponseFormatAac  SpeechResponseFormat = "aac"
 	SpeechResponseFormatFlac SpeechResponseFormat = "flac"
-	SpeechResponseFormatWav SpeechResponseFormat = "wav"
-	SpeechResponseFormatPcm SpeechResponseFormat = "pcm"
+	SpeechResponseFormatWav  SpeechResponseFormat = "wav"
+	SpeechResponseFormatPcm  SpeechResponseFormat = "pcm"
 )
 
 var (

--- a/speech.go
+++ b/speech.go
@@ -33,6 +33,9 @@ const (
 	SpeechResponseFormatOpus SpeechResponseFormat = "opus"
 	SpeechResponseFormatAac  SpeechResponseFormat = "aac"
 	SpeechResponseFormatFlac SpeechResponseFormat = "flac"
+	SpeechResponseFormatWav SpeechResponseFormat = "wav"
+	SpeechResponseFormatPcm SpeechResponseFormat = "pcm"
+
 )
 
 var (


### PR DESCRIPTION
**Describe the change**
Added "wav" and "pcm" audio formats as per OpenAI API documentation for createSpeech endpoint.  Ref: https://platform.openai.com/docs/api-reference/audio/createSpeech 
Supported formats are mp3, opus, aac, flac, wav, and pcm.

**OpenAI documentation link**
[ Relevant API doc from https://platform.openai.com/docs/api-reference
 ](https://platform.openai.com/docs/api-reference/audio/createSpeech)