### PR TITLE
Completion API: add new params

### DIFF
--- a/common.go
+++ b/common.go
@@ -7,10 +7,18 @@ type Usage struct {
 	PromptTokens            int                      `json:"prompt_tokens"`
 	CompletionTokens        int                      `json:"completion_tokens"`
 	TotalTokens             int                      `json:"total_tokens"`
+	PromptTokensDetails     *PromptTokensDetails     `json:"prompt_tokens_details"`
 	CompletionTokensDetails *CompletionTokensDetails `json:"completion_tokens_details"`
 }
 
 // CompletionTokensDetails Breakdown of tokens used in a completion.
 type CompletionTokensDetails struct {
+	AudioTokens     int `json:"audio_tokens"`
 	ReasoningTokens int `json:"reasoning_tokens"`
+}
+
+// PromptTokensDetails Breakdown of tokens used in the prompt.
+type PromptTokensDetails struct {
+	AudioTokens  int `json:"audio_tokens"`
+	CachedTokens int `json:"cached_tokens"`
 }

--- a/completion.go
+++ b/completion.go
@@ -238,18 +238,21 @@ type CompletionRequest struct {
 	// LogitBias is must be a token id string (specified by their token ID in the tokenizer), not a word string.
 	// incorrect: `"logit_bias":{"You": 6}`, correct: `"logit_bias":{"1639": 6}`
 	// refs: https://platform.openai.com/docs/api-reference/completions/create#completions/create-logit_bias
-	LogitBias       map[string]int `json:"logit_bias,omitempty"`
-	LogProbs        int            `json:"logprobs,omitempty"`
-	MaxTokens       int            `json:"max_tokens,omitempty"`
-	N               int            `json:"n,omitempty"`
-	PresencePenalty float32        `json:"presence_penalty,omitempty"`
-	Seed            *int           `json:"seed,omitempty"`
-	Stop            []string       `json:"stop,omitempty"`
-	Stream          bool           `json:"stream,omitempty"`
-	Suffix          string         `json:"suffix,omitempty"`
-	Temperature     float32        `json:"temperature,omitempty"`
-	TopP            float32        `json:"top_p,omitempty"`
-	User            string         `json:"user,omitempty"`
+	LogitBias map[string]int `json:"logit_bias,omitempty"`
+	// Store can be set to true to store the output of this completion request for use in distillations and evals.
+	// https://platform.openai.com/docs/api-reference/chat/create#chat-create-store
+	Store           bool     `json:"store,omitempty"`
+	LogProbs        int      `json:"logprobs,omitempty"`
+	MaxTokens       int      `json:"max_tokens,omitempty"`
+	N               int      `json:"n,omitempty"`
+	PresencePenalty float32  `json:"presence_penalty,omitempty"`
+	Seed            *int     `json:"seed,omitempty"`
+	Stop            []string `json:"stop,omitempty"`
+	Stream          bool     `json:"stream,omitempty"`
+	Suffix          string   `json:"suffix,omitempty"`
+	Temperature     float32  `json:"temperature,omitempty"`
+	TopP            float32  `json:"top_p,omitempty"`
+	User            string   `json:"user,omitempty"`
 }
 
 // CompletionChoice represents one of possible completions.


### PR DESCRIPTION
**Describe the change**
- `store` in request: this param allows you to opt a completion request in to being stored, for use in distillations and evals.
- `usage.completion_tokens_details.audio_tokens` in response: tracking audio tokens generated
- `usage.prompt_tokens_details` in response: tracking tokens used in the prompt

**Provide OpenAI documentation link**
https://platform.openai.com/docs/api-reference/chat/create#chat-create-store
https://platform.openai.com/docs/api-reference/chat/object#chat/object-usage

**Describe your solution**
Currently it's not possible to opt a completion request in to being stored using go-openai, blocking usage of distillations and evals.

It's also not possible to track usage of audio tokens, nor prompt caching.

**Tests**
These are optional new params, so I've not added specific test cases.