### PR TITLE
fix: ParallelToolCalls should be added to RunRequest

### DIFF
--- a/run.go
+++ b/run.go
@@ -37,8 +37,6 @@ type Run struct {
 	MaxCompletionTokens int `json:"max_completion_tokens,omitempty"`
 	// ThreadTruncationStrategy defines the truncation strategy to use for the thread.
 	TruncationStrategy *ThreadTruncationStrategy `json:"truncation_strategy,omitempty"`
-	// Disable the default behavior of parallel tool calls by setting it: false.
-	ParallelToolCalls any `json:"parallel_tool_calls,omitempty"`
 
 	httpHeader
 }
@@ -112,6 +110,8 @@ type RunRequest struct {
 	ToolChoice any `json:"tool_choice,omitempty"`
 	// This can be either a string or a ResponseFormat object.
 	ResponseFormat any `json:"response_format,omitempty"`
+	// Disable the default behavior of parallel tool calls by setting it: false.
+	ParallelToolCalls any `json:"parallel_tool_calls,omitempty"`
 }
 
 // ThreadTruncationStrategy defines the truncation strategy to use for the thread.


### PR DESCRIPTION
Sorry about that, my previous PR #847 didn't add this field into to the correct struct, it should be added to `RunRequest`, but not `Run`.

**Provide OpenAI documentation link**
[Provide a relevant API doc from https://platform.openai.com/docs/api-reference](https://platform.openai.com/docs/api-reference/runs/createRun#runs-createrun-parallel_tool_calls)

