### PR TITLE
feat: ParallelToolCalls to ChatCompletionRequest with helper functions

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -218,6 +218,18 @@ type ChatCompletionRequest struct {
 	ToolChoice any `json:"tool_choice,omitempty"`
 	// Options for streaming response. Only set this when you set stream: true.
 	StreamOptions *StreamOptions `json:"stream_options,omitempty"`
+	// Disable the default behavior of parallel tool calls.
+	ParallelToolCalls *bool `json:"parallel_tool_calls,omitempty"`
+}
+
+func ParallelOptionFalse() *bool {
+	b := false
+	return &b
+}
+
+func ParallelOptionTrue() *bool {
+	b := true
+	return &b
 }
 
 type StreamOptions struct {

--- a/chat.go
+++ b/chat.go
@@ -218,18 +218,8 @@ type ChatCompletionRequest struct {
 	ToolChoice any `json:"tool_choice,omitempty"`
 	// Options for streaming response. Only set this when you set stream: true.
 	StreamOptions *StreamOptions `json:"stream_options,omitempty"`
-	// Disable the default behavior of parallel tool calls.
-	ParallelToolCalls *bool `json:"parallel_tool_calls,omitempty"`
-}
-
-func ParallelOptionFalse() *bool {
-	b := false
-	return &b
-}
-
-func ParallelOptionTrue() *bool {
-	b := true
-	return &b
+	// Disable the default behavior of parallel tool calls by setting it: false.
+	ParallelToolCalls any `json:"parallel_tool_calls,omitempty"`
 }
 
 type StreamOptions struct {

--- a/chat_test.go
+++ b/chat_test.go
@@ -527,3 +527,21 @@ func TestFinishReason(t *testing.T) {
 		}
 	}
 }
+
+func TestParallelOption(t *testing.T) {
+	ccr := openai.ChatCompletionRequest{}
+
+	if ccr.ParallelToolCalls != nil {
+		t.Error("ParallelToolCalls should be default")
+	}
+	ccr.ParallelToolCalls = openai.ParallelOptionFalse()
+
+	if *ccr.ParallelToolCalls != false {
+		t.Error("ParallelToolCalls should be false")
+	}
+
+	ccr.ParallelToolCalls = openai.ParallelOptionTrue()
+	if *ccr.ParallelToolCalls != true {
+		t.Error("ParallelToolCalls should be true")
+	}
+}

--- a/chat_test.go
+++ b/chat_test.go
@@ -527,21 +527,3 @@ func TestFinishReason(t *testing.T) {
 		}
 	}
 }
-
-func TestParallelOption(t *testing.T) {
-	ccr := openai.ChatCompletionRequest{}
-
-	if ccr.ParallelToolCalls != nil {
-		t.Error("ParallelToolCalls should be default")
-	}
-	ccr.ParallelToolCalls = openai.ParallelOptionFalse()
-
-	if *ccr.ParallelToolCalls != false {
-		t.Error("ParallelToolCalls should be false")
-	}
-
-	ccr.ParallelToolCalls = openai.ParallelOptionTrue()
-	if *ccr.ParallelToolCalls != true {
-		t.Error("ParallelToolCalls should be true")
-	}
-}


### PR DESCRIPTION
**Describe the change**
Openai has by default a `parallel_tool_calls` set to true, which allows the llm to make multiple tool calls in one response.

This can be opted out of with setting it to false, and ensures the llm only responds with one tool call at a time.

**Provide OpenAI documentation link**
https://platform.openai.com/docs/guides/function-calling/parallel-function-calling

**Describe your solution**
We only need to set the field to false, and true for being certain it is true, we can not just use a `bool` type.
As that would require a custom marshaller for not including it when not set.

I think a `*bool` works oke here, it is a bit annoying to set a `*bool` value. Which is why the helper functions have been given: `ParallelOptionFalse()` and `ParallelOptionTrue()`.

Intended use:
```go
request := openai.ChatCompletionRequest{}
request.Model = completeChatModel
	
request.ParallelToolCalls = openai.ParallelOptionFalse()	
```

This seemed the best option without resorting to custom types with custom marshallers, or creating a custom marshal for `ChatCompletionRequest`

**Tests**
Currently using a version with `bool` type and no `omitempty` which has stopped gpt responding with multiple function calls.
