### PR TITLE
Allow structured outputs via function calling

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -264,6 +264,7 @@ type ToolFunction struct {
 type FunctionDefinition struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
+	Strict      bool   `json:"strict,omitempty"`
 	// Parameters is an object describing the function.
 	// You can pass json.RawMessage to describe the schema,
 	// or you can pass in a struct which serializes to the proper JSON schema.

--- a/chat_test.go
+++ b/chat_test.go
@@ -277,6 +277,32 @@ func TestChatCompletionsFunctions(t *testing.T) {
 		})
 		checks.NoError(t, err, "CreateChatCompletion with functions error")
 	})
+	t.Run("StructuredOutputs", func(t *testing.T) {
+		type testMessage struct {
+			Count int      `json:"count"`
+			Words []string `json:"words"`
+		}
+		msg := testMessage{
+			Count: 2,
+			Words: []string{"hello", "world"},
+		}
+		_, err := client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
+			MaxTokens: 5,
+			Model:     openai.GPT3Dot5Turbo0613,
+			Messages: []openai.ChatCompletionMessage{
+				{
+					Role:    openai.ChatMessageRoleUser,
+					Content: "Hello!",
+				},
+			},
+			Functions: []openai.FunctionDefinition{{
+				Name:       "test",
+				Strict:     true,
+				Parameters: &msg,
+			}},
+		})
+		checks.NoError(t, err, "CreateChatCompletion with functions error")
+	})
 }
 
 func TestAzureChatCompletions(t *testing.T) {


### PR DESCRIPTION
**Describe the change**

Allows `strict: true` to be passed to OpenAI within a function's definition, triggering OpenAI's new [structured outputs](https://openai.com/index/introducing-structured-outputs-in-the-api/) setup to ensure the function's schema is strictly adhered to.

**Provide OpenAI documentation link**

https://openai.com/index/introducing-structured-outputs-in-the-api/

**Describe your solution**

Add `Strict` to the properties of `FunctionDefinition`. Only serialise it in the JSON if its value is `true` (to avoid wasting tokens).

**Tests**
Added a test.

**Additional context**
None