### PR TITLE
Add New Optional Parameters to `AssistantRequest` Struct

### DIFF
--- a/assistant.go
+++ b/assistant.go
@@ -62,17 +62,17 @@ type AssistantToolResource struct {
 // If Tools is empty slice it will effectively delete all of the Assistant's tools.
 // If Tools is populated, it will replace all of the existing Assistant's tools with the provided tools.
 type AssistantRequest struct {
-	Model         string                 `json:"model"`
-	Name          *string                `json:"name,omitempty"`
-	Description   *string                `json:"description,omitempty"`
-	Instructions  *string                `json:"instructions,omitempty"`
-	Tools         []AssistantTool        `json:"-"`
-	FileIDs       []string               `json:"file_ids,omitempty"`
-	Metadata      map[string]any         `json:"metadata,omitempty"`
-	ToolResources *AssistantToolResource `json:"tool_resources,omitempty"`
-	ResponseFormat any 					 `json:"response_format,omitempty"`
-	Temperature *float32 				 `json:"temperature,omitempty"`
-	TopP        *float32 				 `json:"top_p,omitempty"`
+	Model          string                 `json:"model"`
+	Name           *string                `json:"name,omitempty"`
+	Description    *string                `json:"description,omitempty"`
+	Instructions   *string                `json:"instructions,omitempty"`
+	Tools          []AssistantTool        `json:"-"`
+	FileIDs        []string               `json:"file_ids,omitempty"`
+	Metadata       map[string]any         `json:"metadata,omitempty"`
+	ToolResources  *AssistantToolResource `json:"tool_resources,omitempty"`
+	ResponseFormat any                    `json:"response_format,omitempty"`
+	Temperature    *float32               `json:"temperature,omitempty"`
+	TopP           *float32               `json:"top_p,omitempty"`
 }
 
 // MarshalJSON provides a custom marshaller for the assistant request to handle the API use cases

--- a/assistant.go
+++ b/assistant.go
@@ -70,6 +70,9 @@ type AssistantRequest struct {
 	FileIDs       []string               `json:"file_ids,omitempty"`
 	Metadata      map[string]any         `json:"metadata,omitempty"`
 	ToolResources *AssistantToolResource `json:"tool_resources,omitempty"`
+	ResponseFormat any 					 `json:"response_format,omitempty"`
+	Temperature *float32 				 `json:"temperature,omitempty"`
+	TopP        *float32 				 `json:"top_p,omitempty"`
 }
 
 // MarshalJSON provides a custom marshaller for the assistant request to handle the API use cases


### PR DESCRIPTION
## Add New Optional Parameters to `AssistantRequest` Struct

This update introduces three new optional parameters to the `AssistantRequest` struct: `ResponseFormat`, `Temperature`, and `TopP`. These parameters provide additional control over the output format and sampling behavior of the OpenAI assistant, enhancing its flexibility and usability.

### OpenAI Documentation Link

For detailed information about these parameters, please refer to the OpenAI API documentation: [OpenAI API Reference](https://platform.openai.com/docs/api-reference/assistants/object)

### Solution Description

The solution involves extending the `AssistantRequest` struct to include the following fields:

- `ResponseFormat any`: Specifies the format that the model must output. Example: setting this to `{ "type": "json_object" }` ensures the model generates valid JSON. but it can also be a string format for 'auto'
- `Temperature *float32`: Determines the sampling temperature. 
- `TopP *float32`: Defines the nucleus sampling parameter.

These additions enable users to specify advanced settings for response generation, aligning the API with the latest OpenAI features.

### Struct Definition

Here is the updated `AssistantRequest` struct with the new fields included:

```go
type AssistantRequest struct {
    Model         string                 `json:"model"`
    Name          *string                `json:"name,omitempty"`
    Description   *string                `json:"description,omitempty"`
    Instructions  *string                `json:"instructions,omitempty"`
    Tools         []AssistantTool        `json:"-"`
    FileIDs       []string               `json:"file_ids,omitempty"`
    Metadata      map[string]any         `json:"metadata,omitempty"`
    ToolResources *AssistantToolResource `json:"tool_resources,omitempty"`
    ResponseFormat any                   `json:"response_format,omitempty"`
    Temperature   *float32               `json:"temperature,omitempty"`
    TopP          *float32               `json:"top_p,omitempty"`
}
