### PR TITLE
Adding new moderation model constants

### DIFF
--- a/moderation.go
+++ b/moderation.go
@@ -14,8 +14,10 @@ import (
 // If you use text-moderation-stable, we will provide advanced notice before updating the model.
 // Accuracy of text-moderation-stable may be slightly lower than for text-moderation-latest.
 const (
-	ModerationTextStable = "text-moderation-stable"
-	ModerationTextLatest = "text-moderation-latest"
+	ModerationOmniLatest   = "omni-moderation-latest"
+	ModerationOmni20240926 = "omni-moderation-2024-09-26"
+	ModerationTextStable   = "text-moderation-stable"
+	ModerationTextLatest   = "text-moderation-latest"
 	// Deprecated: use ModerationTextStable and ModerationTextLatest instead.
 	ModerationText001 = "text-moderation-001"
 )
@@ -25,8 +27,10 @@ var (
 )
 
 var validModerationModel = map[string]struct{}{
-	ModerationTextStable: {},
-	ModerationTextLatest: {},
+	ModerationOmniLatest:   {},
+	ModerationOmni20240926: {},
+	ModerationTextStable:   {},
+	ModerationTextLatest:   {},
 }
 
 // ModerationRequest represents a request structure for moderation API.

--- a/moderation_test.go
+++ b/moderation_test.go
@@ -37,6 +37,8 @@ func TestModerationsWithDifferentModelOptions(t *testing.T) {
 		getModerationModelTestOption(openai.GPT3Dot5Turbo, openai.ErrModerationInvalidModel),
 		getModerationModelTestOption(openai.ModerationTextStable, nil),
 		getModerationModelTestOption(openai.ModerationTextLatest, nil),
+		getModerationModelTestOption(openai.ModerationOmni20240926, nil),
+		getModerationModelTestOption(openai.ModerationOmniLatest, nil),
 		getModerationModelTestOption("", nil),
 	)
 	client, server, teardown := setupOpenAITestServer()


### PR DESCRIPTION
**Describe the change**
Please provide a clear and concise description of the changes you're proposing. Explain what problem it solves or what feature it adds.
This change enables go-openai to use the omni moderation models that are now available to us from openai
**Provide OpenAI documentation link**
Provide a relevant API doc from https://platform.openai.com/docs/models/moderation

**Describe your solution**
These changes define the constants for the new moderation models as specified by openAI, and then puts them into the map of allowed models for the moderation endpoint.  I have tested these strings directly against the moderation api to confirm that these requests return a non-error response and specify the same model that is passed in. 
**Tests**
Briefly describe how you have tested these changes. If possible — please add integration tests.
Unit tests, with the addition of the new models. 
