### PR TITLE
Return response body as byte slice for RequestError type

### DIFF
--- a/client.go
+++ b/client.go
@@ -285,20 +285,21 @@ func (c *Client) baseURLWithAzureDeployment(baseURL, suffix, model string) (newB
 }
 
 func (c *Client) handleErrorResp(resp *http.Response) error {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("error, reading response body: %w", err)
+	}
 	if !strings.HasPrefix(resp.Header.Get("Content-Type"), "application/json") {
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("error, reading response body: %w", err)
-		}
 		return fmt.Errorf("error, status code: %d, status: %s, body: %s", resp.StatusCode, resp.Status, body)
 	}
 	var errRes ErrorResponse
-	err := json.NewDecoder(resp.Body).Decode(&errRes)
+	err = json.Unmarshal(body, &errRes)
 	if err != nil || errRes.Error == nil {
 		reqErr := &RequestError{
 			HTTPStatus:     resp.Status,
 			HTTPStatusCode: resp.StatusCode,
 			Err:            err,
+			Body:           body,
 		}
 		if errRes.Error != nil {
 			reqErr.Err = errRes.Error

--- a/error.go
+++ b/error.go
@@ -29,6 +29,7 @@ type RequestError struct {
 	HTTPStatus     string
 	HTTPStatusCode int
 	Err            error
+	Body           []byte
 }
 
 type ErrorResponse struct {


### PR DESCRIPTION
**Describe the change**
When the inference engine returns an error response that is not of type openai.ErrorResponse, a decode error occurs, leading to the loss of the original error message from the inference engine. To address this issue, this PR implements a change in the go-openai client that ensures the error from the inference engine is included in the openai.RequestError response. This enhancement preserves the original error information, providing clearer insights into the underlying issues.

**Describe your solution**
Introduced a new field called Body of type []byte in the openai.RequestError struct. This field stores the byte slice of the error response body received from the inference engine when the error response does not conform to the openai.ErrorResponse type. This enhancement allows to retain the original error message. Now that the byte slice of the error response body is included, clients using this library can unmarshal it on their end to obtain the correct error message. 

Issue: https://github.com/sashabaranov/go-openai/issues/874