### PR TITLE
Change Definition struct 'Type' field to support multiple data types …

### DIFF
--- a/jsonschema/json.go
+++ b/jsonschema/json.go
@@ -22,7 +22,7 @@ const (
 // It is fairly limited, and you may have better luck using a third-party library.
 type Definition struct {
 	// Type specifies the data type of the schema.
-	Type DataType `json:"type,omitempty"`
+	Type any `json:"type,omitempty"`
 	// Description is the description of the schema.
 	Description string `json:"description,omitempty"`
 	// Enum is used to restrict a value to a fixed set of values. It must be an array with at least


### PR DESCRIPTION
**Describe the change**
This PR modifies the Definition struct by updating the Type field to support multiple data types. This change is intended to facilitate the use of union types for parameters, allowing schemas to accommodate a broader range of data types as specified by the OpenAI documentation.

**Provide OpenAI documentation link**
https://platform.openai.com/docs/guides/structured-outputs/supported-schemas

**Describe your solution**
To address the need for supporting union types in schema definitions, the Type field in the Definition struct has been updated to allow for multiple data types. This change enables developers to define schemas that can handle a variety of data types, offering more flexibility in schema design.


**Tests**
Tested manually for both types (existing single type format and new multiple format)



Issue: #832
