### PR TITLE
Added Vector Store File List properties that allow for pagination

### DIFF
--- a/vector_store.go
+++ b/vector_store.go
@@ -83,6 +83,9 @@ type VectorStoreFileRequest struct {
 
 type VectorStoreFilesList struct {
 	VectorStoreFiles []VectorStoreFile `json:"data"`
+	FirstID          *string           `json:"first_id"`
+	LastID           *string           `json:"last_id"`
+	HasMore          bool              `json:"has_more"`
 
 	httpHeader
 }


### PR DESCRIPTION
**Describe the change**

This change adds pagniation properties for listing Vector Store Files.  A vector store can handle up to 10,000 files at the time of this PR and a max of 100 files can be returned per request.

**Provide OpenAI documentation link**

It's not specifically outlined in the documentation, however, the example response has these fields listed.  

https://platform.openai.com/docs/api-reference/vector-stores-files/listFiles

**Describe your solution**

Added the missing properties that are returned from the API request.
