### PR TITLE
Fix ID field to be optional

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -179,7 +179,7 @@ func (m *ChatCompletionMessage) UnmarshalJSON(bs []byte) error {
 type ToolCall struct {
 	// Index is not nil only in chat completion chunk object
 	Index    *int         `json:"index,omitempty"`
-	ID       string       `json:"id"`
+	ID       string       `json:"id,omitempty"`
 	Type     ToolType     `json:"type"`
 	Function FunctionCall `json:"function"`
 }


### PR DESCRIPTION
When testing tool calls in streaming mode I noticed that I was getting entirely empty deltas. Dumping the json before trying to deserialize showed that the "id" field is missing after the first message. Here's an example json:


```json
{
    "id": "chatcmpl-...",
    "object": "chat.completion.chunk",
    "created": 1733436687,
    "model": "gpt-4o-2024-08-06",
    "system_fingerprint": "fp_...",
    "choices": [
        {
            "index": 0,
            "delta": {
                "tool_calls": [
                    {
                        "index": 0,
                        "function": {
                            "arguments": "{\""
                        }
                    }
                ]
            },
            "logprobs": null,
            "finish_reason": null
        }
    ]
}
```

I tested these changes in a local copy of the lib and it was able to parse successfully.
