### PR TITLE
[New_Features] Adds recently added Assistant cost saving parameters

### DIFF
--- a/run.go
+++ b/run.go
@@ -28,7 +28,7 @@ type Run struct {
 	Metadata       map[string]any     `json:"metadata"`
 	Usage          Usage              `json:"usage,omitempty"`
 
-	Temperature *int `json:"temperature,omitempty"`
+	Temperature *float32 `json:"temperature,omitempty"`
 	// The maximum number of prompt tokens that may be used over the course of the run.
 	// If the run exceeds the number of prompt tokens specified, the run will end with status 'complete'.
 	MaxPromptTokens int `json:"max_prompt_tokens,omitempty"`
@@ -91,7 +91,7 @@ type RunRequest struct {
 
 	// Sampling temperature between 0 and 2. Higher values like 0.8 are  more random.
 	// lower values are more focused and deterministic.
-	Temperature *int `json:"temperature,omitempty"`
+	Temperature *float32 `json:"temperature,omitempty"`
 
 	// The maximum number of prompt tokens that may be used over the course of the run.
 	// If the run exceeds the number of prompt tokens specified, the run will end with status 'complete'.

--- a/run.go
+++ b/run.go
@@ -30,12 +30,12 @@ type Run struct {
 
 	Temperature *int `json:"temperature,omitempty"`
 	// The maximum number of prompt tokens that may be used over the course of the run.
-	// If the run exceeds the number of prompt tokens specified, the run will end with status 'complete'
+	// If the run exceeds the number of prompt tokens specified, the run will end with status 'complete'.
 	MaxPromptTokens int `json:"max_prompt_tokens,omitempty"`
 	// The maximum number of completion tokens that may be used over the course of the run.
-	// If the run exceeds the number of completion tokens specified, the run will end with status 'complete'
+	// If the run exceeds the number of completion tokens specified, the run will end with status 'complete'.
 	MaxCompletionTokens int `json:"max_completion_tokens,omitempty"`
-	// ThreadTruncationStrategy defines the truncation strategy to use for the thread
+	// ThreadTruncationStrategy defines the truncation strategy to use for the thread.
 	TruncationStrategy *ThreadTruncationStrategy `json:"truncation_strategy,omitempty"`
 
 	httpHeader
@@ -93,33 +93,33 @@ type RunRequest struct {
 	Temperature *int `json:"temperature,omitempty"`
 
 	// The maximum number of prompt tokens that may be used over the course of the run.
-	// If the run exceeds the number of prompt tokens specified, the run will end with status 'complete'
+	// If the run exceeds the number of prompt tokens specified, the run will end with status 'complete'.
 	MaxPromptTokens int `json:"max_prompt_tokens,omitempty"`
 
 	// The maximum number of completion tokens that may be used over the course of the run.
-	// If the run exceeds the number of completion tokens specified, the run will end with status 'complete'
+	// If the run exceeds the number of completion tokens specified, the run will end with status 'complete'.
 	MaxCompletionTokens int `json:"max_completion_tokens,omitempty"`
 
-	// ThreadTruncationStrategy defines the truncation strategy to use for the thread
+	// ThreadTruncationStrategy defines the truncation strategy to use for the thread.
 	TruncationStrategy *ThreadTruncationStrategy `json:"truncation_strategy,omitempty"`
 }
 
-// ThreadTruncationStrategy defines the truncation strategy to use for the thread
-// https://platform.openai.com/docs/assistants/how-it-works/truncation-strategy
+// ThreadTruncationStrategy defines the truncation strategy to use for the thread.
+// https://platform.openai.com/docs/assistants/how-it-works/truncation-strategy.
 type ThreadTruncationStrategy struct {
-	// default 'auto'
+	// default 'auto'.
 	Type TruncationStrategy `json:"type,omitempty"`
-	// this field should be set if the truncation strategy is set to LastMessages
+	// this field should be set if the truncation strategy is set to LastMessages.
 	LastMessages *int `json:"last_messages,omitempty"`
 }
 
-// TruncationStrategy defines the existing truncation strategies existing for thread management in an assistant
+// TruncationStrategy defines the existing truncation strategies existing for thread management in an assistant.
 type TruncationStrategy string
 
 const (
-	// TruncationStrategyAuto messages in the middle of the thread will be dropped to fit the context length of the model
+	// TruncationStrategyAuto messages in the middle of the thread will be dropped to fit the context length of the model.
 	TruncationStrategyAuto = TruncationStrategy("auto")
-	// TruncationStrategyLastMessages the thread will be truncated to the n most recent messages in the thread
+	// TruncationStrategyLastMessages the thread will be truncated to the n most recent messages in the thread.
 	TruncationStrategyLastMessages = TruncationStrategy("last_messages")
 )
 

--- a/run.go
+++ b/run.go
@@ -89,7 +89,8 @@ type RunRequest struct {
 	Tools                  []Tool         `json:"tools,omitempty"`
 	Metadata               map[string]any `json:"metadata,omitempty"`
 
-	// Sampling temperature between 0 and 2. Higher values like 0.8 are  more random, lower values are more focused and deterministic.
+	// Sampling temperature between 0 and 2. Higher values like 0.8 are  more random.
+	// lower values are more focused and deterministic.
 	Temperature *int `json:"temperature,omitempty"`
 
 	// The maximum number of prompt tokens that may be used over the course of the run.

--- a/run.go
+++ b/run.go
@@ -89,7 +89,7 @@ type RunRequest struct {
 	Tools                  []Tool         `json:"tools,omitempty"`
 	Metadata               map[string]any `json:"metadata,omitempty"`
 
-	// What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
+	// Sampling temperature between 0 and 2. Higher values like 0.8 are  more random, lower values are more focused and deterministic.
 	Temperature *int `json:"temperature,omitempty"`
 
 	// The maximum number of prompt tokens that may be used over the course of the run.

--- a/run.go
+++ b/run.go
@@ -28,6 +28,16 @@ type Run struct {
 	Metadata       map[string]any     `json:"metadata"`
 	Usage          Usage              `json:"usage,omitempty"`
 
+	Temperature *int `json:"temperature,omitempty"`
+	// The maximum number of prompt tokens that may be used over the course of the run.
+	// If the run exceeds the number of prompt tokens specified, the run will end with status 'complete'
+	MaxPromptTokens int `json:"max_prompt_tokens,omitempty"`
+	// The maximum number of completion tokens that may be used over the course of the run.
+	// If the run exceeds the number of completion tokens specified, the run will end with status 'complete'
+	MaxCompletionTokens int `json:"max_completion_tokens,omitempty"`
+	// ThreadTruncationStrategy defines the truncation strategy to use for the thread
+	TruncationStrategy *ThreadTruncationStrategy `json:"truncation_strategy,omitempty"`
+
 	httpHeader
 }
 
@@ -78,7 +88,40 @@ type RunRequest struct {
 	AdditionalInstructions string         `json:"additional_instructions,omitempty"`
 	Tools                  []Tool         `json:"tools,omitempty"`
 	Metadata               map[string]any `json:"metadata,omitempty"`
+
+	// What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
+	Temperature *int `json:"temperature,omitempty"`
+
+	// The maximum number of prompt tokens that may be used over the course of the run.
+	// If the run exceeds the number of prompt tokens specified, the run will end with status 'complete'
+	MaxPromptTokens int `json:"max_prompt_tokens,omitempty"`
+
+	// The maximum number of completion tokens that may be used over the course of the run.
+	// If the run exceeds the number of completion tokens specified, the run will end with status 'complete'
+	MaxCompletionTokens int `json:"max_completion_tokens,omitempty"`
+
+	// ThreadTruncationStrategy defines the truncation strategy to use for the thread
+	TruncationStrategy *ThreadTruncationStrategy `json:"truncation_strategy,omitempty"`
 }
+
+// ThreadTruncationStrategy defines the truncation strategy to use for the thread
+// https://platform.openai.com/docs/assistants/how-it-works/truncation-strategy
+type ThreadTruncationStrategy struct {
+	// default 'auto'
+	Type TruncationStrategy `json:"type,omitempty"`
+	// this field should be set if the truncation strategy is set to LastMessages
+	LastMessages *int `json:"last_messages,omitempty"`
+}
+
+// TruncationStrategy defines the existing truncation strategies existing for thread management in an assistant
+type TruncationStrategy string
+
+const (
+	// TruncationStrategyAuto messages in the middle of the thread will be dropped to fit the context length of the model
+	TruncationStrategyAuto = TruncationStrategy("auto")
+	// TruncationStrategyLastMessages the thread will be truncated to the n most recent messages in the thread
+	TruncationStrategyLastMessages = TruncationStrategy("last_messages")
+)
 
 type RunModifyRequest struct {
 	Metadata map[string]any `json:"metadata,omitempty"`


### PR DESCRIPTION
.**Describe the change**
OpenAI quietly released a major upgrade of their Assistant's API which gives us vital cost management functionality with easy to use parameters 

**Provide OpenAI documentation link**
[(https://platform.openai.com/docs/api-reference/runs)](https://platform.openai.com/docs/api-reference/runs)


**Describe your solution**
Not much to mention, it simply adds the new parameters to the object

**Tests**
as these are just extra fields in the request and response object, it cannot really be tested with unit tests

**Additional context**
I purposely skipped some of the other new fields such as 
Stream, which requires more infrastructure and should be it's own PR to define a properly abstracted streaming solution
I also skipped tool_choice and response_format, both because the documentation is not clear, and would require additional testing.

This PR is focused primarily on the very straight forward cost cutting parameters 

