### PR TITLE
add finetuning hyperparams

### DIFF
--- a/fine_tuning_job.go
+++ b/fine_tuning_job.go
@@ -26,7 +26,9 @@ type FineTuningJob struct {
 }
 
 type Hyperparameters struct {
-	Epochs any `json:"n_epochs,omitempty"`
+	Epochs                 any `json:"n_epochs,omitempty"`
+	LearningRateMultiplier any `json:"learning_rate_multiplier,omitempty"`
+	BatchSize              any `json:"batch_size,omitempty"`
 }
 
 type FineTuningJobRequest struct {

--- a/fine_tuning_job_test.go
+++ b/fine_tuning_job_test.go
@@ -33,7 +33,9 @@ func TestFineTuningJob(t *testing.T) {
 				ValidationFile: "",
 				TrainingFile:   "file-abc123",
 				Hyperparameters: openai.Hyperparameters{
-					Epochs: "auto",
+					Epochs:                 "auto",
+					LearningRateMultiplier: "auto",
+					BatchSize:              "auto",
 				},
 				TrainedTokens: 5768,
 			})


### PR DESCRIPTION
Adds `learning_rate_multiplier` and `batch_size` parameters.

Supported by both OpenAI and Azure, see:
* https://platform.openai.com/docs/api-reference/fine-tuning/create
* https://learn.microsoft.com/en-us/rest/api/azureopenai/fine-tuning/create?view=rest-azureopenai-2024-03-01-preview&tabs=HTTP#finetuninghyperparameters
