### PR TITLE
fix: text field in MultiContent chat message is required

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -75,7 +75,7 @@ const (
 
 type ChatMessagePart struct {
 	Type     ChatMessagePartType  `json:"type,omitempty"`
-	Text     string               `json:"text,omitempty"`
+	Text     string               `json:"text"`
 	ImageURL *ChatMessageImageURL `json:"image_url,omitempty"`
 }
 


### PR DESCRIPTION
**Describe the change**
Can't omit text field in in multi content chat message, see the example below.

**Provide OpenAI documentation link**
Try
```
curl "https://api.openai.com/v1/chat/completions" \
  -X POST \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -d '{
         "messages": [
           {
             "role": "user",
             "content": [
               {
                 "type": "text"
               },
               {
                 "type": "image_url",
                 "image_url": {
                   "url": "https://shellsamurai.com/wp-content/uploads/2023/04/tux.jpg"
                 }
               }
             ]
           }
         ],
         "model": "gpt-4o",
         "temperature": 0,
         "max_tokens": 1024,
         "top_p": 1,
         "stream": false
       }'
```
You'll get:
```
{
  "error": {
    "message": "Invalid chat format. Expected 'text' field in text type content part to be a string.",
    "type": "invalid_request_error",
    "param": null,
    "code": null
  }
}
```

**Describe your solution**
Don't emit the `Text` field.

**Tests**
Successful request to OpenAI endpoint.

**Additional context**

Issue: #XXXX
