### PR TITLE
Make user field optional in embedding request

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -211,7 +211,7 @@ func TestUploadBatchFileRequest_AddEmbedding(t *testing.T) {
 					Input: []string{"Hello", "World"},
 				},
 			},
-		}, []byte("{\"custom_id\":\"req-1\",\"body\":{\"input\":[\"Hello\",\"World\"],\"model\":\"gpt-3.5-turbo\",\"user\":\"\"},\"method\":\"POST\",\"url\":\"/v1/embeddings\"}\n{\"custom_id\":\"req-2\",\"body\":{\"input\":[\"Hello\",\"World\"],\"model\":\"text-embedding-ada-002\",\"user\":\"\"},\"method\":\"POST\",\"url\":\"/v1/embeddings\"}")}, //nolint:lll
+		}, []byte("{\"custom_id\":\"req-1\",\"body\":{\"input\":[\"Hello\",\"World\"],\"model\":\"gpt-3.5-turbo\"},\"method\":\"POST\",\"url\":\"/v1/embeddings\"}\n{\"custom_id\":\"req-2\",\"body\":{\"input\":[\"Hello\",\"World\"],\"model\":\"text-embedding-ada-002\"},\"method\":\"POST\",\"url\":\"/v1/embeddings\"}")}, //nolint:lll
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/embeddings.go
+++ b/embeddings.go
@@ -155,7 +155,7 @@ const (
 type EmbeddingRequest struct {
 	Input          any                     `json:"input"`
 	Model          EmbeddingModel          `json:"model"`
-	User           string                  `json:"user"`
+	User           string                  `json:"user,omitempty"`
 	EncodingFormat EmbeddingEncodingFormat `json:"encoding_format,omitempty"`
 	// Dimensions The number of dimensions the resulting output embeddings should have.
 	// Only supported in text-embedding-3 and later models.


### PR DESCRIPTION
**Describe the change**
Added `omitempty` json tag for the `User` field in the `EmbeddingRequest` struct. This field is optional in embedding requests as per OpenAI spec.

Issue: If you don't specify any user in the embedding request, the current spec sends the user as an empty string for which embedding models throw errors.

**Provide OpenAI documentation link**
https://platform.openai.com/docs/api-reference/embeddings/create#embeddings-create-user

**Describe your solution**
Added `omitempty` json tag for the `User` field in the `EmbeddingRequest` struct. This will make the `User` field optional as per openai embeddings spec.

**Tests**
Tested the above change by sending embeddings requests to the embeddings model with following payload:
```
curl -k -X 'POST' '/embeddings' \
 -H 'accept: application/json' \
 -H 'Content-Type: application/json' \
 -d '{
      "model": "embedding-model",
      "input": "Hello world",
      "user": "test"
}'

curl -k -X 'POST' '/embeddings' \
 -H 'accept: application/json' \
 -H 'Content-Type: application/json' \
 -d '{
      "model": "embedding-model",
      "input": "Hello world",
      "user": ""
}'

curl -k -X 'POST' '/embeddings' \
 -H 'accept: application/json' \
 -H 'Content-Type: application/json' \
 -d '{
      "model": "embedding-model",
      "input": "Hello world"
}'
```