### PR TITLE
feat: add ParallelToolCalls to RunRequest

### DIFF
--- a/run.go
+++ b/run.go
@@ -37,6 +37,8 @@ type Run struct {
 	MaxCompletionTokens int `json:"max_completion_tokens,omitempty"`
 	// ThreadTruncationStrategy defines the truncation strategy to use for the thread.
 	TruncationStrategy *ThreadTruncationStrategy `json:"truncation_strategy,omitempty"`
+	// Disable the default behavior of parallel tool calls by setting it: false.
+	ParallelToolCalls any `json:"parallel_tool_calls,omitempty"`
 
 	httpHeader
 }


### PR DESCRIPTION
**Describe the change**
By default, `parallel_tool_calls` is set to true, which allows the llm to make multiple tool calls in one response. This can be opted out of with setting it to false, and ensures the llm only responds with one tool call at a time.

**Provide OpenAI documentation link**
https://platform.openai.com/docs/api-reference/runs/createRun#runs-createrun-parallel_tool_calls

**Describe your solution**
This PR added the same change as #787 , an `any`  field `ParallelToolCalls`.

**Tests**
No new tests added.
