### PR TITLE
Add tool_choice, response_format, and top_p to assistant RunRequest

### DIFF
--- a/run.go
+++ b/run.go
@@ -92,6 +92,7 @@ type RunRequest struct {
 	// Sampling temperature between 0 and 2. Higher values like 0.8 are  more random.
 	// lower values are more focused and deterministic.
 	Temperature *float32 `json:"temperature,omitempty"`
+	TopP        *float32 `json:"top_p,omitempty"`
 
 	// The maximum number of prompt tokens that may be used over the course of the run.
 	// If the run exceeds the number of prompt tokens specified, the run will end with status 'complete'.
@@ -103,6 +104,11 @@ type RunRequest struct {
 
 	// ThreadTruncationStrategy defines the truncation strategy to use for the thread.
 	TruncationStrategy *ThreadTruncationStrategy `json:"truncation_strategy,omitempty"`
+
+	// This can be either a string or a ToolChoice object.
+	ToolChoice any `json:"tool_choice,omitempty"`
+	// This can be either a string or a ResponseFormat object.
+	ResponseFormat any `json:"response_format,omitempty"`
 }
 
 // ThreadTruncationStrategy defines the truncation strategy to use for the thread.
@@ -123,6 +129,13 @@ const (
 	// TruncationStrategyLastMessages the thread will be truncated to the n most recent messages in the thread.
 	TruncationStrategyLastMessages = TruncationStrategy("last_messages")
 )
+
+// ReponseFormat specifies the format the model must output.
+// https://platform.openai.com/docs/api-reference/runs/createRun#runs-createrun-response_format.
+// Type can either be text or json_object.
+type ReponseFormat struct {
+	Type string `json:"type"`
+}
 
 type RunModifyRequest struct {
 	Metadata map[string]any `json:"metadata,omitempty"`


### PR DESCRIPTION

**Describe the change**
Adds the `tool_choice`, `response_format`, and `top_p` params to the `RunRequest` object to match AssistantsV2 
https://platform.openai.com/docs/assistants/whats-new
These all don't require any additional implementation. Left out the stream option since that is not yet supported. 

**Provide OpenAI documentation link**
https://platform.openai.com/docs/api-reference/runs/createRun

**Describe your solution**
This just adds the fields to the struct so that they can be passed in the request body. These are just extra params that are ignored when passed to Assistants V1. So they should be safe to add.

**Tests**
Unit tests run successfully. 
Getting the following error when running the integration tests
```
    api_integration_test.go:86: error, status code: 404, message: The model `ada` has been deprecated, learn more here: https://platform.openai.com/docs/deprecations [
CreateCompletionStream returned error]
--- FAIL: TestAPI (2.53s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6a7cf4]
```
But this seems unrelated to my change since these tests are not invoking the assistants api. LMK if this test failure is a user error.

I did test making a request with both Assistants V1 and V2 and both worked.

Issue: #753 
