### PR TITLE
fix: jsonschema integer validation

### DIFF
--- a/jsonschema/validate.go
+++ b/jsonschema/validate.go
@@ -36,6 +36,10 @@ func Validate(schema Definition, data any) bool {
 		_, ok := data.(bool)
 		return ok
 	case Integer:
+		// Golang unmarshals all numbers as float64, so we need to check if the float64 is an integer
+		if num, ok := data.(float64); ok {
+			return num == float64(int64(num))
+		}
 		_, ok := data.(int)
 		return ok
 	case Null:

--- a/jsonschema/validate_test.go
+++ b/jsonschema/validate_test.go
@@ -86,14 +86,6 @@ func TestUnmarshal(t *testing.T) {
 		content []byte
 		v       any
 	}
-	var result1 struct {
-		String string  `json:"string"`
-		Number float64 `json:"number"`
-	}
-	var result2 struct {
-		String string  `json:"string"`
-		Number float64 `json:"number"`
-	}
 	tests := []struct {
 		name    string
 		args    args
@@ -108,7 +100,10 @@ func TestUnmarshal(t *testing.T) {
 				},
 			},
 			content: []byte(`{"string":"abc","number":123.4}`),
-			v:       &result1,
+			v: &struct {
+				String string  `json:"string"`
+				Number float64 `json:"number"`
+			}{},
 		}, false},
 		{"", args{
 			schema: jsonschema.Definition{
@@ -120,7 +115,40 @@ func TestUnmarshal(t *testing.T) {
 				Required: []string{"string", "number"},
 			},
 			content: []byte(`{"string":"abc"}`),
-			v:       result2,
+			v: struct {
+				String string  `json:"string"`
+				Number float64 `json:"number"`
+			}{},
+		}, true},
+		{"validate integer", args{
+			schema: jsonschema.Definition{
+				Type: jsonschema.Object,
+				Properties: map[string]jsonschema.Definition{
+					"string":  {Type: jsonschema.String},
+					"integer": {Type: jsonschema.Integer},
+				},
+				Required: []string{"string", "integer"},
+			},
+			content: []byte(`{"string":"abc","integer":123}`),
+			v: &struct {
+				String  string `json:"string"`
+				Integer int    `json:"integer"`
+			}{},
+		}, false},
+		{"validate integer failed", args{
+			schema: jsonschema.Definition{
+				Type: jsonschema.Object,
+				Properties: map[string]jsonschema.Definition{
+					"string":  {Type: jsonschema.String},
+					"integer": {Type: jsonschema.Integer},
+				},
+				Required: []string{"string", "integer"},
+			},
+			content: []byte(`{"string":"abc","integer":123.4}`),
+			v: &struct {
+				String  string `json:"string"`
+				Integer int    `json:"integer"`
+			}{},
 		}, true},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**Describe the change**
Fix the jsonschema validation failed failure on the integer field.

**Provide OpenAI documentation link**


**Describe your solution**
Follow the #837 instruction. Because go unmarshalls all numbers as float64, we should check the value is an integer.

**Tests**
Add `jsonschema.Integer` cases, include a success and a failed case.

**Additional context**
Add any other context or screenshots or logs about your pull request here. If the pull request relates to an open issue, please link to it.

Issue: #837 