### PR TITLE
Support binary image URLs without copying image data

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -64,14 +64,9 @@ const (
 )
 
 type ChatMessageImageURL struct {
+	// URL can be a string or a BinaryImageURL object.
 	URL    any            `json:"url,omitempty"`
 	Detail ImageURLDetail `json:"detail,omitempty"`
-}
-
-type ImageURL string
-
-func (i ImageURL) String() string {
-	return string(i)
 }
 
 type BinaryImageURL struct {

--- a/chat.go
+++ b/chat.go
@@ -1,7 +1,9 @@
 package openai
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -62,8 +64,42 @@ const (
 )
 
 type ChatMessageImageURL struct {
-	URL    string         `json:"url,omitempty"`
+	URL    any            `json:"url,omitempty"`
 	Detail ImageURLDetail `json:"detail,omitempty"`
+}
+
+type ImageURL string
+
+func (i ImageURL) String() string {
+	return string(i)
+}
+
+type BinaryImageURL struct {
+	MimeType string
+	Data     []byte
+}
+
+func (b BinaryImageURL) MarshalJSON() ([]byte, error) {
+	encodedLength := base64.StdEncoding.EncodedLen(len(b.Data))
+	buf := bytes.NewBuffer(make([]byte, 0, 15+len(b.MimeType)+encodedLength))
+
+	buf.WriteString(`"data:`)
+	buf.WriteString(b.MimeType)
+	buf.WriteString(`;base64,`)
+
+	// base64 encode data and write it to the buffer
+	encoder := base64.NewEncoder(base64.StdEncoding, buf)
+	_, err := encoder.Write(b.Data)
+	if err != nil {
+		return nil, err
+	}
+	err = encoder.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	buf.WriteString(`"`)
+	return buf.Bytes(), nil
 }
 
 type ChatMessagePartType string

--- a/chat_test.go
+++ b/chat_test.go
@@ -555,7 +555,7 @@ func TestFinishReason(t *testing.T) {
 	}
 }
 
-func TestChatCompletionMessageMarshalJSONWithMultiContent(t *testing.T) {
+func TestChatCompletionRequest_MarshalJSON_LargeImage(t *testing.T) {
 	// generate 20 mb of random data
 	imageData := generateEncodedData(t, 20*1024*1024)
 	//imageData = []byte("test")
@@ -597,8 +597,11 @@ func TestChatCompletionMessageMarshalJSONWithMultiContent(t *testing.T) {
 		},
 		ToolCallID: "tool-call-id",
 	}
+	req := openai.ChatCompletionRequest{
+		Messages: []openai.ChatCompletionMessage{msg},
+	}
 
-	data, err := json.Marshal(msg)
+	data, err := json.Marshal(req)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}

--- a/chat_test.go
+++ b/chat_test.go
@@ -343,7 +343,7 @@ func TestMultipartChatCompletions(t *testing.T) {
 					{
 						Type: openai.ChatMessagePartTypeImageURL,
 						ImageURL: &openai.ChatMessageImageURL{
-							URL:    openai.ImageURL("URL"),
+							URL:    "URL",
 							Detail: openai.ImageURLDetailLow,
 						},
 					},


### PR DESCRIPTION
**Describe the change**
This PR allows memory allocation to be optimised when providing a binary image in a ChatCompletionRequest.
It allows for providing the raw image bytes by reference, instead of having to copy the base64 encoded string.

**Provide OpenAI documentation link**
No API documentation is relevant.

**Describe your solution**
The solution makes it possible to provide any type of image URL and implements a BinaryImageURL struct that using MarshalJSON converts the raw image bytes to JSON in the most memory-effective way.

**Tests**


I've tested the changes using a memory profiler. I've profiled the memory allocation using a base64 encoded image URL and using the BinaryImageURL.

Using a 20mb picture, a 24.5% or 27 mb decrease in memory allocation can be seen for ChatCompletionMessage.MarshalJSON.

**Additional context**
![image](https://github.com/user-attachments/assets/0478d629-e6eb-4640-afd7-7f65946c54b2)
![flamegraph](https://github.com/user-attachments/assets/5100e8b7-dcb7-4272-916e-a7e9275054b7)

