### PR TITLE
Allow passing any object in json schema in response format

### DIFF
--- a/api_integration_test.go
+++ b/api_integration_test.go
@@ -315,3 +315,63 @@ func TestChatCompletionStructuredOutputsFunctionCalling(t *testing.T) {
 		}
 	}
 }
+
+func TestChatCompletionResponseFormat_JSONSchemaAsString(t *testing.T) {
+	apiToken := os.Getenv("OPENAI_TOKEN")
+	if apiToken == "" {
+		t.Skip("Skipping testing against production OpenAI API. Set OPENAI_TOKEN environment variable to enable it.")
+	}
+
+	var err error
+	c := openai.NewClient(apiToken)
+	ctx := context.Background()
+
+	resp, err := c.CreateChatCompletion(
+		ctx,
+		openai.ChatCompletionRequest{
+			Model: openai.GPT4oMini,
+			Messages: []openai.ChatCompletionMessage{
+				{
+					Role: openai.ChatMessageRoleSystem,
+					Content: "Please enter a string, and we will convert it into the following naming conventions:" +
+						"1. PascalCase: Each word starts with an uppercase letter, with no spaces or separators." +
+						"2. CamelCase: The first word starts with a lowercase letter, " +
+						"and subsequent words start with an uppercase letter, with no spaces or separators." +
+						"3. KebabCase: All letters are lowercase, with words separated by hyphens `-`." +
+						"4. SnakeCase: All letters are lowercase, with words separated by underscores `_`.",
+				},
+				{
+					Role:    openai.ChatMessageRoleUser,
+					Content: "Hello World",
+				},
+			},
+			ResponseFormat: &openai.ChatCompletionResponseFormat{
+				Type: openai.ChatCompletionResponseFormatTypeJSONSchema,
+				JSONSchema: &openai.ChatCompletionResponseFormatJSONSchema{
+					Name: "cases",
+					Schema: json.RawMessage(`{
+						"type": "object",
+						"properties": {
+							"PascalCase": {"type": "string"},
+							"CamelCase": {"type": "string"},
+							"KebabCase": {"type": "string"},
+							"SnakeCase": {"type": "string"}
+						},
+						"required": ["PascalCase", "CamelCase", "KebabCase", "SnakeCase"],
+						"additionalProperties": false
+					}`),
+					Strict: true,
+				},
+			},
+		},
+	)
+	checks.NoError(t, err, "CreateChatCompletion (use string json_schema response) returned error")
+	var result = make(map[string]string)
+	err = json.Unmarshal([]byte(resp.Choices[0].Message.Content), &result)
+	checks.NoError(t, err, "CreateChatCompletion (use string json_schema response) unmarshal error")
+	for _, key := range []string{"PascalCase", "CamelCase", "KebabCase", "SnakeCase"} {
+		if _, ok := result[key]; !ok {
+			t.Errorf("key:%s does not exist.", key)
+		}
+	}
+}

--- a/chat.go
+++ b/chat.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-
-	"github.com/sashabaranov/go-openai/jsonschema"
 )
 
 // Chat message role defined by the OpenAI API.
@@ -187,10 +185,14 @@ type ChatCompletionResponseFormat struct {
 }
 
 type ChatCompletionResponseFormatJSONSchema struct {
-	Name        string                `json:"name"`
-	Description string                `json:"description,omitempty"`
-	Schema      jsonschema.Definition `json:"schema"`
-	Strict      bool                  `json:"strict"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Strict      bool   `json:"strict"`
+	// You can pass json.RawMessage to describe the schema,
+	// or you can pass in a struct which serializes to the proper JSON schema.
+	// The jsonschema package is provided for convenience, but you should
+	// consider another specialized library if you require more complex schemas.
+	Schema any `json:"schema"`
 }
 
 // ChatCompletionRequest represents a request structure for chat completion API.


### PR DESCRIPTION
**Describe the change**
- Changed type of `Schema` field in `ChatCompletionResponseFormatJSONSchema` from `jsonschema.Definition` to any. This will allow it to be more flexible and accept schemas from multiple sources rather than just the internal `jsonschema` package.
- Added integration test for the change.

**Tests**
- Integration test added
```
=== RUN   TestAPI
--- PASS: TestAPI (5.63s)
=== RUN   TestCompletionStream
--- PASS: TestCompletionStream (0.79s)
=== RUN   TestAPIError
--- PASS: TestAPIError (0.32s)
=== RUN   TestChatCompletionResponseFormat_JSONSchema
--- PASS: TestChatCompletionResponseFormat_JSONSchema (1.11s)
=== RUN   TestChatCompletionStructuredOutputsFunctionCalling
--- PASS: TestChatCompletionStructuredOutputsFunctionCalling (1.13s)
=== RUN   TestChatCompletionResponseFormat_JSONSchemaAsString
--- PASS: TestChatCompletionResponseFormat_JSONSchemaAsString (5.21s)
PASS
ok      command-line-arguments  14.684s
```


Issue: #829 
