### PR TITLE
Completion API: add Store and Metadata parameters

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -255,6 +255,11 @@ type ChatCompletionRequest struct {
 	StreamOptions *StreamOptions `json:"stream_options,omitempty"`
 	// Disable the default behavior of parallel tool calls by setting it: false.
 	ParallelToolCalls any `json:"parallel_tool_calls,omitempty"`
+	// Store can be set to true to store the output of this completion request for use in distillations and evals.
+	// https://platform.openai.com/docs/api-reference/chat/create#chat-create-store
+	Store bool `json:"store,omitempty"`
+	// Metadata to store with the completion.
+	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
 type StreamOptions struct {

--- a/completion.go
+++ b/completion.go
@@ -241,18 +241,20 @@ type CompletionRequest struct {
 	LogitBias map[string]int `json:"logit_bias,omitempty"`
 	// Store can be set to true to store the output of this completion request for use in distillations and evals.
 	// https://platform.openai.com/docs/api-reference/chat/create#chat-create-store
-	Store           bool     `json:"store,omitempty"`
-	LogProbs        int      `json:"logprobs,omitempty"`
-	MaxTokens       int      `json:"max_tokens,omitempty"`
-	N               int      `json:"n,omitempty"`
-	PresencePenalty float32  `json:"presence_penalty,omitempty"`
-	Seed            *int     `json:"seed,omitempty"`
-	Stop            []string `json:"stop,omitempty"`
-	Stream          bool     `json:"stream,omitempty"`
-	Suffix          string   `json:"suffix,omitempty"`
-	Temperature     float32  `json:"temperature,omitempty"`
-	TopP            float32  `json:"top_p,omitempty"`
-	User            string   `json:"user,omitempty"`
+	Store bool `json:"store,omitempty"`
+	// Metadata to store with the completion.
+	Metadata        map[string]string `json:"metadata,omitempty"`
+	LogProbs        int               `json:"logprobs,omitempty"`
+	MaxTokens       int               `json:"max_tokens,omitempty"`
+	N               int               `json:"n,omitempty"`
+	PresencePenalty float32           `json:"presence_penalty,omitempty"`
+	Seed            *int              `json:"seed,omitempty"`
+	Stop            []string          `json:"stop,omitempty"`
+	Stream          bool              `json:"stream,omitempty"`
+	Suffix          string            `json:"suffix,omitempty"`
+	Temperature     float32           `json:"temperature,omitempty"`
+	TopP            float32           `json:"top_p,omitempty"`
+	User            string            `json:"user,omitempty"`
 }
 
 // CompletionChoice represents one of possible completions.


### PR DESCRIPTION
**Describe the change**
The `store` parameter recently introduced by OpenAI has been added to `CompletionRequest` already in #870 ; it is here added to `ChatCompletionRequest`, and the related `metadata` parameter added to both.

**Provide OpenAI documentation link**
https://platform.openai.com/docs/api-reference/chat/create#chat-create-store
https://platform.openai.com/docs/api-reference/chat/create#chat-create-metadata

**Describe your solution**
Simply adds new fields to the API call objects.

**Tests**
No new tests added.

(Partly addresses) Issue: #872 