### PR TITLE
Add preliminary MistralAI support

### DIFF
--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 
 	utils "github.com/sashabaranov/go-openai/internal"
@@ -224,6 +225,9 @@ func decodeString(body io.Reader, output *string) error {
 // fullURL returns full URL for request.
 // args[0] is model name, if API type is Azure, model name is required to get deployment name.
 func (c *Client) fullURL(suffix string, args ...any) string {
+	if val := os.Getenv("OPENAI_BASEURL"); val != "" {
+		baseURL = val
+	}
 	// /openai/deployments/{model}/chat/completions?api-version={api_version}
 	if c.config.APIType == APITypeAzure || c.config.APIType == APITypeAzureAD {
 		baseURL := c.config.BaseURL

--- a/client.go
+++ b/client.go
@@ -226,7 +226,7 @@ func decodeString(body io.Reader, output *string) error {
 // args[0] is model name, if API type is Azure, model name is required to get deployment name.
 func (c *Client) fullURL(suffix string, args ...any) string {
 	if val := os.Getenv("OPENAI_BASEURL"); val != "" {
-		baseURL = val
+		c.config.baseURL = val
 	}
 	// /openai/deployments/{model}/chat/completions?api-version={api_version}
 	if c.config.APIType == APITypeAzure || c.config.APIType == APITypeAzureAD {

--- a/client.go
+++ b/client.go
@@ -226,7 +226,7 @@ func decodeString(body io.Reader, output *string) error {
 // args[0] is model name, if API type is Azure, model name is required to get deployment name.
 func (c *Client) fullURL(suffix string, args ...any) string {
 	if val := os.Getenv("OPENAI_BASEURL"); val != "" {
-		c.config.baseURL = val
+		c.config.BaseURL = val
 	}
 	// /openai/deployments/{model}/chat/completions?api-version={api_version}
 	if c.config.APIType == APITypeAzure || c.config.APIType == APITypeAzureAD {

--- a/completion.go
+++ b/completion.go
@@ -61,6 +61,9 @@ const (
 	GPT3Ada002            = "ada-002"
 	GPT3Babbage           = "babbage"
 	GPT3Babbage002        = "babbage-002"
+	MistralSmall          = "mistral-small"
+	MistralMedium         = "mistral-medium"
+	MistralLarge          = "mistral-large"
 )
 
 // Codex Defines the models provided by OpenAI.

--- a/completion.go
+++ b/completion.go
@@ -66,6 +66,7 @@ const (
 	MistralTiny           = "mistral-tiny"
 	MistralSmall          = "mistral-small"
 	MistralMedium         = "mistral-medium"
+	MistralLarge          = "mistral-large"
 )
 
 // Codex Defines the models provided by OpenAI.

--- a/completion.go
+++ b/completion.go
@@ -61,9 +61,9 @@ const (
 	GPT3Ada002            = "ada-002"
 	GPT3Babbage           = "babbage"
 	GPT3Babbage002        = "babbage-002"
+	MistralTiny           = "mistral-tiny"
 	MistralSmall          = "mistral-small"
 	MistralMedium         = "mistral-medium"
-	MistralLarge          = "mistral-large"
 )
 
 // Codex Defines the models provided by OpenAI.


### PR DESCRIPTION
This small patch provides the ability to use another API endpoint declared in an environment variable, and adds Mistral models.

Here is the python example from MistralAI: https://github.com/mistralai/client-python/blob/0d55818364fd2a7ca67401dd550632f8ca70e5af/examples/chatbot_with_streaming.py#L15

Successfully tested with MistralAI.