### PR TITLE
Make "Content" field in "ChatCompletionMessage" omitempty

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -93,7 +93,7 @@ type ChatMessagePart struct {
 
 type ChatCompletionMessage struct {
 	Role         string `json:"role"`
-	Content      string `json:"content"`
+	Content      string `json:"content,omitempty"`
 	Refusal      string `json:"refusal,omitempty"`
 	MultiContent []ChatMessagePart
 
@@ -132,7 +132,7 @@ func (m ChatCompletionMessage) MarshalJSON() ([]byte, error) {
 
 	msg := struct {
 		Role         string            `json:"role"`
-		Content      string            `json:"content"`
+		Content      string            `json:"content,omitempty"`
 		Refusal      string            `json:"refusal,omitempty"`
 		MultiContent []ChatMessagePart `json:"-"`
 		Name         string            `json:"name,omitempty"`
@@ -146,7 +146,7 @@ func (m ChatCompletionMessage) MarshalJSON() ([]byte, error) {
 func (m *ChatCompletionMessage) UnmarshalJSON(bs []byte) error {
 	msg := struct {
 		Role         string `json:"role"`
-		Content      string `json:"content"`
+		Content      string `json:"content,omitempty"`
 		Refusal      string `json:"refusal,omitempty"`
 		MultiContent []ChatMessagePart
 		Name         string        `json:"name,omitempty"`

--- a/chat_test.go
+++ b/chat_test.go
@@ -631,7 +631,7 @@ func TestMultipartChatMessageSerialization(t *testing.T) {
 		t.Fatalf("Unexpected error")
 	}
 	res = strings.ReplaceAll(string(s), " ", "")
-	if res != `{"role":"user","content":""}` {
+	if res != `{"role":"user"}` {
 		t.Fatalf("invalid message: %s", string(s))
 	}
 }

--- a/openai_test.go
+++ b/openai_test.go
@@ -29,9 +29,9 @@ func setupAzureTestServer() (client *openai.Client, server *test.ServerTest, tea
 
 // numTokens Returns the number of GPT-3 encoded tokens in the given text.
 // This function approximates based on the rule of thumb stated by OpenAI:
-// https://beta.openai.com/tokenizer
+// https://beta.openai.com/tokenizer/
 //
-// TODO: implement an actual tokenizer for GPT-3 and Codex (once available)
+// TODO: implement an actual tokenizer for GPT-3 and Codex (once available).
 func numTokens(s string) int {
 	return int(float32(len(s)) / 4)
 }


### PR DESCRIPTION
**Describe the change**
According to the OpenAI API spec, the content field of ChatCompletionMessage should be nullable. Right now when we try to marshal the struct with empty string, we get `"content": ""`, but ideally, the content key should exist if that field is empty

**Provide OpenAI documentation link**
https://platform.openai.com/docs/api-reference/chat/object
Under: choices -> message -> content
<img width="607" alt="image" src="https://github.com/user-attachments/assets/4e8ebbfe-5fb1-4c89-8b77-06d9c571c99c" />


**Describe your solution**
We can fix this my adding an omitempty json tag to the "content" field in the "ChatCompletionMessage" struct

**Tests**
Tested this by sending a completion request with empty content field to a Nvidia NIM Inference Server

