### PR TITLE
[BREAKING_CHANGES] Make temperature nullable so that it can be set to 0

### DIFF
--- a/audio.go
+++ b/audio.go
@@ -45,8 +45,8 @@ type AudioRequest struct {
 	Reader io.Reader
 
 	Prompt                 string
-	Temperature            float32
-	Language               string // Only for transcription.
+	Temperature            float32 // defaults to 0, so fine to not be a pointer
+	Language               string  // Only for transcription.
 	Format                 AudioResponseFormat
 	TimestampGranularities []TranscriptionTimestampGranularity // Only for transcription.
 }

--- a/chat.go
+++ b/chat.go
@@ -222,7 +222,7 @@ type ChatCompletionRequest struct {
 	// MaxCompletionTokens An upper bound for the number of tokens that can be generated for a completion,
 	// including visible output tokens and reasoning tokens https://platform.openai.com/docs/guides/reasoning
 	MaxCompletionTokens int                           `json:"max_completion_tokens,omitempty"`
-	Temperature         float32                       `json:"temperature,omitempty"`
+	Temperature         *float32                      `json:"temperature,omitempty"`
 	TopP                float32                       `json:"top_p,omitempty"`
 	N                   int                           `json:"n,omitempty"`
 	Stream              bool                          `json:"stream,omitempty"`

--- a/chat_test.go
+++ b/chat_test.go
@@ -153,7 +153,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 						Role: openai.ChatMessageRoleAssistant,
 					},
 				},
-				Temperature: float32(2),
+				Temperature: openai.NewFloat(2),
 			},
 			expectedError: openai.ErrO1BetaLimitationsOther,
 		},
@@ -170,7 +170,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 						Role: openai.ChatMessageRoleAssistant,
 					},
 				},
-				Temperature: float32(1),
+				Temperature: openai.NewFloat(1),
 				TopP:        float32(0.1),
 			},
 			expectedError: openai.ErrO1BetaLimitationsOther,
@@ -188,7 +188,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 						Role: openai.ChatMessageRoleAssistant,
 					},
 				},
-				Temperature: float32(1),
+				Temperature: openai.NewFloat(1),
 				TopP:        float32(1),
 				N:           2,
 			},
@@ -254,6 +254,22 @@ func TestChatRequestOmitEmpty(t *testing.T) {
 
 	// messages is also required so isn't omitted
 	const expected = `{"model":"gpt-4","messages":null}`
+	if string(data) != expected {
+		t.Errorf("expected JSON with all empty fields to be %v but was %v", expected, string(data))
+	}
+}
+
+func TestChatRequestOmitEmptyWithZeroTemp(t *testing.T) {
+	data, err := json.Marshal(openai.ChatCompletionRequest{
+		// We set model b/c it's required, so omitempty doesn't make sense
+		Model:       "gpt-4",
+		Temperature: openai.NewFloat(0),
+	})
+	checks.NoError(t, err)
+
+	// messages is also required so isn't omitted
+	// but the zero-value for temp is not excluded, b/c that's a valid value to set the temp to!
+	const expected = `{"model":"gpt-4","messages":null,"temperature":0}`
 	if string(data) != expected {
 		t.Errorf("expected JSON with all empty fields to be %v but was %v", expected, string(data))
 	}

--- a/common.go
+++ b/common.go
@@ -22,3 +22,13 @@ type PromptTokensDetails struct {
 	AudioTokens  int `json:"audio_tokens"`
 	CachedTokens int `json:"cached_tokens"`
 }
+
+// NewFloat returns a pointer to a float, useful for setting the temperature on some APIs
+func NewFloat(v float32) *float32 {
+	return &v
+}
+
+// NewInt returns a pointer to an int, useful for setting the seed and other nullable parameters
+func NewInt(v int) *int {
+	return &v
+}

--- a/completion.go
+++ b/completion.go
@@ -220,7 +220,7 @@ func validateRequestForO1Models(request ChatCompletionRequest) error {
 	}
 
 	// Other: temperature, top_p and n are fixed at 1, while presence_penalty and frequency_penalty are fixed at 0.
-	if request.Temperature > 0 && request.Temperature != 1 {
+	if request.Temperature != nil && *request.Temperature != 1 {
 		return ErrO1BetaLimitationsOther
 	}
 	if request.TopP > 0 && request.TopP != 1 {
@@ -263,7 +263,7 @@ type CompletionRequest struct {
 	Stop            []string          `json:"stop,omitempty"`
 	Stream          bool              `json:"stream,omitempty"`
 	Suffix          string            `json:"suffix,omitempty"`
-	Temperature     float32           `json:"temperature,omitempty"`
+	Temperature     *float32          `json:"temperature,omitempty"`
 	TopP            float32           `json:"top_p,omitempty"`
 	User            string            `json:"user,omitempty"`
 }


### PR DESCRIPTION
For the Chat and Completions APIs make the `Temperature` field a `*float32` so we can distinguish between `0` and `null`.  Users often want to set the temperature to 0, but right now that's not possible because then the `temperature` field is `omitempty`'d from the JSON request object.

Other numeric parameters already default to 0 or have 0 as a nonsensical value, so this is only needed, AFAICT, for these two params.

This is an API break, but I think it's one worth making.  We've been unintentionally running queries at the default temp (2) when we meant to be running it at 0.

Fixes #9