### PR TITLE
Add support for  word-level and segment-level timestamp granularities

### DIFF
--- a/audio.go
+++ b/audio.go
@@ -47,11 +47,12 @@ type AudioRequest struct {
 	// Reader is an optional io.Reader when you do not want to use an existing file.
 	Reader io.Reader
 
-	Prompt                  string // For translation, it should be in English
-	Temperature             float32
-	Language                string // For translation, just do not use it. It seems "en" works, not confirmed...
-	Format                  AudioResponseFormat
-	Timestamp_Granularities TimestampGranularitiesLevel // response_format must be set verbose_json to use timestamp granularities
+	Prompt      string // For translation, it should be in English
+	Temperature float32
+	Language    string // For translation, just do not use it. It seems "en" works, not confirmed...
+	Format      AudioResponseFormat
+	// response_format must be set verbose_json to use timestamp granularities
+	TimestampGranularities TimestampGranularitiesLevel
 }
 
 // AudioResponse represents a response structure for audio API.
@@ -179,8 +180,8 @@ func audioMultipartForm(request AudioRequest, b utils.FormBuilder) error {
 	}
 
 	// Create a form field for the timestamp_granularities[] (if provided)
-	if request.Timestamp_Granularities != "" {
-		err = b.WriteField("timestamp_granularities[]", string(request.Timestamp_Granularities))
+	if request.TimestampGranularities != "" {
+		err = b.WriteField("timestamp_granularities[]", string(request.TimestampGranularities))
 		if err != nil {
 			return fmt.Errorf("writing timestamp_granularities: %w", err)
 		}

--- a/audio_api_test.go
+++ b/audio_api_test.go
@@ -99,12 +99,13 @@ func TestAudioWithOptionalArgs(t *testing.T) {
 			test.CreateTestFile(t, path)
 
 			req := openai.AudioRequest{
-				FilePath:    path,
-				Model:       "whisper-3",
-				Prompt:      "用简体中文",
-				Temperature: 0.5,
-				Language:    "zh",
-				Format:      openai.AudioResponseFormatSRT,
+				FilePath:               path,
+				Model:                  "whisper-3",
+				Prompt:                 "用简体中文",
+				Temperature:            0.5,
+				Language:               "zh",
+				Format:                 openai.AudioResponseFormatVerboseJSON,
+				TimestampGranularities: openai.TimestampGranularitiesWord,
 			}
 			_, err := tc.createFn(ctx, req)
 			checks.NoError(t, err, "audio API error")

--- a/examples/voice-to-text/main.go
+++ b/examples/voice-to-text/main.go
@@ -24,10 +24,10 @@ func main() {
 	resp, err := client.CreateTranscription(
 		context.Background(),
 		openai.AudioRequest{
-			Model:                   openai.Whisper1,
-			FilePath:                os.Args[1],
-			Format:                  openai.AudioResponseFormatVerboseJSON,
-			Timestamp_Granularities: openai.TimestampGranularitiesWord, // Timestamp granularities are only supported with response_format=verbose_json
+			Model:                  openai.Whisper1,
+			FilePath:               os.Args[1],
+			Format:                 openai.AudioResponseFormatVerboseJSON,
+			TimestampGranularities: openai.TimestampGranularitiesWord, // Timestamp granularities are only supported with response_format=verbose_json
 		},
 	)
 	if err != nil {

--- a/examples/voice-to-text/main.go
+++ b/examples/voice-to-text/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -23,13 +24,23 @@ func main() {
 	resp, err := client.CreateTranscription(
 		context.Background(),
 		openai.AudioRequest{
-			Model:    openai.Whisper1,
-			FilePath: os.Args[1],
+			Model:                   openai.Whisper1,
+			FilePath:                os.Args[1],
+			Format:                  openai.AudioResponseFormatVerboseJSON,
+			Timestamp_Granularities: openai.TimestampGranularitiesWord, // Timestamp granularities are only supported with response_format=verbose_json
 		},
 	)
 	if err != nil {
 		fmt.Printf("Transcription error: %v\n", err)
 		return
 	}
+
+	jsonOutput, err := json.Marshal(&resp.Words)
+	if err != nil {
+		fmt.Printf("Unmarshal JSON error: %v\n", err)
+		return
+	}
+
+	fmt.Println(string(jsonOutput))
 	fmt.Println(resp.Text)
 }


### PR DESCRIPTION
…allows users to define timestamp granularities for transcriptions, including word-level and segment-level granularity. The  struct now includes a  field, and the corresponding JSON serialization is implemented to include this field in the request. This extends the capabilities of the wrapper, providing users with more flexibility in handling transcriptions.

https://platform.openai.com/docs/api-reference/audio/createTranscription#audio-createtranscription-timestamp_granularities
