### PR TITLE
Addded Word-Level Timestamp Granularity Support

### DIFF
--- a/audio_api_test.go
+++ b/audio_api_test.go
@@ -99,12 +99,13 @@ func TestAudioWithOptionalArgs(t *testing.T) {
 			test.CreateTestFile(t, path)
 
 			req := openai.AudioRequest{
-				FilePath:    path,
-				Model:       "whisper-3",
-				Prompt:      "用简体中文",
-				Temperature: 0.5,
-				Language:    "zh",
-				Format:      openai.AudioResponseFormatSRT,
+				FilePath:               path,
+				Model:                  "whisper-3",
+				Prompt:                 "用简体中文",
+				Temperature:            0.5,
+				Language:               "zh",
+				Format:                 openai.AudioResponseFormatVerboseJSON,
+				TimestampGranularities: openai.TimestampGranularitiesWord,
 			}
 			_, err := tc.createFn(ctx, req)
 			checks.NoError(t, err, "audio API error")


### PR DESCRIPTION
Added word-level timestamp granularity support as outlined in the OpenAI API documentation for the transcription endpoint. 
ref: 
https://platform.openai.com/docs/api-reference/audio/createTranscription#audio-createtranscription-timestamp_granularities

![word_timestamps](https://github.com/sashabaranov/go-openai/assets/68427058/9c618a5b-e703-4175-8634-effaec225929)
