### PR TITLE
Openai Supported AI Providers [fireworks.ai]

### DIFF
--- a/embeddings.go
+++ b/embeddings.go
@@ -155,7 +155,7 @@ const (
 type EmbeddingRequest struct {
 	Input          any                     `json:"input"`
 	Model          EmbeddingModel          `json:"model"`
-	User           string                  `json:"user"`
+	User           string                  `json:"user,omitempty"`
 	EncodingFormat EmbeddingEncodingFormat `json:"encoding_format,omitempty"`
 	// Dimensions The number of dimensions the resulting output embeddings should have.
 	// Only supported in text-embedding-3 and later models.
@@ -179,7 +179,7 @@ type EmbeddingRequestStrings struct {
 	// or see our Model overview for descriptions of them.
 	Model EmbeddingModel `json:"model"`
 	// A unique identifier representing your end-user, which will help OpenAI to monitor and detect abuse.
-	User string `json:"user"`
+	User string `json:"user,omitempty"`
 	// EmbeddingEncodingFormat is the format of the embeddings data.
 	// Currently, only "float" and "base64" are supported, however, "base64" is not officially documented.
 	// If not specified OpenAI will use "float".
@@ -211,7 +211,7 @@ type EmbeddingRequestTokens struct {
 	// or see our Model overview for descriptions of them.
 	Model EmbeddingModel `json:"model"`
 	// A unique identifier representing your end-user, which will help OpenAI to monitor and detect abuse.
-	User string `json:"user"`
+	User string `json:"user,omitempty"`
 	// EmbeddingEncodingFormat is the format of the embeddings data.
 	// Currently, only "float" and "base64" are supported, however, "base64" is not officially documented.
 	// If not specified OpenAI will use "float".


### PR DESCRIPTION
**Describe the change**

I was testing **fireworks AI** to create the embedding, and it threw an error due to an extra parameter (`user`) being included in the request body even when it was an empty string. This PR modifies the code to ensure the `user` parameter is omitted when it is empty, aligning with fireworks AI's requirements.

**Provide OpenAI documentation link**

Relevant API documentation can be found [here](https://platform.openai.com/docs/api-reference/embeddings/create).

**Describe your solution**

The solution involves adding the `omitempty` JSON tag to the `user` field in the `EmbeddingRequest` struct. This ensures that if the `user` field is empty, it will not be included in the JSON payload sent to the API. This change allows the request to be accepted by fireworks AI without triggering an error due to an empty `user` field.

**Tests**

I tested the change by making a request to the fireworks AI API using the modified code and verified that the request was successful. The test involved creating an embedding with the following details:

```json
{
  "input": ["hi satya"],
  "model": "nomic-ai/nomic-embed-text-v1.5",
  "encoding_format": "float",
  "dimensions": 100
}
```


**Additional context**

Example error response before the fix:

```bash
curl --request POST \
  --url https://api.fireworks.ai/inference/v1/embeddings \
  --header 'accept: application/json' \
  --header 'authorization: Bearer token' \
  --header 'content-type: application/json' \
  --data '{
	"input": [
		"hi satya"
	],
	"model": "nomic-ai/nomic-embed-text-v1.5",
	"encoding_format": "float",
	"dimensions": 10,
	"user": ""
}'
```

```json
{
  "error": {
    "object": "error",
    "type": "internal_server_error",
    "message": "server had an error while processing your request, please retry again after a brief wait"
  },
  "raw_output": null
}

```

<img width="1074" alt="Screenshot 2024-06-27 at 1 50 58 AM" src="https://github.com/sashabaranov/go-openai/assets/59475944/5f6da124-f14f-4658-8fea-f5a8f01e633d">
<img width="1322" alt="Screenshot 2024-06-27 at 1 51 46 AM" src="https://github.com/sashabaranov/go-openai/assets/59475944/267cd2a5-c696-4618-9850-322a471d74ff">


**Example successful response after the fix:**

```bash
curl --request POST \
  --url https://api.fireworks.ai/inference/v1/embeddings \
  --header 'accept: application/json' \
  --header 'authorization: Bearer token' \
  --header 'content-type: application/json' \
  --data '{
	"input": [
		"hi satya"
	],
	"model": "nomic-ai/nomic-embed-text-v1.5",
	"encoding_format": "float",
	"dimensions": 10
}'
```

```json
{
  "data": [
    {
      "index": 0,
      "embedding": [
        -0.1552734375,
        0.09490966796875,
        -0.90283203125,
        0.1776123046875,
        0.11700439453125,
        -0.00719451904296875,
        -0.119873046875,
        -0.1888427734375,
        -0.22216796875,
        0.08270263671875
      ],
      "object": "embedding"
    }
  ],
  "model": "nomic-ai/nomic-embed-text-v1.5",
  "object": "list",
  "usage": {
    "prompt_tokens": 3,
    "total_tokens": 3
  }
}

```

<img width="1332" alt="Screenshot 2024-06-27 at 1 52 14 AM" src="https://github.com/sashabaranov/go-openai/assets/59475944/050cd0f8-d44f-4c06-9c0c-9f3d0274e000">
<img width="1074" alt="Screenshot 2024-06-27 at 1 53 03 AM" src="https://github.com/sashabaranov/go-openai/assets/59475944/7927fe8a-ef17-4d57-a0b7-19e969c55d71">

**go code**

```go
package main

import (
	"context"
	"log"

	openai "github.com/sashabaranov/go-openai"
)

func main() {

	config := openai.DefaultConfig("token")
	config.BaseURL = "https://api.fireworks.ai/inference/v1"

	openaiClient := openai.NewClientWithConfig(config)

	resp, err := openaiClient.CreateEmbeddings(context.Background(), openai.EmbeddingRequest{
		Dimensions:     100,
		Model:          openai.EmbeddingModel("nomic-ai/nomic-embed-text-v1.5"),
		Input:          []string{"hi satya"},
		EncodingFormat: openai.EmbeddingEncodingFormatFloat,
	})

	if err != nil {
		log.Fatal("Error creating target embedding:", err)
	} else {
		log.Println("-->", resp.Data)
	}
}

```
