### PR TITLE
add jailbreak filter result, add ContentFilterResults on output

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -344,19 +344,21 @@ type ChatCompletionChoice struct {
 	// function_call: The model decided to call a function
 	// content_filter: Omitted content due to a flag from our content filters
 	// null: API response still in progress or incomplete
-	FinishReason FinishReason `json:"finish_reason"`
-	LogProbs     *LogProbs    `json:"logprobs,omitempty"`
+	FinishReason         FinishReason         `json:"finish_reason"`
+	LogProbs             *LogProbs            `json:"logprobs,omitempty"`
+	ContentFilterResults ContentFilterResults `json:"content_filter_results,omitempty"`
 }
 
 // ChatCompletionResponse represents a response structure for chat completion API.
 type ChatCompletionResponse struct {
-	ID                string                 `json:"id"`
-	Object            string                 `json:"object"`
-	Created           int64                  `json:"created"`
-	Model             string                 `json:"model"`
-	Choices           []ChatCompletionChoice `json:"choices"`
-	Usage             Usage                  `json:"usage"`
-	SystemFingerprint string                 `json:"system_fingerprint"`
+	ID                  string                 `json:"id"`
+	Object              string                 `json:"object"`
+	Created             int64                  `json:"created"`
+	Model               string                 `json:"model"`
+	Choices             []ChatCompletionChoice `json:"choices"`
+	Usage               Usage                  `json:"usage"`
+	SystemFingerprint   string                 `json:"system_fingerprint"`
+	PromptFilterResults []PromptFilterResult   `json:"prompt_filter_results,omitempty"`
 
 	httpHeader
 }

--- a/chat.go
+++ b/chat.go
@@ -46,12 +46,18 @@ type JailBreak struct {
 	Detected bool `json:"detected"`
 }
 
+type Profanity struct {
+	Filtered bool `json:"filtered"`
+	Detected bool `json:"detected"`
+}
+
 type ContentFilterResults struct {
 	Hate      Hate      `json:"hate,omitempty"`
 	SelfHarm  SelfHarm  `json:"self_harm,omitempty"`
 	Sexual    Sexual    `json:"sexual,omitempty"`
 	Violence  Violence  `json:"violence,omitempty"`
 	JailBreak JailBreak `json:"jailbreak,omitempty"`
+	Profanity Profanity `json:"profanity,omitempty"`
 }
 
 type PromptAnnotation struct {

--- a/chat.go
+++ b/chat.go
@@ -41,11 +41,17 @@ type Violence struct {
 	Severity string `json:"severity,omitempty"`
 }
 
+type JailBreak struct {
+	Filtered bool `json:"filtered"`
+	Detected bool `json:"detected"`
+}
+
 type ContentFilterResults struct {
-	Hate     Hate     `json:"hate,omitempty"`
-	SelfHarm SelfHarm `json:"self_harm,omitempty"`
-	Sexual   Sexual   `json:"sexual,omitempty"`
-	Violence Violence `json:"violence,omitempty"`
+	Hate      Hate      `json:"hate,omitempty"`
+	SelfHarm  SelfHarm  `json:"self_harm,omitempty"`
+	Sexual    Sexual    `json:"sexual,omitempty"`
+	Violence  Violence  `json:"violence,omitempty"`
+	JailBreak JailBreak `json:"jailbreak,omitempty"`
 }
 
 type PromptAnnotation struct {


### PR DESCRIPTION
Adding field for prompt_filter_results which is in the open content filters to assess the content of the user input. Current implementation in go-openai will only return content filter information on the model output using ChatCompletionResponse. This is for AzureOpenAI spec.

Adding field for content_filter_results which is in the open content filters to assess the content of the user input. Current implementation in go-openai will only return content filter information on the model output using ChatCompletionChoice. This is for AzureOpenAI spec.

Adding field for jailbreak which is in a content filter. Current implementation in go-openai will only return content filter information on the error output using InnerError.ContentFilterResults. This is for AzureOpenAI spec.

Provide OpenAI documentation link
Relevant API doc: https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/content-filter

Describe your solution
Change struct