### PR TITLE
feat(whisper): add request parameter TimeStampGranularities and respo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,11 @@ func main() {
 
 	req := openai.AudioRequest{
 		Model:    openai.Whisper1,
+		Format:      openai.AudioResponseFormatVerboseJSON,
+		TimeStampGranularities: []openai.TimestampGranularity{ // Only supported with response_format=verbose_json
+			openai.TimestampGranularitySegment,
+			openai.TimestampGranularityWord,
+		},
 		FilePath: "recording.mp3",
 	}
 	resp, err := c.CreateTranscription(ctx, req)


### PR DESCRIPTION
**Describe the change**
Add new struct field `timestamp_granularities[]` and `words` for whisper transcatiption API

**Provide OpenAI documentation link**
* [timestamp_granularities[]](https://platform.openai.com/docs/api-reference/audio/createTranscription#audio-createtranscription-timestamp_granularities)
* [words](https://platform.openai.com/docs/api-reference/audio/verbose-json-object#audio/verbose-json-object-words)


**Describe your solution**
Add OpenAI new added parameter in request&response

**Tests**
manual


