### PR TITLE
Added tools and tool_resources to Assistant and ThreadRequest structures

### DIFF
--- a/assistant.go
+++ b/assistant.go
@@ -13,17 +13,29 @@ const (
 	assistantsFilesSuffix = "/files"
 )
 
+type FileSearchResource struct {
+	VectorStoreIds []string `json:"vector_store_ids"`
+}
+type FileIdResource struct {
+	FileIds []string `json:"file_ids,omitempty"`
+}
+type ToolResource struct {
+	FileSearch      FileSearchResource `json:"file_search,omitempty"`
+	CodeInterpreter FileIdResource     `json:"code_interpreter,omitempty"`
+}
+
 type Assistant struct {
-	ID           string          `json:"id"`
-	Object       string          `json:"object"`
-	CreatedAt    int64           `json:"created_at"`
-	Name         *string         `json:"name,omitempty"`
-	Description  *string         `json:"description,omitempty"`
-	Model        string          `json:"model"`
-	Instructions *string         `json:"instructions,omitempty"`
-	Tools        []AssistantTool `json:"tools"`
-	FileIDs      []string        `json:"file_ids,omitempty"`
-	Metadata     map[string]any  `json:"metadata,omitempty"`
+	ID            string          `json:"id"`
+	Object        string          `json:"object"`
+	CreatedAt     int64           `json:"created_at"`
+	Name          *string         `json:"name,omitempty"`
+	Description   *string         `json:"description,omitempty"`
+	Model         string          `json:"model"`
+	Instructions  *string         `json:"instructions,omitempty"`
+	Tools         []AssistantTool `json:"tools"`
+	ToolResources ToolResource    `json:"tool_resources"`
+	FileIDs       []string        `json:"file_ids,omitempty"`
+	Metadata      map[string]any  `json:"metadata,omitempty"`
 
 	httpHeader
 }
@@ -34,6 +46,7 @@ const (
 	AssistantToolTypeCodeInterpreter AssistantToolType = "code_interpreter"
 	AssistantToolTypeRetrieval       AssistantToolType = "retrieval"
 	AssistantToolTypeFunction        AssistantToolType = "function"
+	AssistantToolTypeFileSearch      AssistantToolType = "file_search"
 )
 
 type AssistantTool struct {

--- a/thread.go
+++ b/thread.go
@@ -14,13 +14,14 @@ type Thread struct {
 	Object    string         `json:"object"`
 	CreatedAt int64          `json:"created_at"`
 	Metadata  map[string]any `json:"metadata"`
-
 	httpHeader
 }
 
 type ThreadRequest struct {
-	Messages []ThreadMessage `json:"messages,omitempty"`
-	Metadata map[string]any  `json:"metadata,omitempty"`
+	Messages      []ThreadMessage `json:"messages,omitempty"`
+	Metadata      map[string]any  `json:"metadata,omitempty"`
+	Tools         []AssistantTool `json:"tools,omitempty"`
+	ToolResources ToolResource    `json:"tool_resources,omitempty"`
 }
 
 type ModifyThreadRequest struct {


### PR DESCRIPTION
Assistants have changed in V2 version need to adjust accordingly. Link for docs is below

We are migrating assistants from v1 to v2 and have files associated with them. When we switched OpenAI was returning error saying there are no files associated with the assistant. V2 version takes to files little differently 
 

A similar PR may already be submitted!
Please search among the [Pull request](https://github.com/sashabaranov/go-openai/pulls) before creating one.
I did not find any existing PR for this 

**Describe the change**
The change add Tools and ToolResources to ThreadRequest structure and ToolResources to Assistant structure. With this when you retrieve assistant you get tool resource and you can pass that along when you create a thread. Without this you can not create threads and OpenAI returns error saying tool_resources.code_interpreter.file_ids is required 

**Provide OpenAI documentation link**
https://platform.openai.com/docs/assistants/migration

**Describe your solution**
Solution is simple to update the response definitions for v2 version of the assistant. .

**Tests**
Did not add any tests. Ran current tests and they seem to be working fine

**Additional context**
Here is how we use it.

```golang
	config := openai.DefaultConfig(token)
	config.AssistantVersion = "v2"
	client := openai.NewClientWithConfig(config)
	assistant, err := client.RetrieveAssistant(ctx, assistantName)
	if err != nil {
		return result, err
	}
	log.Printf("found assistant: %v", assistant)
        thread, err := client.CreateThread(ctx, openai.ThreadRequest{ToolResources: assistant.ToolResources})
        if err != nil {
                return result, err
        }
```
        
Issue: #XXXX
