### PR TITLE
ordered jsonschema def

### DIFF
--- a/jsonschema/json_test.go
+++ b/jsonschema/json_test.go
@@ -17,7 +17,7 @@ func TestDefinition_MarshalJSON(t *testing.T) {
 		{
 			name: "Test with empty Definition",
 			def:  jsonschema.Definition{},
-			want: `{"properties":{}}`,
+			want: `{}`,
 		},
 		{
 			name: "Test with Definition properties set",
@@ -35,8 +35,7 @@ func TestDefinition_MarshalJSON(t *testing.T) {
    "description":"A string type",
    "properties":{
       "name":{
-         "type":"string",
-         "properties":{}
+         "type":"string"
       }
    }
 }`,
@@ -66,12 +65,10 @@ func TestDefinition_MarshalJSON(t *testing.T) {
          "type":"object",
          "properties":{
             "name":{
-               "type":"string",
-               "properties":{}
+               "type":"string"
             },
             "age":{
-               "type":"integer",
-               "properties":{}
+               "type":"integer"
             }
          }
       }
@@ -114,23 +111,19 @@ func TestDefinition_MarshalJSON(t *testing.T) {
          "type":"object",
          "properties":{
             "name":{
-               "type":"string",
-               "properties":{}
+               "type":"string"
             },
             "age":{
-               "type":"integer",
-               "properties":{}
+               "type":"integer"
             },
             "address":{
                "type":"object",
                "properties":{
                   "city":{
-                     "type":"string",
-                     "properties":{}
+                     "type":"string"
                   },
                   "country":{
-                     "type":"string",
-                     "properties":{}
+                     "type":"string"
                   }
                }
             }
@@ -146,25 +139,11 @@ func TestDefinition_MarshalJSON(t *testing.T) {
 				Items: &jsonschema.Definition{
 					Type: jsonschema.String,
 				},
-				Properties: map[string]jsonschema.Definition{
-					"name": {
-						Type: jsonschema.String,
-					},
-				},
 			},
 			want: `{
    "type":"array",
    "items":{
-      "type":"string",
-      "properties":{
-         
-      }
-   },
-   "properties":{
-      "name":{
-         "type":"string",
-         "properties":{}
-      }
+      "type":"string"
    }
 }`,
 		},

--- a/jsonschema/validate.go
+++ b/jsonschema/validate.go
@@ -55,7 +55,7 @@ func validateObject(schema Definition, data any) bool {
 			return false
 		}
 	}
-	for key, valueSchema := range schema.Properties {
+	for key, valueSchema := range schema.Properties.Values {
 		value, exists := dataMap[key]
 		if exists && !Validate(valueSchema, value) {
 			return false

--- a/jsonschema/validate_test.go
+++ b/jsonschema/validate_test.go
@@ -47,12 +47,15 @@ func Test_Validate(t *testing.T) {
 			"number":  123.4,
 			"boolean": false,
 			"array":   []any{1, 2, 3},
-		}, schema: jsonschema.Definition{Type: jsonschema.Object, Properties: map[string]jsonschema.Definition{
-			"string":  {Type: jsonschema.String},
-			"integer": {Type: jsonschema.Integer},
-			"number":  {Type: jsonschema.Number},
-			"boolean": {Type: jsonschema.Boolean},
-			"array":   {Type: jsonschema.Array, Items: &jsonschema.Definition{Type: jsonschema.Number}},
+		}, schema: jsonschema.Definition{Type: jsonschema.Object, Properties: jsonschema.OrderedProperties{
+			Keys: []string{"string", "integer", "number", "boolean", "array"},
+			Values: map[string]jsonschema.Definition{
+				"string":  {Type: jsonschema.String},
+				"integer": {Type: jsonschema.Integer},
+				"number":  {Type: jsonschema.Number},
+				"boolean": {Type: jsonschema.Boolean},
+				"array":   {Type: jsonschema.Array, Items: &jsonschema.Definition{Type: jsonschema.Number}},
+			},
 		},
 			Required: []string{"string"},
 		}}, true},
@@ -61,12 +64,15 @@ func Test_Validate(t *testing.T) {
 			"number":  123.4,
 			"boolean": false,
 			"array":   []any{1, 2, 3},
-		}, schema: jsonschema.Definition{Type: jsonschema.Object, Properties: map[string]jsonschema.Definition{
-			"string":  {Type: jsonschema.String},
-			"integer": {Type: jsonschema.Integer},
-			"number":  {Type: jsonschema.Number},
-			"boolean": {Type: jsonschema.Boolean},
-			"array":   {Type: jsonschema.Array, Items: &jsonschema.Definition{Type: jsonschema.Number}},
+		}, schema: jsonschema.Definition{Type: jsonschema.Object, Properties: jsonschema.OrderedProperties{
+			Keys: []string{"string", "integer", "number", "boolean", "array"},
+			Values: map[string]jsonschema.Definition{
+				"string":  {Type: jsonschema.String},
+				"integer": {Type: jsonschema.Integer},
+				"number":  {Type: jsonschema.Number},
+				"boolean": {Type: jsonschema.Boolean},
+				"array":   {Type: jsonschema.Array, Items: &jsonschema.Definition{Type: jsonschema.Number}},
+			},
 		},
 			Required: []string{"string"},
 		}}, false},
@@ -102,9 +108,12 @@ func TestUnmarshal(t *testing.T) {
 		{"", args{
 			schema: jsonschema.Definition{
 				Type: jsonschema.Object,
-				Properties: map[string]jsonschema.Definition{
-					"string": {Type: jsonschema.String},
-					"number": {Type: jsonschema.Number},
+				Properties: jsonschema.OrderedProperties{
+					Keys: []string{"string", "number"},
+					Values: map[string]jsonschema.Definition{
+						"string": {Type: jsonschema.String},
+						"number": {Type: jsonschema.Number},
+					},
 				},
 			},
 			content: []byte(`{"string":"abc","number":123.4}`),
@@ -113,9 +122,12 @@ func TestUnmarshal(t *testing.T) {
 		{"", args{
 			schema: jsonschema.Definition{
 				Type: jsonschema.Object,
-				Properties: map[string]jsonschema.Definition{
-					"string": {Type: jsonschema.String},
-					"number": {Type: jsonschema.Number},
+				Properties: jsonschema.OrderedProperties{
+					Keys: []string{"string", "number"},
+					Values: map[string]jsonschema.Definition{
+						"string": {Type: jsonschema.String},
+						"number": {Type: jsonschema.Number},
+					},
 				},
 				Required: []string{"string", "number"},
 			},


### PR DESCRIPTION
The old jsonschema package does not ensure that the order of fields is the same as go struct def , which is bad for taking advantage of chain of thought.

also fix Issue: #839