### PR TITLE
Update client.go to get response header whether there is an error or not

### DIFF
--- a/client.go
+++ b/client.go
@@ -129,12 +129,12 @@ func (c *Client) sendRequest(req *http.Request, v Response) error {
 
 	defer res.Body.Close()
 
-	if isFailureStatusCode(res) {
-		return c.handleErrorResp(res)
-	}
-
 	if v != nil {
 		v.SetHeader(res.Header)
+	}
+
+	if isFailureStatusCode(res) {
+		return c.handleErrorResp(res)
 	}
 
 	return decodeResponse(res.Body, v)


### PR DESCRIPTION
Update client.go to get response header whether there is an error or not. Because 429 Too Many Requests error response has "Retry-After" header.

A similar PR may already be submitted!
Please search among the [Pull request](https://github.com/sashabaranov/go-openai/pulls) before creating one.

If your changes introduce breaking changes, please prefix the title of your pull request with "[BREAKING_CHANGES]". This allows for clear identification of such changes in the 'What's Changed' section on the release page, making it developer-friendly.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.

**Describe the change**
Please provide a clear and concise description of the changes you're proposing. Explain what problem it solves or what feature it adds.

**Provide OpenAI documentation link**
Provide a relevant API doc from https://platform.openai.com/docs/api-reference

**Describe your solution**
Describe how your changes address the problem or how they add the feature. This should include a brief description of your approach and any new libraries or dependencies you're using.

**Tests**
Briefly describe how you have tested these changes. If possible — please add integration tests.

**Additional context**
Add any other context or screenshots or logs about your pull request here. If the pull request relates to an open issue, please link to it.

Issue: #XXXX
