### PR TITLE
fix MaxCompletionTokens typo

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -207,9 +207,9 @@ type ChatCompletionRequest struct {
 	// This value is now deprecated in favor of max_completion_tokens, and is not compatible with o1 series models.
 	// refs: https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_tokens
 	MaxTokens int `json:"max_tokens,omitempty"`
-	// MaxCompletionsTokens An upper bound for the number of tokens that can be generated for a completion,
+	// MaxCompletionTokens An upper bound for the number of tokens that can be generated for a completion,
 	// including visible output tokens and reasoning tokens https://platform.openai.com/docs/guides/reasoning
-	MaxCompletionsTokens int                           `json:"max_completions_tokens,omitempty"`
+	MaxCompletionTokens int                           `json:"max_completion_tokens,omitempty"`
 	Temperature          float32                       `json:"temperature,omitempty"`
 	TopP                 float32                       `json:"top_p,omitempty"`
 	N                    int                           `json:"n,omitempty"`

--- a/chat.go
+++ b/chat.go
@@ -210,15 +210,15 @@ type ChatCompletionRequest struct {
 	// MaxCompletionTokens An upper bound for the number of tokens that can be generated for a completion,
 	// including visible output tokens and reasoning tokens https://platform.openai.com/docs/guides/reasoning
 	MaxCompletionTokens int                           `json:"max_completion_tokens,omitempty"`
-	Temperature          float32                       `json:"temperature,omitempty"`
-	TopP                 float32                       `json:"top_p,omitempty"`
-	N                    int                           `json:"n,omitempty"`
-	Stream               bool                          `json:"stream,omitempty"`
-	Stop                 []string                      `json:"stop,omitempty"`
-	PresencePenalty      float32                       `json:"presence_penalty,omitempty"`
-	ResponseFormat       *ChatCompletionResponseFormat `json:"response_format,omitempty"`
-	Seed                 *int                          `json:"seed,omitempty"`
-	FrequencyPenalty     float32                       `json:"frequency_penalty,omitempty"`
+	Temperature         float32                       `json:"temperature,omitempty"`
+	TopP                float32                       `json:"top_p,omitempty"`
+	N                   int                           `json:"n,omitempty"`
+	Stream              bool                          `json:"stream,omitempty"`
+	Stop                []string                      `json:"stop,omitempty"`
+	PresencePenalty     float32                       `json:"presence_penalty,omitempty"`
+	ResponseFormat      *ChatCompletionResponseFormat `json:"response_format,omitempty"`
+	Seed                *int                          `json:"seed,omitempty"`
+	FrequencyPenalty    float32                       `json:"frequency_penalty,omitempty"`
 	// LogitBias is must be a token id string (specified by their token ID in the tokenizer), not a word string.
 	// incorrect: `"logit_bias":{"You": 6}`, correct: `"logit_bias":{"1639": 6}`
 	// refs: https://platform.openai.com/docs/api-reference/chat/create#chat/create-logit_bias

--- a/chat.go
+++ b/chat.go
@@ -209,7 +209,6 @@ type ChatCompletionRequest struct {
 	MaxTokens int `json:"max_tokens,omitempty"`
 	// MaxCompletionTokens An upper bound for the number of tokens that can be generated for a completion,
 	// including visible output tokens and reasoning tokens https://platform.openai.com/docs/guides/reasoning
-
 	MaxCompletionTokens int                           `json:"max_completion_tokens,omitempty"`
 	Temperature         float32                       `json:"temperature,omitempty"`
 	TopP                float32                       `json:"top_p,omitempty"`
@@ -220,7 +219,6 @@ type ChatCompletionRequest struct {
 	ResponseFormat      *ChatCompletionResponseFormat `json:"response_format,omitempty"`
 	Seed                *int                          `json:"seed,omitempty"`
 	FrequencyPenalty    float32                       `json:"frequency_penalty,omitempty"`
-
 	// LogitBias i s must be a token id string (specified by their token ID in the tokenizer), not a word string.
 	// incorrect: `"logit_bias":{"You": 6}`, correct: `"logit_bias":{"1639": 6}`
 	// refs: https://platform.openai.com/docs/api-reference/chat/create#chat/create-logit_bias

--- a/chat.go
+++ b/chat.go
@@ -219,7 +219,7 @@ type ChatCompletionRequest struct {
 	ResponseFormat      *ChatCompletionResponseFormat `json:"response_format,omitempty"`
 	Seed                *int                          `json:"seed,omitempty"`
 	FrequencyPenalty    float32                       `json:"frequency_penalty,omitempty"`
-	// LogitBias i s must be a token id string (specified by their token ID in the tokenizer), not a word string.
+	// LogitBias is must be a token id string (specified by their token ID in the tokenizer), not a word string.
 	// incorrect: `"logit_bias":{"You": 6}`, correct: `"logit_bias":{"1639": 6}`
 	// refs: https://platform.openai.com/docs/api-reference/chat/create#chat/create-logit_bias
 	LogitBias map[string]int `json:"logit_bias,omitempty"`

--- a/chat_test.go
+++ b/chat_test.go
@@ -100,7 +100,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 		{
 			name: "log_probs_unsupported",
 			in: openai.ChatCompletionRequest{
-				MaxCompletionsTokens: 1000,
+				MaxCompletionTokens: 1000,
 				LogProbs:             true,
 				Model:                openai.O1Preview,
 			},
@@ -109,7 +109,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 		{
 			name: "message_type_unsupported",
 			in: openai.ChatCompletionRequest{
-				MaxCompletionsTokens: 1000,
+				MaxCompletionTokens: 1000,
 				Model:                openai.O1Mini,
 				Messages: []openai.ChatCompletionMessage{
 					{
@@ -122,7 +122,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 		{
 			name: "tool_unsupported",
 			in: openai.ChatCompletionRequest{
-				MaxCompletionsTokens: 1000,
+				MaxCompletionTokens: 1000,
 				Model:                openai.O1Mini,
 				Messages: []openai.ChatCompletionMessage{
 					{
@@ -143,7 +143,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 		{
 			name: "set_temperature_unsupported",
 			in: openai.ChatCompletionRequest{
-				MaxCompletionsTokens: 1000,
+				MaxCompletionTokens: 1000,
 				Model:                openai.O1Mini,
 				Messages: []openai.ChatCompletionMessage{
 					{
@@ -160,7 +160,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 		{
 			name: "set_top_unsupported",
 			in: openai.ChatCompletionRequest{
-				MaxCompletionsTokens: 1000,
+				MaxCompletionTokens: 1000,
 				Model:                openai.O1Mini,
 				Messages: []openai.ChatCompletionMessage{
 					{
@@ -178,7 +178,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 		{
 			name: "set_n_unsupported",
 			in: openai.ChatCompletionRequest{
-				MaxCompletionsTokens: 1000,
+				MaxCompletionTokens: 1000,
 				Model:                openai.O1Mini,
 				Messages: []openai.ChatCompletionMessage{
 					{
@@ -197,7 +197,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 		{
 			name: "set_presence_penalty_unsupported",
 			in: openai.ChatCompletionRequest{
-				MaxCompletionsTokens: 1000,
+				MaxCompletionTokens: 1000,
 				Model:                openai.O1Mini,
 				Messages: []openai.ChatCompletionMessage{
 					{
@@ -214,7 +214,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 		{
 			name: "set_frequency_penalty_unsupported",
 			in: openai.ChatCompletionRequest{
-				MaxCompletionsTokens: 1000,
+				MaxCompletionTokens: 1000,
 				Model:                openai.O1Mini,
 				Messages: []openai.ChatCompletionMessage{
 					{
@@ -297,7 +297,7 @@ func TestO1ModelChatCompletions(t *testing.T) {
 	server.RegisterHandler("/v1/chat/completions", handleChatCompletionEndpoint)
 	_, err := client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
 		Model:                openai.O1Preview,
-		MaxCompletionsTokens: 1000,
+		MaxCompletionTokens: 1000,
 		Messages: []openai.ChatCompletionMessage{
 			{
 				Role:    openai.ChatMessageRoleUser,

--- a/chat_test.go
+++ b/chat_test.go
@@ -101,8 +101,8 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 			name: "log_probs_unsupported",
 			in: openai.ChatCompletionRequest{
 				MaxCompletionTokens: 1000,
-				LogProbs:             true,
-				Model:                openai.O1Preview,
+				LogProbs:            true,
+				Model:               openai.O1Preview,
 			},
 			expectedError: openai.ErrO1BetaLimitationsLogprobs,
 		},
@@ -110,7 +110,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 			name: "message_type_unsupported",
 			in: openai.ChatCompletionRequest{
 				MaxCompletionTokens: 1000,
-				Model:                openai.O1Mini,
+				Model:               openai.O1Mini,
 				Messages: []openai.ChatCompletionMessage{
 					{
 						Role: openai.ChatMessageRoleSystem,
@@ -123,7 +123,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 			name: "tool_unsupported",
 			in: openai.ChatCompletionRequest{
 				MaxCompletionTokens: 1000,
-				Model:                openai.O1Mini,
+				Model:               openai.O1Mini,
 				Messages: []openai.ChatCompletionMessage{
 					{
 						Role: openai.ChatMessageRoleUser,
@@ -144,7 +144,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 			name: "set_temperature_unsupported",
 			in: openai.ChatCompletionRequest{
 				MaxCompletionTokens: 1000,
-				Model:                openai.O1Mini,
+				Model:               openai.O1Mini,
 				Messages: []openai.ChatCompletionMessage{
 					{
 						Role: openai.ChatMessageRoleUser,
@@ -161,7 +161,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 			name: "set_top_unsupported",
 			in: openai.ChatCompletionRequest{
 				MaxCompletionTokens: 1000,
-				Model:                openai.O1Mini,
+				Model:               openai.O1Mini,
 				Messages: []openai.ChatCompletionMessage{
 					{
 						Role: openai.ChatMessageRoleUser,
@@ -179,7 +179,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 			name: "set_n_unsupported",
 			in: openai.ChatCompletionRequest{
 				MaxCompletionTokens: 1000,
-				Model:                openai.O1Mini,
+				Model:               openai.O1Mini,
 				Messages: []openai.ChatCompletionMessage{
 					{
 						Role: openai.ChatMessageRoleUser,
@@ -198,7 +198,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 			name: "set_presence_penalty_unsupported",
 			in: openai.ChatCompletionRequest{
 				MaxCompletionTokens: 1000,
-				Model:                openai.O1Mini,
+				Model:               openai.O1Mini,
 				Messages: []openai.ChatCompletionMessage{
 					{
 						Role: openai.ChatMessageRoleUser,
@@ -215,7 +215,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 			name: "set_frequency_penalty_unsupported",
 			in: openai.ChatCompletionRequest{
 				MaxCompletionTokens: 1000,
-				Model:                openai.O1Mini,
+				Model:               openai.O1Mini,
 				Messages: []openai.ChatCompletionMessage{
 					{
 						Role: openai.ChatMessageRoleUser,
@@ -296,7 +296,7 @@ func TestO1ModelChatCompletions(t *testing.T) {
 	defer teardown()
 	server.RegisterHandler("/v1/chat/completions", handleChatCompletionEndpoint)
 	_, err := client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
-		Model:                openai.O1Preview,
+		Model:               openai.O1Preview,
 		MaxCompletionTokens: 1000,
 		Messages: []openai.ChatCompletionMessage{
 			{

--- a/completion.go
+++ b/completion.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	ErrO1MaxTokensDeprecated                   = errors.New("this model is not supported MaxTokens, please use MaxCompletionsTokens")                              //nolint:lll
+	ErrO1MaxTokensDeprecated                   = errors.New("this model is not supported MaxTokens, please use MaxCompletionTokens")                              //nolint:lll
 	ErrCompletionUnsupportedModel              = errors.New("this model is not supported with this method, please use CreateChatCompletion client method instead") //nolint:lll
 	ErrCompletionStreamNotSupported            = errors.New("streaming is not supported with this method, please use CreateCompletionStream")                      //nolint:lll
 	ErrCompletionRequestPromptTypeNotSupported = errors.New("the type of CompletionRequest.Prompt only supports string and []string")                              //nolint:lll

--- a/completion.go
+++ b/completion.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	ErrO1MaxTokensDeprecated                   = errors.New("this model is not supported MaxTokens, please use MaxCompletionTokens")                              //nolint:lll
+	ErrO1MaxTokensDeprecated                   = errors.New("this model is not supported MaxTokens, please use MaxCompletionTokens")                               //nolint:lll
 	ErrCompletionUnsupportedModel              = errors.New("this model is not supported with this method, please use CreateChatCompletion client method instead") //nolint:lll
 	ErrCompletionStreamNotSupported            = errors.New("streaming is not supported with this method, please use CreateCompletionStream")                      //nolint:lll
 	ErrCompletionRequestPromptTypeNotSupported = errors.New("the type of CompletionRequest.Prompt only supports string and []string")                              //nolint:lll


### PR DESCRIPTION
Currently API calls to o1 models are broken due to a typo in the json tag of `ChatCompletionRequest`

This PR corrects the spelling of `MaxCompletionsTokens` to `MaxCompletionTokens` and also fixes the json tag `max_completion_tokens`. 

There already exists a [similar PR](https://github.com/sashabaranov/go-openai/pull/860) but it doesn't fix all occurrences of the typo.