### PR TITLE
Support OpenAI reasoning models

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -17,6 +17,10 @@ var (
 // GPT3 Models are designed for text-based tasks. For code-specific
 // tasks, please refer to the Codex series of models.
 const (
+	O1Mini                = "o1-mini"
+	O1Mini20240912        = "o1-mini-2024-09-12"
+	O1Preview             = "o1-preview"
+	O1Preview20240912     = "o1-preview-2024-09-12"
 	GPT432K0613           = "gpt-4-32k-0613"
 	GPT432K0314           = "gpt-4-32k-0314"
 	GPT432K               = "gpt-4-32k"


### PR DESCRIPTION
These model strings are now available for use.

More info:
https://openai.com/index/introducing-openai-o1-preview/
https://platform.openai.com/docs/guides/reasoning
