### PR TITLE
Bump GitHub workflow actions to latest versions

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v9
         with:
           days-before-issue-stale: 30
           days-before-issue-close: 14

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,19 +9,19 @@ jobs:
     name: Sanity check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: '1.19'
+        go-version: '1.21'
     - name: Run vet
       run: |
         go vet .
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v4
       with:
         version: latest
     - name: Run tests
       run: go test -race -covermode=atomic -coverprofile=coverage.out -v .
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4


### PR DESCRIPTION
This PR bumps GitHub workflow actions to their latest versions, thus avoiding deprecation warnings as e.g. seen [here](https://github.com/sashabaranov/go-openai/actions/runs/8643918363).