### PR TITLE
Refactor authentication process and update tests accordingly

### DIFF
--- a/api_integration_test.go
+++ b/api_integration_test.go
@@ -5,7 +5,6 @@ package openai_test
 import (
 	"context"
 	"errors"
-	"io"
 	"os"
 	"testing"
 
@@ -26,7 +25,7 @@ func TestAPI(t *testing.T) {
 	_, err = c.ListEngines(ctx)
 	checks.NoError(t, err, "ListEngines error")
 
-	_, err = c.GetEngine(ctx, "davinci")
+	_, err = c.GetEngine(ctx, "text-embedding-3-small")
 	checks.NoError(t, err, "GetEngine error")
 
 	fileRes, err := c.ListFiles(ctx)
@@ -42,7 +41,7 @@ func TestAPI(t *testing.T) {
 			"The food was delicious and the waiter",
 			"Other examples of embedding request",
 		},
-		Model: openai.AdaSearchQuery,
+		Model: openai.SmallEmbedding3,
 	}
 	_, err = c.CreateEmbeddings(ctx, embeddingReq)
 	checks.NoError(t, err, "Embedding error")
@@ -76,31 +75,6 @@ func TestAPI(t *testing.T) {
 		},
 	)
 	checks.NoError(t, err, "CreateChatCompletion (with name) returned error")
