### PR TITLE
Allow streaming for O1 model family

### DIFF
--- a/chat_stream_test.go
+++ b/chat_stream_test.go
@@ -36,27 +36,6 @@ func TestChatCompletionsStreamWrongModel(t *testing.T) {
 	}
 }
 
-func TestChatCompletionsStreamWithO1BetaLimitations(t *testing.T) {
-	config := openai.DefaultConfig("whatever")
-	config.BaseURL = "http://localhost/v1/chat/completions"
-	client := openai.NewClientWithConfig(config)
-	ctx := context.Background()
-
-	req := openai.ChatCompletionRequest{
-		Model: openai.O1Preview,
-		Messages: []openai.ChatCompletionMessage{
-			{
-				Role:    openai.ChatMessageRoleUser,
-				Content: "Hello!",
-			},
-		},
-	}
-	_, err := client.CreateChatCompletionStream(ctx, req)
-	if !errors.Is(err, openai.ErrO1BetaLimitationsStreaming) {
-		t.Fatalf("CreateChatCompletion should return ErrO1BetaLimitationsStreaming, but returned: %v", err)
-	}
-}
-
 func TestCreateChatCompletionStream(t *testing.T) {
 	client, server, teardown := setupOpenAITestServer()
 	defer teardown()

--- a/completion.go
+++ b/completion.go
@@ -15,7 +15,6 @@ var (
 
 var (
 	ErrO1BetaLimitationsMessageTypes = errors.New("this model has beta-limitations, user and assistant messages only, system messages are not supported")                                  //nolint:lll
-	ErrO1BetaLimitationsStreaming    = errors.New("this model has beta-limitations, streaming not supported")                                                                              //nolint:lll
 	ErrO1BetaLimitationsTools        = errors.New("this model has beta-limitations, tools, function calling, and response format parameters are not supported")                            //nolint:lll
 	ErrO1BetaLimitationsLogprobs     = errors.New("this model has beta-limitations, logprobs not supported")                                                                               //nolint:lll
 	ErrO1BetaLimitationsOther        = errors.New("this model has beta-limitations, temperature, top_p and n are fixed at 1, while presence_penalty and frequency_penalty are fixed at 0") //nolint:lll
@@ -199,12 +198,6 @@ func validateRequestForO1Models(request ChatCompletionRequest) error {
 		return ErrO1MaxTokensDeprecated
 	}
 
-	// Beta Limitations
-	// refs:https://platform.openai.com/docs/guides/reasoning/beta-limitations
-	// Streaming: not supported
-	if request.Stream {
-		return ErrO1BetaLimitationsStreaming
-	}
 	// Logprobs: not supported.
 	if request.LogProbs {
 		return ErrO1BetaLimitationsLogprobs


### PR DESCRIPTION
**Describe the change**
Don't return error if streaming is enable for o1 model family.

**Provide OpenAI documentation link**
https://platform.openai.com/docs/api-reference/streaming

**Additional context**
https://x.com/OpenAIDevs/status/1858609150999359559
