### PR TITLE
Make reponse format JSONSchema optional

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -182,8 +182,8 @@ const (
 )
 
 type ChatCompletionResponseFormat struct {
-	Type       ChatCompletionResponseFormatType       `json:"type,omitempty"`
-	JSONSchema ChatCompletionResponseFormatJSONSchema `json:"json_schema,omitempty"`
+	Type       ChatCompletionResponseFormatType        `json:"type,omitempty"`
+	JSONSchema *ChatCompletionResponseFormatJSONSchema `json:"json_schema,omitempty"`
 }
 
 type ChatCompletionResponseFormatJSONSchema struct {


### PR DESCRIPTION
**Describe the change**
This morning's PR #813 makes it impossible to do ChatCompletionRequest that doesn't supply a json schema.


**Describe your solution**
I followed the suggestion in #818, changing the JSONSchema attached to a request format object to a pointer type, so that the JSON marshaler can properly exclude it when not provided.

**Tests**
I ran the go tests.  (did you guys know you have a bunch of broken tests in the repo?)
All tests pass except for the ones in the jsonschema directory.  Those tests were broken both before and after my changes.

I updated my own software to use my fork, and everything works.


Issue: #818
