### PR TITLE
feat: make RequestBuilder configurable

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,7 +16,6 @@ import (
 type Client struct {
 	config ClientConfig
 
-	requestBuilder    utils.RequestBuilder
 	createFormBuilder func(io.Writer) utils.FormBuilder
 }
 
@@ -52,9 +51,11 @@ func NewClient(authToken string) *Client {
 
 // NewClientWithConfig creates new OpenAI API client for specified config.
 func NewClientWithConfig(config ClientConfig) *Client {
+	if config.RequestBuilder == nil {
+		config.RequestBuilder = utils.NewRequestBuilder()
+	}
 	return &Client{
-		config:         config,
-		requestBuilder: utils.NewRequestBuilder(),
+		config: config,
 		createFormBuilder: func(body io.Writer) utils.FormBuilder {
 			return utils.NewFormBuilder(body)
 		},
@@ -104,7 +105,7 @@ func (c *Client) newRequest(ctx context.Context, method, url string, setters ...
 	for _, setter := range setters {
 		setter(args)
 	}
-	req, err := c.requestBuilder.Build(ctx, method, url, args.body, args.header)
+	req, err := c.config.RequestBuilder.Build(ctx, method, url, args.body, args.header)
 	if err != nil {
 		return nil, err
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -215,8 +215,8 @@ func TestHandleErrorResp(t *testing.T) {
 
 func TestClientReturnsRequestBuilderErrors(t *testing.T) {
 	config := DefaultConfig(test.GetTestToken())
+	config.RequestBuilder = &failingRequestBuilder{}
 	client := NewClientWithConfig(config)
-	client.requestBuilder = &failingRequestBuilder{}
 	ctx := context.Background()
 
 	type TestCase struct {
@@ -408,14 +408,25 @@ func TestClientReturnsRequestBuilderErrors(t *testing.T) {
 
 func TestClientReturnsRequestBuilderErrorsAddition(t *testing.T) {
 	config := DefaultConfig(test.GetTestToken())
+	config.RequestBuilder = &failingRequestBuilder{}
 	client := NewClientWithConfig(config)
-	client.requestBuilder = &failingRequestBuilder{}
 	ctx := context.Background()
 	_, err := client.CreateCompletion(ctx, CompletionRequest{Prompt: 1})
 	if !errors.Is(err, ErrCompletionRequestPromptTypeNotSupported) {
 		t.Fatalf("Did not return error when request builder failed: %v", err)
 	}
 	_, err = client.CreateCompletionStream(ctx, CompletionRequest{Prompt: 1})
+	if !errors.Is(err, ErrCompletionRequestPromptTypeNotSupported) {
+		t.Fatalf("Did not return error when request builder failed: %v", err)
+	}
+}
+
+func TestClientDefaultRequestBuilder(t *testing.T) {
+	config := DefaultConfig(test.GetTestToken())
+	client := NewClientWithConfig(config)
+	ctx := context.Background()
+
+	_, err := client.CreateCompletion(ctx, CompletionRequest{Prompt: 1})
 	if !errors.Is(err, ErrCompletionRequestPromptTypeNotSupported) {
 		t.Fatalf("Did not return error when request builder failed: %v", err)
 	}

--- a/config.go
+++ b/config.go
@@ -3,6 +3,8 @@ package openai
 import (
 	"net/http"
 	"regexp"
+
+	utils "github.com/sashabaranov/go-openai/internal"
 )
 
 const (
@@ -33,6 +35,7 @@ type ClientConfig struct {
 	APIVersion           string                    // required when APIType is APITypeAzure or APITypeAzureAD
 	AzureModelMapperFunc func(model string) string // replace model to azure deployment name func
 	HTTPClient           *http.Client
+	RequestBuilder       utils.RequestBuilder
 
 	EmptyMessagesLimit uint
 }


### PR DESCRIPTION
`RequestBuilder` is an interface, therefore, it's designed to be extensible.

```go
type RequestBuilder interface {
	Build(ctx context.Context, method, url string, body any, header http.Header) (*http.Request, error)
}
```

However, currently it's a private field of `Client`, which make it impossible to customize.

```go
type Client struct {
	config ClientConfig

	requestBuilder    utils.RequestBuilder
	createFormBuilder func(io.Writer) utils.FormBuilder
}
```

This PR moves `requestBuilder` to `ClientConfig`, making it configurable, so that users can implement their own `RequestBuilder`, which is very useful in situation of adding custom request headers and injecting tracing attributes.