### PR TITLE
Add prompt filter results to content filters

### DIFF
--- a/chat_stream.go
+++ b/chat_stream.go
@@ -19,13 +19,19 @@ type ChatCompletionStreamChoice struct {
 	ContentFilterResults ContentFilterResults            `json:"content_filter_results,omitempty"`
 }
 
+type PromptFilterResult struct {
+	Index                int                  `json:"index"`
+	ContentFilterResults ContentFilterResults `json:"content_filter_results,omitempty"`
+}
+
 type ChatCompletionStreamResponse struct {
-	ID                string                       `json:"id"`
-	Object            string                       `json:"object"`
-	Created           int64                        `json:"created"`
-	Model             string                       `json:"model"`
-	Choices           []ChatCompletionStreamChoice `json:"choices"`
-	PromptAnnotations []PromptAnnotation           `json:"prompt_annotations,omitempty"`
+	ID                  string                       `json:"id"`
+	Object              string                       `json:"object"`
+	Created             int64                        `json:"created"`
+	Model               string                       `json:"model"`
+	Choices             []ChatCompletionStreamChoice `json:"choices"`
+	PromptAnnotations   []PromptAnnotation           `json:"prompt_annotations,omitempty"`
+	PromptFilterResults []PromptFilterResult         `json:"prompt_filter_results,omitempty"`
 }
 
 // ChatCompletionStream


### PR DESCRIPTION
**Describe the change**
Adding field for `prompt_filter_results` which is in the open content filters to assess the content of the user input. Current implementation in go-openai will only return content filter information on the model output using `ChatCompletionStreamResponse`. This is for AzureOpenAI spec.

**Provide OpenAI documentation link**
Relevant API doc: https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/content-filter
[See Bottom under Annotations]

**Describe your solution**
Change struct