### PR TITLE
Allow custom Voice and Speech Models

### DIFF
--- a/speech.go
+++ b/speech.go
@@ -2,7 +2,6 @@ package openai
 
 import (
 	"context"
-	"errors"
 	"io"
 	"net/http"
 )
@@ -37,11 +36,6 @@ const (
 	SpeechResponseFormatPcm  SpeechResponseFormat = "pcm"
 )
 
-var (
-	ErrInvalidSpeechModel = errors.New("invalid speech model")
-	ErrInvalidVoice       = errors.New("invalid voice")
-)
-
 type CreateSpeechRequest struct {
 	Model          SpeechModel          `json:"model"`
 	Input          string               `json:"input"`
@@ -50,32 +44,7 @@ type CreateSpeechRequest struct {
 	Speed          float64              `json:"speed,omitempty"`           // Optional, default to 1.0
 }
 
-func contains[T comparable](s []T, e T) bool {
-	for _, v := range s {
-		if v == e {
-			return true
-		}
-	}
-	return false
-}
-
-func isValidSpeechModel(model SpeechModel) bool {
-	return contains([]SpeechModel{TTSModel1, TTSModel1HD, TTSModelCanary}, model)
-}
-
-func isValidVoice(voice SpeechVoice) bool {
-	return contains([]SpeechVoice{VoiceAlloy, VoiceEcho, VoiceFable, VoiceOnyx, VoiceNova, VoiceShimmer}, voice)
-}
-
 func (c *Client) CreateSpeech(ctx context.Context, request CreateSpeechRequest) (response io.ReadCloser, err error) {
-	if !isValidSpeechModel(request.Model) {
-		err = ErrInvalidSpeechModel
-		return
-	}
-	if !isValidVoice(request.Voice) {
-		err = ErrInvalidVoice
-		return
-	}
 	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL("/audio/speech", string(request.Model)),
 		withBody(request),
 		withContentType("application/json"),

--- a/speech_test.go
+++ b/speech_test.go
@@ -95,21 +95,4 @@ func TestSpeechIntegration(t *testing.T) {
 		err = os.WriteFile("test.mp3", buf, 0644)
 		checks.NoError(t, err, "Create error")
 	})
-	t.Run("invalid model", func(t *testing.T) {
-		_, err := client.CreateSpeech(context.Background(), openai.CreateSpeechRequest{
-			Model: "invalid_model",
-			Input: "Hello!",
-			Voice: openai.VoiceAlloy,
-		})
-		checks.ErrorIs(t, err, openai.ErrInvalidSpeechModel, "CreateSpeech error")
-	})
-
-	t.Run("invalid voice", func(t *testing.T) {
-		_, err := client.CreateSpeech(context.Background(), openai.CreateSpeechRequest{
-			Model: openai.TTSModel1,
-			Input: "Hello!",
-			Voice: "invalid_voice",
-		})
-		checks.ErrorIs(t, err, openai.ErrInvalidVoice, "CreateSpeech error")
-	})
 }


### PR DESCRIPTION
this pull request removes the client-side logic to verify a valid speech and voice model.
the motivation is to support custom models on openai compatible backends

thanks for considering