### PR TITLE
feat: Support Delete Message API

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -348,6 +348,9 @@ func TestClientReturnsRequestBuilderErrors(t *testing.T) {
 		{"ModifyMessage", func() (any, error) {
 			return client.ModifyMessage(ctx, "", "", nil)
 		}},
+		{"DeleteMessage", func() (any, error) {
+			return client.DeleteMessage(ctx, "", "")
+		}},
 		{"RetrieveMessageFile", func() (any, error) {
 			return client.RetrieveMessageFile(ctx, "", "", "")
 		}},

--- a/fine_tunes.go
+++ b/fine_tunes.go
@@ -115,7 +115,7 @@ func (c *Client) CreateFineTune(ctx context.Context, request FineTuneRequest) (r
 // This API will be officially deprecated on January 4th, 2024.
 // OpenAI recommends to migrate to the new fine tuning API implemented in fine_tuning_job.go.
 func (c *Client) CancelFineTune(ctx context.Context, fineTuneID string) (response FineTune, err error) {
-	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL("/fine-tunes/"+fineTuneID+"/cancel"))
+	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL("/fine-tunes/"+fineTuneID+"/cancel")) //nolint:lll //this method is deprecated
 	if err != nil {
 		return
 	}

--- a/messages.go
+++ b/messages.go
@@ -73,6 +73,14 @@ type MessageFilesList struct {
 	httpHeader
 }
 
+type MessageDeletionStatus struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Deleted bool   `json:"deleted"`
+
+	httpHeader
+}
+
 // CreateMessage creates a new message.
 func (c *Client) CreateMessage(ctx context.Context, threadID string, request MessageRequest) (msg Message, err error) {
 	urlSuffix := fmt.Sprintf("/threads/%s/%s", threadID, messagesSuffix)
@@ -184,5 +192,21 @@ func (c *Client) ListMessageFiles(
 	}
 
 	err = c.sendRequest(req, &files)
+	return
+}
+
+// DeleteMessage deletes a message..
+func (c *Client) DeleteMessage(
+	ctx context.Context,
+	threadID, messageID string,
+) (status MessageDeletionStatus, err error) {
+	urlSuffix := fmt.Sprintf("/threads/%s/%s/%s", threadID, messagesSuffix, messageID)
+	req, err := c.newRequest(ctx, http.MethodDelete, c.fullURL(urlSuffix),
+		withBetaAssistantVersion(c.config.AssistantVersion))
+	if err != nil {
+		return
+	}
+
+	err = c.sendRequest(req, &status)
 	return
 }

--- a/messages_test.go
+++ b/messages_test.go
@@ -8,19 +8,16 @@ import (
 	"testing"
 
 	"github.com/sashabaranov/go-openai"
+	"github.com/sashabaranov/go-openai/internal/test"
 	"github.com/sashabaranov/go-openai/internal/test/checks"
 )
 
 var emptyStr = ""
 
-// TestMessages Tests the messages endpoint of the API using the mocked server.
-func TestMessages(t *testing.T) {
+func registerServer(t *testing.T, server *test.ServerTest) {
 	threadID := "thread_abc123"
 	messageID := "msg_abc123"
 	fileID := "file_abc123"
-
-	client, server, teardown := setupOpenAITestServer()
-	defer teardown()
 
 	server.RegisterHandler(
 		"/v1/threads/"+threadID+"/messages/"+messageID+"/files/"+fileID,
@@ -183,7 +180,18 @@ func TestMessages(t *testing.T) {
 			}
 		},
 	)
+}
 
+// TestMessages Tests the messages endpoint of the API using the mocked server.
+func TestMessages(t *testing.T) {
+	threadID := "thread_abc123"
+	messageID := "msg_abc123"
+	fileID := "file_abc123"
+
+	client, server, teardown := setupOpenAITestServer()
+	defer teardown()
+
+	registerServer(t, server)
 	ctx := context.Background()
 
 	// static assertion of return type

--- a/messages_test.go
+++ b/messages_test.go
@@ -14,7 +14,7 @@ import (
 
 var emptyStr = ""
 
-func registerServer(t *testing.T, server *test.ServerTest) {
+func setupServerForTestMessage(t *testing.T, server *test.ServerTest) {
 	threadID := "thread_abc123"
 	messageID := "msg_abc123"
 	fileID := "file_abc123"
@@ -191,7 +191,7 @@ func TestMessages(t *testing.T) {
 	client, server, teardown := setupOpenAITestServer()
 	defer teardown()
 
-	registerServer(t, server)
+	setupServerForTestMessage(t, server)
 	ctx := context.Background()
 
 	// static assertion of return type


### PR DESCRIPTION
# Describe the change
- support Delete Message API
- No breaking changes

# OpenAI documentation 
relevant API doc from https://platform.openai.com/docs/api-reference/messages/deleteMessage


# Additional context
- fix lint