-
-	stream, err := c.CreateCompletionStream(ctx, openai.CompletionRequest{
-		Prompt:    "Ex falso quodlibet",
-		Model:     openai.GPT3Ada,
-		MaxTokens: 5,
-		Stream:    true,
-	})
-	checks.NoError(t, err, "CreateCompletionStream returned error")
-	defer stream.Close()
-
-	counter := 0
-	for {
-		_, err = stream.Recv()
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			t.Errorf("Stream error: %v", err)
-		} else {
-			counter++
-		}
-	}
-	if counter == 0 {
-		t.Error("Stream did not return any responses")
-	}
 
 	_, err = c.CreateChatCompletion(
 		context.Background(),

--- a/api_internal_test.go
+++ b/api_internal_test.go
@@ -41,7 +41,7 @@ func TestRequestAuthHeader(t *testing.T) {
 		Name      string
 		APIType   APIType
 		HeaderKey string
-		Token     string
+		Token     AuthBuilder
 		OrgID     string
 		Expect    string
 	}{
@@ -49,7 +49,7 @@ func TestRequestAuthHeader(t *testing.T) {
 			"OpenAIDefault",
 			"",
 			"Authorization",
-			"dummy-token-openai",
+			APIKey("dummy-token-openai"),
 			"",
 			"Bearer dummy-token-openai",
 		},
@@ -57,7 +57,7 @@ func TestRequestAuthHeader(t *testing.T) {
 			"OpenAIOrg",
 			APITypeOpenAI,
 			"Authorization",
-			"dummy-token-openai",
+			APIKey("dummy-token-openai"),
 			"dummy-org-openai",
 			"Bearer dummy-token-openai",
 		},
@@ -65,7 +65,7 @@ func TestRequestAuthHeader(t *testing.T) {
 			"OpenAI",
 			APITypeOpenAI,
 			"Authorization",
-			"dummy-token-openai",
+			APIKey("dummy-token-openai"),
 			"",
 			"Bearer dummy-token-openai",
 		},
@@ -73,7 +73,7 @@ func TestRequestAuthHeader(t *testing.T) {
 			"AzureAD",
 			APITypeAzureAD,
 			"Authorization",
-			"dummy-token-azure",
+			APIKey("dummy-token-azure"),
 			"",
 			"Bearer dummy-token-azure",
 		},
@@ -81,7 +81,7 @@ func TestRequestAuthHeader(t *testing.T) {
 			"Azure",
 			APITypeAzure,
 			AzureAPIKeyHeader,
-			"dummy-api-key-here",
+			AzureAPIKey("dummy-api-key-here"),
 			"",
 			"dummy-api-key-here",
 		},
@@ -89,7 +89,9 @@ func TestRequestAuthHeader(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
-			az := DefaultConfig(c.Token)
+			az := ClientConfig{
+				AuthToken: c.Token,
+			}
 			az.APIType = c.APIType
 			az.OrgID = c.OrgID
 

--- a/client.go
+++ b/client.go
@@ -14,7 +14,7 @@ import (
 
 // Client is OpenAI GPT-3 API client.
 type Client struct {
-	config ClientConfig
+	config *ClientConfig
 
 	requestBuilder    utils.RequestBuilder
 	createFormBuilder func(io.Writer) utils.FormBuilder
@@ -47,7 +47,7 @@ func NewClient(authToken string) *Client {
 // NewClientWithConfig creates new OpenAI API client for specified config.
 func NewClientWithConfig(config ClientConfig) *Client {
 	return &Client{
-		config:         config,
+		config:         &config,
 		requestBuilder: utils.NewRequestBuilder(),
 		createFormBuilder: func(body io.Writer) utils.FormBuilder {
 			return utils.NewFormBuilder(body)
@@ -173,12 +173,8 @@ func sendRequestStream[T streamable](client *Client, req *http.Request) (*stream
 func (c *Client) setCommonHeaders(req *http.Request) {
 	// https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference#authentication
 	// Azure API Key authentication
-	if c.config.APIType == APITypeAzure {
-		req.Header.Set(AzureAPIKeyHeader, c.config.authToken)
-	} else if c.config.authToken != "" {
-		// OpenAI or Azure AD authentication
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.authToken))
-	}
+	c.config.AuthToken(req)
+
 	if c.config.OrgID != "" {
 		req.Header.Set("OpenAI-Organization", c.config.OrgID)
 	}

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"fmt"
 	"net/http"
 	"regexp"
 )
@@ -23,10 +24,23 @@ const (
 
 const AzureAPIKeyHeader = "api-key"
 
+type AuthBuilder func(req *http.Request)
+
+func APIKey(authToken string) AuthBuilder {
+	return func(req *http.Request) {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", authToken))
+	}
+}
+
+func AzureAPIKey(apiKey string) AuthBuilder {
+	return func(req *http.Request) {
+		req.Header.Set(AzureAPIKeyHeader, apiKey)
+	}
+}
+
 // ClientConfig is a configuration of a client.
 type ClientConfig struct {
-	authToken string
-
+	AuthToken            AuthBuilder
 	BaseURL              string
 	OrgID                string
 	APIType              APIType
@@ -39,7 +53,7 @@ type ClientConfig struct {
 
 func DefaultConfig(authToken string) ClientConfig {
 	return ClientConfig{
-		authToken: authToken,
+		AuthToken: APIKey(authToken),
 		BaseURL:   openaiAPIURLv1,
 		APIType:   APITypeOpenAI,
 		OrgID:     "",
@@ -52,7 +66,7 @@ func DefaultConfig(authToken string) ClientConfig {
 
 func DefaultAzureConfig(apiKey, baseURL string) ClientConfig {
 	return ClientConfig{
-		authToken:  apiKey,
+		AuthToken:  AzureAPIKey(apiKey),
 		BaseURL:    baseURL,
 		OrgID:      "",
 		APIType:    APITypeAzure,


### PR DESCRIPTION
Updated the authentication process in the `ClientConfig` by replacing the `authToken` string with `AuthBuilder` functions. This allows setting up various authentication headers, supporting different types of authentication like OpenAI or Azure AD. As part of this update, corresponding tests have also been modified to work with the new authentication process.

A similar PR may already be submitted!
Please search among the [Pull request](https://github.com/sashabaranov/go-openai/pulls) before creating one.

If your changes introduce breaking changes, please prefix the title of your pull request with "[BREAKING_CHANGES]". This allows for clear identification of such changes in the 'What's Changed' section on the release page, making it developer-friendly.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.

**Describe the change**
Please provide a clear and concise description of the changes you're proposing. Explain what problem it solves or what feature it adds.

**Provide OpenAI documentation link**
Provide a relevant API doc from https://platform.openai.com/docs/api-reference

**Describe your solution**
Describe how your changes address the problem or how they add the feature. This should include a brief description of your approach and any new libraries or dependencies you're using.

**Tests**
Briefly describe how you have tested these changes. If possible — please add integration tests.

**Additional context**
Add any other context or screenshots or logs about your pull request here. If the pull request relates to an open issue, please link to it.

Issue: #XXXX
