### PR TITLE
Add incomplete run status

### DIFF
--- a/run.go
+++ b/run.go
@@ -30,10 +30,10 @@ type Run struct {
 
 	Temperature *float32 `json:"temperature,omitempty"`
 	// The maximum number of prompt tokens that may be used over the course of the run.
-	// If the run exceeds the number of prompt tokens specified, the run will end with status 'complete'.
+	// If the run exceeds the number of prompt tokens specified, the run will end with status 'incomplete'.
 	MaxPromptTokens int `json:"max_prompt_tokens,omitempty"`
 	// The maximum number of completion tokens that may be used over the course of the run.
-	// If the run exceeds the number of completion tokens specified, the run will end with status 'complete'.
+	// If the run exceeds the number of completion tokens specified, the run will end with status 'incomplete'.
 	MaxCompletionTokens int `json:"max_completion_tokens,omitempty"`
 	// ThreadTruncationStrategy defines the truncation strategy to use for the thread.
 	TruncationStrategy *ThreadTruncationStrategy `json:"truncation_strategy,omitempty"`
@@ -50,6 +50,7 @@ const (
 	RunStatusCancelling     RunStatus = "cancelling"
 	RunStatusFailed         RunStatus = "failed"
 	RunStatusCompleted      RunStatus = "completed"
+	RunStatusIncomplete     RunStatus = "incomplete"
 	RunStatusExpired        RunStatus = "expired"
 	RunStatusCancelled      RunStatus = "cancelled"
 )
@@ -95,11 +96,11 @@ type RunRequest struct {
 	TopP        *float32 `json:"top_p,omitempty"`
 
 	// The maximum number of prompt tokens that may be used over the course of the run.
-	// If the run exceeds the number of prompt tokens specified, the run will end with status 'complete'.
+	// If the run exceeds the number of prompt tokens specified, the run will end with status 'incomplete'.
 	MaxPromptTokens int `json:"max_prompt_tokens,omitempty"`
 
 	// The maximum number of completion tokens that may be used over the course of the run.
-	// If the run exceeds the number of completion tokens specified, the run will end with status 'complete'.
+	// If the run exceeds the number of completion tokens specified, the run will end with status 'incomplete'.
 	MaxCompletionTokens int `json:"max_completion_tokens,omitempty"`
 
 	// ThreadTruncationStrategy defines the truncation strategy to use for the thread.


### PR DESCRIPTION
### Description
This PR adds the missing `incomplete` run status to the code, which is defined in the OpenAI documentation but was not present in the codebase.

Additionally, I corrected discrepancies between the documentation and the code for the explanations of MaxPromptTokens and MaxCompletionTokens.

### References
[OpenAI Documentation on Run Lifecycle](https://platform.openai.com/docs/assistants/how-it-works/run-lifecycle)