### PR TITLE
Updated client_test to solve lint error

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -169,7 +169,7 @@ linters:
     - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
     # Removed execinquery (deprecated). execinquery is a linter about query string checker in Query function which reads your Go src files and warning it finds
     - exhaustive # check exhaustiveness of enum switch statements
-    - copyloopvar # checks for pointers to enclosing loop variables
+    - exportloopref # checks for pointers to enclosing loop variables
     - forbidigo # Forbids identifiers
     - funlen # Tool for detection of long functions
     # - gochecknoglobals # check that no global variables exist

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,7 +57,7 @@ linters-settings:
         # Default: true
         skipRecvDeref: false
 
-  gomnd:
+  mnd:
     # List of function patterns to exclude from analysis.
     # Values always ignored: `time.Date`
     # Default: []
@@ -167,9 +167,9 @@ linters:
     - durationcheck # check for two durations multiplied together
     - errname # Checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error.
     - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
-    - execinquery # execinquery is a linter about query string checker in Query function which reads your Go src files and warning it finds
+    # Removed execinquery (deprecated). execinquery is a linter about query string checker in Query function which reads your Go src files and warning it finds
     - exhaustive # check exhaustiveness of enum switch statements
-    - exportloopref # checks for pointers to enclosing loop variables
+    - copyloopvar # checks for pointers to enclosing loop variables
     - forbidigo # Forbids identifiers
     - funlen # Tool for detection of long functions
     # - gochecknoglobals # check that no global variables exist
@@ -180,7 +180,6 @@ linters:
     - gocyclo # Computes and checks the cyclomatic complexity of functions
     - godot # Check if comments end in a period
     - goimports # In addition to fixing imports, goimports also formats your code in the same style as gofmt.
-    - gomnd # An analyzer to detect magic numbers.
     - gomoddirectives # Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod.
     - gomodguard # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations.
     - goprintffuncname # Checks that printf-like functions are named with f at the end
@@ -188,6 +187,7 @@ linters:
     - lll # Reports long lines
     - makezero # Finds slice declarations with non-zero initial length
     # - nakedret # Finds naked returns in functions greater than a specified function length
+    - mnd # An analyzer to detect magic numbers.
     - nestif # Reports deeply nested if statements
     - nilerr # Finds the code that returns nil even if it checks that the error is not nil.
     - nilnil # Checks that there is no simultaneous return of nil error and an invalid value.

--- a/client_test.go
+++ b/client_test.go
@@ -513,8 +513,14 @@ func TestClient_suffixWithAPIVersion(t *testing.T) {
 			}
 			defer func() {
 				if r := recover(); r != nil {
-					if r.(string) != tt.wantPanic {
-						t.Errorf("suffixWithAPIVersion() = %v, want %v", r, tt.wantPanic)
+					// Check if the panic message matches the expected panic message
+					if rStr, ok := r.(string); ok {
+						if rStr != tt.wantPanic {
+							t.Errorf("suffixWithAPIVersion() = %v, want %v", rStr, tt.wantPanic)
+						}
+					} else {
+						// If the panic is not a string, log it
+						t.Errorf("suffixWithAPIVersion() panicked with non-string value: %v", r)
 					}
 				}
 			}()


### PR DESCRIPTION
**Describe the change**
Latest version of golangci-lint is used in github workflows to check for lint errors. The [recent release](https://github.com/golangci/golangci-lint/releases/tag/v1.62.0) of golangci-lint introduced additional linting rules, which surfaced a new [lint error](https://github.com/sashabaranov/go-openai/actions/runs/11833389300/job/32971951797#step:5:25) in client_test.go file. Also linter execinquery is deprecated and linter gomnd is replaced by mnd [more info](https://github.com/golangci/golangci-lint/pull/5110)
This PR addresses and resolves that newly reported lint error and removes the deprecated linters.

**Describe your solution**
PR adds a type assertion to check if the recovered panic value (r) is a string before comparing it to the expected panic message (tt.wantPanic). If r is indeed a string, it verifies that the panic message matches the expected output.If r is not a string, the code now logs a message indicating that the panic value was of an unexpected type.
