### PR TITLE
Handling for non-json response

### DIFF
--- a/client.go
+++ b/client.go
@@ -289,9 +289,6 @@ func (c *Client) handleErrorResp(resp *http.Response) error {
 	if err != nil {
 		return fmt.Errorf("error, reading response body: %w", err)
 	}
-	if !strings.HasPrefix(resp.Header.Get("Content-Type"), "application/json") {
-		return fmt.Errorf("error, status code: %d, status: %s, body: %s", resp.StatusCode, resp.Status, body)
-	}
 	var errRes ErrorResponse
 	err = json.Unmarshal(body, &errRes)
 	if err != nil || errRes.Error == nil {

--- a/client_test.go
+++ b/client_test.go
@@ -203,14 +203,16 @@ func TestHandleErrorResp(t *testing.T) {
 			name:        "413 Request Entity Too Large",
 			httpCode:    http.StatusRequestEntityTooLarge,
 			contentType: "text/html",
-			body: bytes.NewReader([]byte(`<html>
+			body: bytes.NewReader([]byte(`
+	<html>
 	<head><title>413 Request Entity Too Large</title></head>
 	<body>
 	<center><h1>413 Request Entity Too Large</h1></center>
 	<hr><center>nginx</center>
 	</body>
 	</html>`)),
-			expected: `error, status code: 413, status: , message: invalid character '<' looking for beginning of value, body: <html>
+			expected: `error, status code: 413, status: , message: invalid character '<' looking for beginning of value, body: 
+	<html>
 	<head><title>413 Request Entity Too Large</title></head>
 	<body>
 	<center><h1>413 Request Entity Too Large</h1></center>

--- a/client_test.go
+++ b/client_test.go
@@ -207,13 +207,7 @@ func TestHandleErrorResp(t *testing.T) {
 <hr><center>nginx</center>
 </body>
 </html>`)),
-			expected: `error, status code: 413, status: , body: <html>
-<head><title>413 Request Entity Too Large</title></head>
-<body>
-<center><h1>413 Request Entity Too Large</h1></center>
-<hr><center>nginx</center>
-</body>
-</html>`,
+			expected: `error, status code: 413, status: , message: invalid character '<' looking for beginning of value`,
 		},
 		{
 			name:        "errorReader",

--- a/client_test.go
+++ b/client_test.go
@@ -194,20 +194,29 @@ func TestHandleErrorResp(t *testing.T) {
 				{
 					"error":{}
 				}`)),
-			expected: "error, status code: 503, status: , message: ",
+			expected: `error, status code: 503, status: , message: , body: 
+				{
+					"error":{}
+				}`,
 		},
 		{
 			name:        "413 Request Entity Too Large",
 			httpCode:    http.StatusRequestEntityTooLarge,
 			contentType: "text/html",
 			body: bytes.NewReader([]byte(`<html>
-<head><title>413 Request Entity Too Large</title></head>
-<body>
-<center><h1>413 Request Entity Too Large</h1></center>
-<hr><center>nginx</center>
-</body>
-</html>`)),
-			expected: `error, status code: 413, status: , message: invalid character '<' looking for beginning of value`,
+	<head><title>413 Request Entity Too Large</title></head>
+	<body>
+	<center><h1>413 Request Entity Too Large</h1></center>
+	<hr><center>nginx</center>
+	</body>
+	</html>`)),
+			expected: `error, status code: 413, status: , message: invalid character '<' looking for beginning of value, body: <html>
+	<head><title>413 Request Entity Too Large</title></head>
+	<body>
+	<center><h1>413 Request Entity Too Large</h1></center>
+	<hr><center>nginx</center>
+	</body>
+	</html>`,
 		},
 		{
 			name:        "errorReader",

--- a/error.go
+++ b/error.go
@@ -104,7 +104,10 @@ func (e *APIError) UnmarshalJSON(data []byte) (err error) {
 }
 
 func (e *RequestError) Error() string {
-	return fmt.Sprintf("error, status code: %d, status: %s, message: %s, body: %s", e.HTTPStatusCode, e.HTTPStatus, e.Err, e.Body)
+	return fmt.Sprintf(
+		"error, status code: %d, status: %s, message: %s, body: %s",
+		e.HTTPStatusCode, e.HTTPStatus, e.Err, e.Body,
+	)
 }
 
 func (e *RequestError) Unwrap() error {

--- a/error.go
+++ b/error.go
@@ -104,7 +104,7 @@ func (e *APIError) UnmarshalJSON(data []byte) (err error) {
 }
 
 func (e *RequestError) Error() string {
-	return fmt.Sprintf("error, status code: %d, status: %s, message: %s", e.HTTPStatusCode, e.HTTPStatus, e.Err)
+	return fmt.Sprintf("error, status code: %d, status: %s, message: %s, body: %s", e.HTTPStatusCode, e.HTTPStatus, e.Err, e.Body)
 }
 
 func (e *RequestError) Unwrap() error {


### PR DESCRIPTION
**Describe the change**
Since the original error response is included in the body field of openai.RequestError, even when the response is not in JSON format, it would be more appropriate to return openai.RequestError directly, rather than returning an errorString. This approach ensures that the original error details are preserved within the body field.

**Describe your solution**
Removed the condition that checked if the response was in a non-JSON format and returned an errorString with the original error response. Now, the original error response will be directly included in the body field of openai.RequestError.

