### PR TITLE
[BREAKING_CHANGES] fix: support ThreadMessage.Content as an array

### DIFF
--- a/run_test.go
+++ b/run_test.go
@@ -204,6 +204,7 @@ func TestRun(t *testing.T) {
 	_, err = client.CancelRun(ctx, threadID, runID)
 	checks.NoError(t, err, "CancelRun error")
 
+	prompt := "Hello, World!"
 	_, err = client.CreateThreadAndRun(ctx, openai.CreateThreadAndRunRequest{
 		RunRequest: openai.RunRequest{
 			AssistantID: assistantID,
@@ -211,8 +212,13 @@ func TestRun(t *testing.T) {
 		Thread: openai.ThreadRequest{
 			Messages: []openai.ThreadMessage{
 				{
-					Role:    openai.ThreadMessageRoleUser,
-					Content: "Hello, World!",
+					Role: openai.ThreadMessageRoleUser,
+					Content: []openai.ThreadMessageContent{
+						{
+							Type: "text",
+							Text: prompt,
+						},
+					},
 				},
 			},
 		},

--- a/thread.go
+++ b/thread.go
@@ -88,11 +88,21 @@ const (
 )
 
 type ThreadMessage struct {
-	Role        ThreadMessageRole  `json:"role"`
-	Content     string             `json:"content"`
-	FileIDs     []string           `json:"file_ids,omitempty"`
-	Attachments []ThreadAttachment `json:"attachments,omitempty"`
-	Metadata    map[string]any     `json:"metadata,omitempty"`
+	Role        ThreadMessageRole      `json:"role"`
+	Content     []ThreadMessageContent `json:"content"`
+	Attachments []ThreadAttachment     `json:"attachments,omitempty"`
+	Metadata    map[string]any         `json:"metadata,omitempty"`
+}
+
+type ThreadMessageContent struct {
+	Type      string                  `json:"type"`
+	ImageFile *ThreadMessageImageFile `json:"image_file,omitempty"`
+	Text      string                  `json:"text,omitempty"`
+}
+
+type ThreadMessageImageFile struct {
+	FileID string  `json:"file_id"`
+	Detail *string `json:"detail,omitempty"`
 }
 
 type ThreadAttachment struct {

--- a/thread_test.go
+++ b/thread_test.go
@@ -70,11 +70,17 @@ func TestThread(t *testing.T) {
 
 	ctx := context.Background()
 
+	prompt := "Hello, World!"
 	_, err := client.CreateThread(ctx, openai.ThreadRequest{
 		Messages: []openai.ThreadMessage{
 			{
-				Role:    openai.ThreadMessageRoleUser,
-				Content: "Hello, World!",
+				Role: openai.ThreadMessageRoleUser,
+				Content: []openai.ThreadMessageContent{
+					{
+						Type: "text",
+						Text: prompt,
+					},
+				},
 			},
 		},
 	})
@@ -153,11 +159,17 @@ func TestAzureThread(t *testing.T) {
 
 	ctx := context.Background()
 
+	prompt := "Hello, World!"
 	_, err := client.CreateThread(ctx, openai.ThreadRequest{
 		Messages: []openai.ThreadMessage{
 			{
-				Role:    openai.ThreadMessageRoleUser,
-				Content: "Hello, World!",
+				Role: openai.ThreadMessageRoleUser,
+				Content: []openai.ThreadMessageContent{
+					{
+						Type: "text",
+						Text: prompt,
+					},
+				},
 			},
 		},
 	})


### PR DESCRIPTION
**Describe the change**
FileIDs on ThreadMessage isn't supported anymore, but Content can be an array.

**Provide OpenAI documentation link**
https://platform.openai.com/docs/api-reference/threads/createThread

**Describe your solution**
Remove old fields and update existing ones to support current OpenAI endpoints.

**Tests**
I've verified this allows me to upload an image and prompt in a thread (ran under an assistant). 

Here's the snippet of code that creates the thread. 

```go
	thread, err := c.underlying.CreateThread(ctx, openaiclient.ThreadRequest{
		Messages: []openaiclient.ThreadMessage{
			{
				Role: openaiclient.ThreadMessageRoleUser,
				Content: []openaiclient.ThreadMessageContent{
					{
						Type: "image_file",
						ImageFile: &openaiclient.ThreadMessageImageFile{
							FileID: file.ID,
						},
					},
					{
						Type: "text",
						Text: &prompt,
					},
				},
			},
		},
	})
```

Fixes: https://github.com/sashabaranov/go-openai/issues/773
