### PR TITLE
feat: support cloudflare AI Gateway flavored azure openai

### DIFF
--- a/client.go
+++ b/client.go
@@ -182,7 +182,7 @@ func sendRequestStream[T streamable](client *Client, req *http.Request) (*stream
 func (c *Client) setCommonHeaders(req *http.Request) {
 	// https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference#authentication
 	// Azure API Key authentication
-	if c.config.APIType == APITypeAzure {
+	if c.config.APIType == APITypeAzure || c.config.APIType == APITypeCloudflareAzure {
 		req.Header.Set(AzureAPIKeyHeader, c.config.authToken)
 	} else if c.config.authToken != "" {
 		// OpenAI or Azure AD authentication
@@ -244,6 +244,12 @@ func (c *Client) fullURL(suffix string, args ...any) string {
 			baseURL, azureAPIPrefix, azureDeploymentsPrefix,
 			azureDeploymentName, suffix, c.config.APIVersion,
 		)
+	}
+
+	if c.config.APIType == APITypeCloudflareAzure {
+		baseURL := c.config.BaseURL
+		baseURL = strings.TrimRight(baseURL, "/")
+		return fmt.Sprintf("%s%s?api-version=%s", baseURL, suffix, c.config.APIVersion)
 	}
 
 	// c.config.APIType == APITypeOpenAI || c.config.APIType == ""

--- a/config.go
+++ b/config.go
@@ -16,9 +16,10 @@ const (
 type APIType string
 
 const (
-	APITypeOpenAI  APIType = "OPEN_AI"
-	APITypeAzure   APIType = "AZURE"
-	APITypeAzureAD APIType = "AZURE_AD"
+	APITypeOpenAI          APIType = "OPEN_AI"
+	APITypeAzure           APIType = "AZURE"
+	APITypeAzureAD         APIType = "AZURE_AD"
+	APITypeCloudflareAzure APIType = "CLOUDFLARE_AZURE"
 )
 
 const AzureAPIKeyHeader = "api-key"


### PR DESCRIPTION
**Describe the change**
Please provide a clear and concise description of the changes you're proposing. Explain what problem it solves or what feature it adds.

Support Cloudflare AI Gateway flavored azure openai.


**Provide OpenAI documentation link**

Here is Cloudflare docs:

https://developers.cloudflare.com/ai-gateway/providers/azureopenai/

The URL follows this pattern

`https://gateway.ai.cloudflare.com/v1/<ACCOUNT_TAG>/<GATEWAY>/azure-openai/<RESOURCE_NAME>/<MODEL_NAME>/chat/completions?api-version=2023-05-15`

- `<ACCOUNT_TAG>` is the Cloudflare Account ID
- `<GATEWAY>` is the name of "Cloudflare AI Gateway"
- `<RESOURCE_NAME>` is Azure Resource Name
- `<MODEL_NAME>` is the Azure Deployment Name / Model Name



**Describe your solution**

I introduced a new APIType `APITypeCloudflareAzure` and append corresponding fullURL for it. 

**Tests**

I have tested it my application.

I am glad to append more tests if somebody could guide me how to write testcases


**Additional context**

N/A
