### PR TITLE
Support Attachments in MessageRequest

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -52,10 +52,11 @@ type ImageFile struct {
 }
 
 type MessageRequest struct {
-	Role     string         `json:"role"`
-	Content  string         `json:"content"`
-	FileIds  []string       `json:"file_ids,omitempty"` //nolint:revive // backwards-compatibility
-	Metadata map[string]any `json:"metadata,omitempty"`
+	Role        string             `json:"role"`
+	Content     string             `json:"content"`
+	FileIds     []string           `json:"file_ids,omitempty"` //nolint:revive // backwards-compatibility
+	Metadata    map[string]any     `json:"metadata,omitempty"`
+	Attachments []ThreadAttachment `json:"attachments,omitempty"`
 }
 
 type MessageFile struct {

--- a/messages.go
+++ b/messages.go
@@ -11,11 +11,6 @@ const (
 	messagesSuffix = "messages"
 )
 
-const (
-	MessageToolCodeInterpreter = "code_interpreter"
-	MessageToolFileSearch      = "file_search"
-)
-
 type Message struct {
 	ID          string           `json:"id"`
 	Object      string           `json:"object"`

--- a/messages.go
+++ b/messages.go
@@ -11,6 +11,11 @@ const (
 	messagesSuffix = "messages"
 )
 
+const (
+	MessageToolCodeInterpreter = "code_interpreter"
+	MessageToolFileSearch      = "file_search"
+)
+
 type Message struct {
 	ID          string           `json:"id"`
 	Object      string           `json:"object"`

--- a/thread.go
+++ b/thread.go
@@ -9,12 +9,6 @@ const (
 	threadsSuffix = "/threads"
 )
 
-const (
-	ThreadAttachmentToolCodeInterpreter = "code_interpreter"
-	ThreadAttachmentToolFunction        = "function"
-	ThreadAttachmentToolFileSearch      = "file_search"
-)
-
 type Thread struct {
 	ID            string         `json:"id"`
 	Object        string         `json:"object"`

--- a/thread.go
+++ b/thread.go
@@ -9,6 +9,12 @@ const (
 	threadsSuffix = "/threads"
 )
 
+const (
+	ThreadAttachmentToolCodeInterpreter = "code_interpreter"
+	ThreadAttachmentToolFunction        = "function"
+	ThreadAttachmentToolFileSearch      = "file_search"
+)
+
 type Thread struct {
 	ID            string         `json:"id"`
 	Object        string         `json:"object"`


### PR DESCRIPTION
**Describe the change**
Add Attachments field in MessageRequest struct so we can attach file to thread message and can refer the file in chat content.

**Provide OpenAI documentation link**
https://platform.openai.com/docs/api-reference/messages/createMessage

**Describe your solution**
Adding Attachments Field and tools type const in message.go

**Tests**
using unit test and example app

**Additional context**
-

Issue: -
