### PR TITLE
Update streamReader Close() method to return error

### DIFF
--- a/stream_reader.go
+++ b/stream_reader.go
@@ -108,6 +108,6 @@ func (stream *streamReader[T]) unmarshalError() (errResp *ErrorResponse) {
 	return
 }
 
-func (stream *streamReader[T]) Close() {
-	stream.response.Body.Close()
+func (stream *streamReader[T]) Close() error {
+	return stream.response.Body.Close()
 }


### PR DESCRIPTION
This commit updates the Close() method of the streamReader struct to return an error. This allows callers to handle any errors that occur when closing the stream.