### PR TITLE
add strict parameter to function definition

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -269,7 +269,8 @@ type FunctionDefinition struct {
 	// or you can pass in a struct which serializes to the proper JSON schema.
 	// The jsonschema package is provided for convenience, but you should
 	// consider another specialized library if you require more complex schemas.
-	Parameters any `json:"parameters"`
+	Parameters any  `json:"parameters"`
+	Strict     bool `json:"strict"`
 }
 
 // Deprecated: use FunctionDefinition instead.


### PR DESCRIPTION
**Describe the change**
This supports the "function calling" aspect of https://openai.com/index/introducing-structured-outputs-in-the-api/

Other PRs address the response_format part, but I haven't seen one for this yet?

**Provide OpenAI documentation link**
https://openai.com/index/introducing-structured-outputs-in-the-api/
https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools

**Describe your solution**
This seems like a dead simple change, unless I'm missing something?

https://github.com/sashabaranov/go-openai/issues/814