### PR TITLE
fix: Updated ThreadMessage struct with latest fields based on OpenAI docs

### DIFF
--- a/thread.go
+++ b/thread.go
@@ -83,14 +83,24 @@ type ModifyThreadRequest struct {
 type ThreadMessageRole string
 
 const (
-	ThreadMessageRoleUser ThreadMessageRole = "user"
+	ThreadMessageRoleAssistant ThreadMessageRole = "assistant"
+	ThreadMessageRoleUser      ThreadMessageRole = "user"
 )
 
 type ThreadMessage struct {
-	Role     ThreadMessageRole `json:"role"`
-	Content  string            `json:"content"`
-	FileIDs  []string          `json:"file_ids,omitempty"`
-	Metadata map[string]any    `json:"metadata,omitempty"`
+	Role        ThreadMessageRole  `json:"role"`
+	Content     string             `json:"content"`
+	Attachments []ThreadAttachment `json:"attachments,omitempty"`
+	Metadata    map[string]any     `json:"metadata,omitempty"`
+}
+
+type ThreadAttachment struct {
+	FileID string                 `json:"file_id"`
+	Tools  []ThreadAttachmentTool `json:"tools"`
+}
+
+type ThreadAttachmentTool struct {
+	Type string `json:"type"`
 }
 
 type ThreadDeleteResponse struct {

--- a/thread.go
+++ b/thread.go
@@ -90,6 +90,7 @@ const (
 type ThreadMessage struct {
 	Role        ThreadMessageRole  `json:"role"`
 	Content     string             `json:"content"`
+	FileIDs     []string           `json:"file_ids,omitempty"`
 	Attachments []ThreadAttachment `json:"attachments,omitempty"`
 	Metadata    map[string]any     `json:"metadata,omitempty"`
 }


### PR DESCRIPTION
**Describe the change**
ThreadMessage has deprecated fields, and new fields are missing, so requests with files cannot be made.

**Provide OpenAI documentation link**
https://platform.openai.com/docs/api-reference/threads/createThread

**Describe your solution**
Updated ThreadMessage based on OpenAI docs.
