### PR TITLE
Add support for word-level audio transcription timestamp granularity

### DIFF
--- a/audio.go
+++ b/audio.go
@@ -27,11 +27,11 @@ const (
 	AudioResponseFormatVTT         AudioResponseFormat = "vtt"
 )
 
-type TranscriptionTimestampGranularities string
+type TranscriptionTimestampGranularity string
 
 const (
-	TranscriptionTimestampGranularitiesWord    TranscriptionTimestampGranularities = "word"
-	TranscriptionTimestampGranularitiesSegment TranscriptionTimestampGranularities = "segment"
+	TranscriptionTimestampGranularityWord    TranscriptionTimestampGranularity = "word"
+	TranscriptionTimestampGranularitySegment TranscriptionTimestampGranularity = "segment"
 )
 
 // AudioRequest represents a request structure for audio API.
@@ -48,7 +48,7 @@ type AudioRequest struct {
 	Temperature            float32
 	Language               string // Only for transcription.
 	Format                 AudioResponseFormat
-	TimestampGranularities TranscriptionTimestampGranularities // Only for transcription.
+	TimestampGranularities []TranscriptionTimestampGranularity // Only for transcription.
 }
 
 // AudioResponse represents a response structure for audio API.
@@ -192,9 +192,11 @@ func audioMultipartForm(request AudioRequest, b utils.FormBuilder) error {
 	}
 
 	if len(request.TimestampGranularities) > 0 {
-		err = b.WriteField("timestamp_granularities[]", string(request.TimestampGranularities))
-		if err != nil {
-			return fmt.Errorf("writing timestamp_granularities[]: %w", err)
+		for _, tg := range request.TimestampGranularities {
+			err = b.WriteField("timestamp_granularities[]", string(tg))
+			if err != nil {
+				return fmt.Errorf("writing timestamp_granularities[]: %w", err)
+			}
 		}
 	}
 

--- a/audio.go
+++ b/audio.go
@@ -27,8 +27,14 @@ const (
 	AudioResponseFormatVTT         AudioResponseFormat = "vtt"
 )
 
+type TranscriptionTimestampGranularities string
+
+const (
+	TranscriptionTimestampGranularitiesWord    TranscriptionTimestampGranularities = "word"
+	TranscriptionTimestampGranularitiesSegment TranscriptionTimestampGranularities = "segment"
+)
+
 // AudioRequest represents a request structure for audio API.
-// ResponseFormat is not supported for now. We only return JSON text, which may be sufficient.
 type AudioRequest struct {
 	Model string
 
@@ -38,10 +44,11 @@ type AudioRequest struct {
 	// Reader is an optional io.Reader when you do not want to use an existing file.
 	Reader io.Reader
 
-	Prompt      string // For translation, it should be in English
-	Temperature float32
-	Language    string // For translation, just do not use it. It seems "en" works, not confirmed...
-	Format      AudioResponseFormat
+	Prompt                 string
+	Temperature            float32
+	Language               string // Only for transcription.
+	Format                 AudioResponseFormat
+	TimestampGranularities TranscriptionTimestampGranularities // Only for transcription.
 }
 
 // AudioResponse represents a response structure for audio API.
@@ -62,6 +69,11 @@ type AudioResponse struct {
 		NoSpeechProb     float64 `json:"no_speech_prob"`
 		Transient        bool    `json:"transient"`
 	} `json:"segments"`
+	Words []struct {
+		Word  string  `json:"word"`
+		Start float64 `json:"start"`
+		End   float64 `json:"end"`
+	} `json:"words"`
 	Text string `json:"text"`
 
 	httpHeader
@@ -176,6 +188,13 @@ func audioMultipartForm(request AudioRequest, b utils.FormBuilder) error {
 		err = b.WriteField("language", request.Language)
 		if err != nil {
 			return fmt.Errorf("writing language: %w", err)
+		}
+	}
+
+	if len(request.TimestampGranularities) > 0 {
+		err = b.WriteField("timestamp_granularities[]", string(request.TimestampGranularities))
+		if err != nil {
+			return fmt.Errorf("writing timestamp_granularities[]: %w", err)
 		}
 	}
 

--- a/audio_api_test.go
+++ b/audio_api_test.go
@@ -99,13 +99,16 @@ func TestAudioWithOptionalArgs(t *testing.T) {
 			test.CreateTestFile(t, path)
 
 			req := openai.AudioRequest{
-				FilePath:               path,
-				Model:                  "whisper-3",
-				Prompt:                 "用简体中文",
-				Temperature:            0.5,
-				Language:               "zh",
-				Format:                 openai.AudioResponseFormatSRT,
-				TimestampGranularities: openai.TranscriptionTimestampGranularitiesWord,
+				FilePath:    path,
+				Model:       "whisper-3",
+				Prompt:      "用简体中文",
+				Temperature: 0.5,
+				Language:    "zh",
+				Format:      openai.AudioResponseFormatSRT,
+				TimestampGranularities: []openai.TranscriptionTimestampGranularity{
+					openai.TranscriptionTimestampGranularitySegment,
+					openai.TranscriptionTimestampGranularityWord,
+				},
 			}
 			_, err := tc.createFn(ctx, req)
 			checks.NoError(t, err, "audio API error")

--- a/audio_api_test.go
+++ b/audio_api_test.go
@@ -99,12 +99,13 @@ func TestAudioWithOptionalArgs(t *testing.T) {
 			test.CreateTestFile(t, path)
 
 			req := openai.AudioRequest{
-				FilePath:    path,
-				Model:       "whisper-3",
-				Prompt:      "用简体中文",
-				Temperature: 0.5,
-				Language:    "zh",
-				Format:      openai.AudioResponseFormatSRT,
+				FilePath:               path,
+				Model:                  "whisper-3",
+				Prompt:                 "用简体中文",
+				Temperature:            0.5,
+				Language:               "zh",
+				Format:                 openai.AudioResponseFormatSRT,
+				TimestampGranularities: openai.TranscriptionTimestampGranularitiesWord,
 			}
 			_, err := tc.createFn(ctx, req)
 			checks.NoError(t, err, "audio API error")

--- a/audio_test.go
+++ b/audio_test.go
@@ -47,7 +47,7 @@ func TestAudioWithFailingFormBuilder(t *testing.T) {
 		return nil
 	}
 
-	failOn := []string{"model", "prompt", "temperature", "language", "response_format"}
+	failOn := []string{"model", "prompt", "temperature", "language", "response_format", "timestamp_granularities[]"}
 	for _, failingField := range failOn {
 		failForField = failingField
 		mockFailedErr = fmt.Errorf("mock form builder fail on field %s", failingField)

--- a/audio_test.go
+++ b/audio_test.go
@@ -24,6 +24,10 @@ func TestAudioWithFailingFormBuilder(t *testing.T) {
 		Temperature: 0.5,
 		Language:    "en",
 		Format:      AudioResponseFormatSRT,
+		TimestampGranularities: []TranscriptionTimestampGranularity{
+			TranscriptionTimestampGranularitySegment,
+			TranscriptionTimestampGranularityWord,
+		},
 	}
 
 	mockFailedErr := fmt.Errorf("mock form builder fail")


### PR DESCRIPTION
**Describe the change**
Add support for word-level audio transcription timestamp granularity.

**Provide OpenAI documentation link**
- [timestamp_granularities[]](https://platform.openai.com/docs/api-reference/audio/createTranscription#audio-createtranscription-timestamp_granularities)
- [words](https://platform.openai.com/docs/api-reference/audio/verbose-json-object#audio/verbose-json-object-words)

**Describe your solution**
Added `AudioRequest.TimestampGranularities` and `AudioResponse.Words` fields.

**Tests**
Filled `AudioRequest.TimestampGranularities` field in the existing tests' audio requests.

**Additional context**

- Related to two-months-abandoned #673, self-closed #680, and self-closed #674.
- Also removed some obsolete comments on `AudioRequest` fields.