### PR TITLE
feat: update ChatCompletionResponseFormatJSONSchema to use jsonschema…

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 Your issue may already be reported!
-Please search on the [issue tracker](https://github.com/sashabaranov/go-openai/issues) before creating one.
+Please search on the [issue tracker](https://github.com/alejandrojnm/go-openai/issues) before creating one.
 
 **Describe the bug**
 A clear and concise description of what the bug is. If it's an API-related bug, please provide relevant endpoint(s).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 Your issue may already be reported!
-Please search on the [issue tracker](https://github.com/sashabaranov/go-openai/issues) before creating one.
+Please search on the [issue tracker](https://github.com/alejandrojnm/go-openai/issues) before creating one.
 
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 A similar PR may already be submitted!
-Please search among the [Pull request](https://github.com/sashabaranov/go-openai/pulls) before creating one.
+Please search among the [Pull request](https://github.com/alejandrojnm/go-openai/pulls) before creating one.
 
 If your changes introduce breaking changes, please prefix the title of your pull request with "[BREAKING_CHANGES]". This allows for clear identification of such changes in the 'What's Changed' section on the release page, making it developer-friendly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,22 +1,22 @@
 # Contributing Guidelines
 
 ## Overview
-Thank you for your interest in contributing to the "Go OpenAI" project! By following this guideline, we hope to ensure that your contributions are made smoothly and efficiently. The Go OpenAI project is licensed under the [Apache 2.0 License](https://github.com/sashabaranov/go-openai/blob/master/LICENSE), and we welcome contributions through GitHub pull requests.
+Thank you for your interest in contributing to the "Go OpenAI" project! By following this guideline, we hope to ensure that your contributions are made smoothly and efficiently. The Go OpenAI project is licensed under the [Apache 2.0 License](https://github.com/alejandrojnm/go-openai/blob/master/LICENSE), and we welcome contributions through GitHub pull requests.
 
 ## Reporting Bugs
-If you discover a bug, first check the [GitHub Issues page](https://github.com/sashabaranov/go-openai/issues) to see if the issue has already been reported. If you're reporting a new issue, please use the "Bug report" template and provide detailed information about the problem, including steps to reproduce it.
+If you discover a bug, first check the [GitHub Issues page](https://github.com/alejandrojnm/go-openai/issues) to see if the issue has already been reported. If you're reporting a new issue, please use the "Bug report" template and provide detailed information about the problem, including steps to reproduce it.
 
 ## Suggesting Features
-If you want to suggest a new feature or improvement, first check the [GitHub Issues page](https://github.com/sashabaranov/go-openai/issues) to ensure a similar suggestion hasn't already been made. Use the "Feature request" template to provide a detailed description of your suggestion.
+If you want to suggest a new feature or improvement, first check the [GitHub Issues page](https://github.com/alejandrojnm/go-openai/issues) to ensure a similar suggestion hasn't already been made. Use the "Feature request" template to provide a detailed description of your suggestion.
 
 ## Reporting Vulnerabilities
-If you identify a security concern, please use the "Report a security vulnerability" template on the [GitHub Issues page](https://github.com/sashabaranov/go-openai/issues) to share the details. This report will only be viewable to repository maintainers. You will be credited if the advisory is published.
+If you identify a security concern, please use the "Report a security vulnerability" template on the [GitHub Issues page](https://github.com/alejandrojnm/go-openai/issues) to share the details. This report will only be viewable to repository maintainers. You will be credited if the advisory is published.
 
 ## Questions for Users
-If you have questions, please utilize [StackOverflow](https://stackoverflow.com/) or the [GitHub Discussions page](https://github.com/sashabaranov/go-openai/discussions).
+If you have questions, please utilize [StackOverflow](https://stackoverflow.com/) or the [GitHub Discussions page](https://github.com/alejandrojnm/go-openai/discussions).
 
 ## Contributing Code
-There might already be a similar pull requests submitted! Please search for [pull requests](https://github.com/sashabaranov/go-openai/pulls) before creating one.
+There might already be a similar pull requests submitted! Please search for [pull requests](https://github.com/alejandrojnm/go-openai/pulls) before creating one.
 
 ### Requirements for Merging a Pull Request
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Go OpenAI
-[![Go Reference](https://pkg.go.dev/badge/github.com/sashabaranov/go-openai.svg)](https://pkg.go.dev/github.com/sashabaranov/go-openai)
-[![Go Report Card](https://goreportcard.com/badge/github.com/sashabaranov/go-openai)](https://goreportcard.com/report/github.com/sashabaranov/go-openai)
+[![Go Reference](https://pkg.go.dev/badge/github.com/alejandrojnm/go-openai.svg)](https://pkg.go.dev/github.com/alejandrojnm/go-openai)
+[![Go Report Card](https://goreportcard.com/badge/github.com/alejandrojnm/go-openai)](https://goreportcard.com/report/github.com/alejandrojnm/go-openai)
 [![codecov](https://codecov.io/gh/sashabaranov/go-openai/branch/master/graph/badge.svg?token=bCbIfHLIsW)](https://codecov.io/gh/sashabaranov/go-openai)
 
 This library provides unofficial Go clients for [OpenAI API](https://platform.openai.com/). We support: 
@@ -13,7 +13,7 @@ This library provides unofficial Go clients for [OpenAI API](https://platform.op
 ## Installation
 
 ```
-go get github.com/sashabaranov/go-openai
+go get github.com/alejandrojnm/go-openai
 ```
 Currently, go-openai requires Go version 1.18 or greater.
 
@@ -28,7 +28,7 @@ package main
 import (
 	"context"
 	"fmt"
-	openai "github.com/sashabaranov/go-openai"
+	openai "github.com/alejandrojnm/go-openai"
 )
 
 func main() {
@@ -80,7 +80,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	openai "github.com/sashabaranov/go-openai"
+	openai "github.com/alejandrojnm/go-openai"
 )
 
 func main() {
@@ -133,7 +133,7 @@ package main
 import (
 	"context"
 	"fmt"
-	openai "github.com/sashabaranov/go-openai"
+	openai "github.com/alejandrojnm/go-openai"
 )
 
 func main() {
@@ -166,7 +166,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	openai "github.com/sashabaranov/go-openai"
+	openai "github.com/alejandrojnm/go-openai"
 )
 
 func main() {
@@ -215,7 +215,7 @@ import (
 	"context"
 	"fmt"
 
-	openai "github.com/sashabaranov/go-openai"
+	openai "github.com/alejandrojnm/go-openai"
 )
 
 func main() {
@@ -247,7 +247,7 @@ import (
 	"fmt"
 	"os"
 
-	openai "github.com/sashabaranov/go-openai"
+	openai "github.com/alejandrojnm/go-openai"
 )
 
 func main() {
@@ -288,7 +288,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	openai "github.com/sashabaranov/go-openai"
+	openai "github.com/alejandrojnm/go-openai"
 	"image/png"
 	"os"
 )
@@ -376,7 +376,7 @@ config.HTTPClient = &http.Client{
 c := openai.NewClientWithConfig(config)
 ```
 
-See also: https://pkg.go.dev/github.com/sashabaranov/go-openai#ClientConfig
+See also: https://pkg.go.dev/github.com/alejandrojnm/go-openai#ClientConfig
 </details>
 
 <details>
@@ -392,7 +392,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/sashabaranov/go-openai"
+	"github.com/alejandrojnm/go-openai"
 )
 
 func main() {
@@ -446,7 +446,7 @@ import (
 	"context"
 	"fmt"
 
-	openai "github.com/sashabaranov/go-openai"
+	openai "github.com/alejandrojnm/go-openai"
 )
 
 func main() {
@@ -492,7 +492,7 @@ package main
 import (
 	"context"
 	"log"
-	openai "github.com/sashabaranov/go-openai"
+	openai "github.com/alejandrojnm/go-openai"
 
 )
 
@@ -549,7 +549,7 @@ import (
 	"context"
 	"fmt"
 
-	openai "github.com/sashabaranov/go-openai"
+	openai "github.com/alejandrojnm/go-openai"
 )
 
 func main() {
@@ -680,7 +680,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/sashabaranov/go-openai"
+	"github.com/alejandrojnm/go-openai"
 )
 
 func main() {
@@ -755,8 +755,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/jsonschema"
+	"github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/jsonschema"
 )
 
 func main() {
@@ -828,7 +828,7 @@ Due to the factors mentioned above, different answers may be returned even for t
 By adopting these strategies, you can expect more consistent results.
 
 **Related Issues:**  
-[omitempty option of request struct will generate incorrect request when parameter is 0.](https://github.com/sashabaranov/go-openai/issues/9)
+[omitempty option of request struct will generate incorrect request when parameter is 0.](https://github.com/alejandrojnm/go-openai/issues/9)
 
 ### Does Go OpenAI provide a method to count tokens?
 
@@ -839,15 +839,15 @@ For counting tokens, you might find the following links helpful:
 - [How to count tokens with tiktoken](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb)
 
 **Related Issues:**  
-[Is it possible to join the implementation of GPT3 Tokenizer](https://github.com/sashabaranov/go-openai/issues/62)
+[Is it possible to join the implementation of GPT3 Tokenizer](https://github.com/alejandrojnm/go-openai/issues/62)
 
 ## Contributing
 
-By following [Contributing Guidelines](https://github.com/sashabaranov/go-openai/blob/master/CONTRIBUTING.md), we hope to ensure that your contributions are made smoothly and efficiently.
+By following [Contributing Guidelines](https://github.com/alejandrojnm/go-openai/blob/master/CONTRIBUTING.md), we hope to ensure that your contributions are made smoothly and efficiently.
 
 ## Thank you
 
-We want to take a moment to express our deepest gratitude to the [contributors](https://github.com/sashabaranov/go-openai/graphs/contributors) and sponsors of this project:
+We want to take a moment to express our deepest gratitude to the [contributors](https://github.com/alejandrojnm/go-openai/graphs/contributors) and sponsors of this project:
 - [Carson Kahn](https://carsonkahn.com) of [Spindle AI](https://spindleai.com)
 
 To all of you: thank you. You've helped us achieve more than we ever imagined possible. Can't wait to see where we go next, together!

--- a/api_integration_test.go
+++ b/api_integration_test.go
@@ -10,9 +10,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
-	"github.com/sashabaranov/go-openai/jsonschema"
+	"github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
+	"github.com/alejandrojnm/go-openai/jsonschema"
 )
 
 func TestAPI(t *testing.T) {

--- a/assistant_test.go
+++ b/assistant_test.go
@@ -3,8 +3,8 @@ package openai_test
 import (
 	"context"
 
-	openai "github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	openai "github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 
 	"encoding/json"
 	"fmt"

--- a/audio.go
+++ b/audio.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"os"
 
-	utils "github.com/sashabaranov/go-openai/internal"
+	utils "github.com/alejandrojnm/go-openai/internal"
 )
 
 // Whisper Defines the models provided by OpenAI to use when processing audio with OpenAI.

--- a/audio_api_test.go
+++ b/audio_api_test.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/internal/test"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	"github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/internal/test"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 )
 
 // TestAudio Tests the transcription and translation endpoints of the API using the mocked server.

--- a/audio_test.go
+++ b/audio_test.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/sashabaranov/go-openai/internal/test"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	"github.com/alejandrojnm/go-openai/internal/test"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 )
 
 func TestAudioWithFailingFormBuilder(t *testing.T) {

--- a/batch_test.go
+++ b/batch_test.go
@@ -7,8 +7,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	"github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 )
 
 func TestUploadBatchFile(t *testing.T) {

--- a/chat.go
+++ b/chat.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/sashabaranov/go-openai/jsonschema"
+	"github.com/alejandrojnm/go-openai/jsonschema"
 )
 
 // Chat message role defined by the OpenAI API.

--- a/chat.go
+++ b/chat.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+
+	"github.com/sashabaranov/go-openai/jsonschema"
 )
 
 // Chat message role defined by the OpenAI API.
@@ -204,10 +206,10 @@ type ChatCompletionResponseFormat struct {
 }
 
 type ChatCompletionResponseFormatJSONSchema struct {
-	Name        string         `json:"name"`
-	Description string         `json:"description,omitempty"`
-	Schema      json.Marshaler `json:"schema"`
-	Strict      bool           `json:"strict"`
+	Name        string                `json:"name"`
+	Description string                `json:"description,omitempty"`
+	Schema      jsonschema.Definition `json:"schema"`
+	Strict      bool                  `json:"strict"`
 }
 
 // ChatCompletionRequest represents a request structure for chat completion API.

--- a/chat_stream_test.go
+++ b/chat_stream_test.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	"github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 )
 
 func TestChatCompletionsStreamWrongModel(t *testing.T) {

--- a/chat_test.go
+++ b/chat_test.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
-	"github.com/sashabaranov/go-openai/jsonschema"
+	"github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
+	"github.com/alejandrojnm/go-openai/jsonschema"
 )
 
 const (

--- a/client.go
+++ b/client.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 	"strings"
 
-	utils "github.com/sashabaranov/go-openai/internal"
+	utils "github.com/alejandrojnm/go-openai/internal"
 )
 
 // Client is OpenAI GPT-3 API client.

--- a/client_test.go
+++ b/client_test.go
@@ -10,8 +10,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/sashabaranov/go-openai/internal/test"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	"github.com/alejandrojnm/go-openai/internal/test"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 )
 
 var errTestRequestBuilderFailed = errors.New("test request builder failed")

--- a/completion_test.go
+++ b/completion_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	"github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 )
 
 func TestCompletionsWrongModel(t *testing.T) {

--- a/config_test.go
+++ b/config_test.go
@@ -3,7 +3,7 @@ package openai_test
 import (
 	"testing"
 
-	"github.com/sashabaranov/go-openai"
+	"github.com/alejandrojnm/go-openai"
 )
 
 func TestGetAzureDeploymentByModel(t *testing.T) {

--- a/edits_test.go
+++ b/edits_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	"github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 )
 
 // TestEdits Tests the edits endpoint of the API using the mocked server.

--- a/embeddings_test.go
+++ b/embeddings_test.go
@@ -11,8 +11,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	"github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 )
 
 func TestEmbedding(t *testing.T) {

--- a/engines_test.go
+++ b/engines_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	"github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 )
 
 // TestGetEngine Tests the retrieve engine endpoint of the API using the mocked server.

--- a/error.go
+++ b/error.go
@@ -54,7 +54,7 @@ func (e *APIError) UnmarshalJSON(data []byte) (err error) {
 	err = json.Unmarshal(rawMap["message"], &e.Message)
 	if err != nil {
 		// If the parameter field of a function call is invalid as a JSON schema
-		// refs: https://github.com/sashabaranov/go-openai/issues/381
+		// refs: https://github.com/alejandrojnm/go-openai/issues/381
 		var messages []string
 		err = json.Unmarshal(rawMap["message"], &messages)
 		if err != nil {
@@ -64,7 +64,7 @@ func (e *APIError) UnmarshalJSON(data []byte) (err error) {
 	}
 
 	// optional fields for azure openai
-	// refs: https://github.com/sashabaranov/go-openai/issues/343
+	// refs: https://github.com/alejandrojnm/go-openai/issues/343
 	if _, ok := rawMap["type"]; ok {
 		err = json.Unmarshal(rawMap["type"], &e.Type)
 		if err != nil {

--- a/error_test.go
+++ b/error_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/sashabaranov/go-openai"
+	"github.com/alejandrojnm/go-openai"
 )
 
 func TestAPIErrorUnmarshalJSON(t *testing.T) {

--- a/example_test.go
+++ b/example_test.go
@@ -11,7 +11,7 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/sashabaranov/go-openai"
+	"github.com/alejandrojnm/go-openai"
 )
 
 func Example() {

--- a/examples/chatbot/main.go
+++ b/examples/chatbot/main.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sashabaranov/go-openai"
+	"github.com/alejandrojnm/go-openai"
 )
 
 func main() {

--- a/examples/completion-with-tool/main.go
+++ b/examples/completion-with-tool/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/jsonschema"
+	"github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/jsonschema"
 )
 
 func main() {

--- a/examples/completion/main.go
+++ b/examples/completion/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sashabaranov/go-openai"
+	"github.com/alejandrojnm/go-openai"
 )
 
 func main() {

--- a/examples/images/main.go
+++ b/examples/images/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sashabaranov/go-openai"
+	"github.com/alejandrojnm/go-openai"
 )
 
 func main() {

--- a/examples/voice-to-text/main.go
+++ b/examples/voice-to-text/main.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sashabaranov/go-openai"
+	"github.com/alejandrojnm/go-openai"
 )
 
 func main() {

--- a/files_api_test.go
+++ b/files_api_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	"github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 )
 
 func TestFileBytesUpload(t *testing.T) {

--- a/files_test.go
+++ b/files_test.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"testing"
 
-	utils "github.com/sashabaranov/go-openai/internal"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	utils "github.com/alejandrojnm/go-openai/internal"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 )
 
 func TestFileBytesUploadWithFailingFormBuilder(t *testing.T) {

--- a/fine_tunes_test.go
+++ b/fine_tunes_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	"github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 )
 
 const testFineTuneID = "fine-tune-id"

--- a/fine_tuning_job_test.go
+++ b/fine_tuning_job_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	"github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 )
 
 const testFineTuninigJobID = "fine-tuning-job-id"

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/sashabaranov/go-openai
+module github.com/alejandrojnm/go-openai
 
 go 1.18

--- a/image_api_test.go
+++ b/image_api_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	"github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 )
 
 func TestImages(t *testing.T) {

--- a/image_test.go
+++ b/image_test.go
@@ -1,8 +1,8 @@
 package openai //nolint:testpackage // testing private field
 
 import (
-	utils "github.com/sashabaranov/go-openai/internal"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	utils "github.com/alejandrojnm/go-openai/internal"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 
 	"context"
 	"fmt"

--- a/internal/error_accumulator_test.go
+++ b/internal/error_accumulator_test.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"testing"
 
-	utils "github.com/sashabaranov/go-openai/internal"
-	"github.com/sashabaranov/go-openai/internal/test"
+	utils "github.com/alejandrojnm/go-openai/internal"
+	"github.com/alejandrojnm/go-openai/internal/test"
 )
 
 func TestErrorAccumulatorBytes(t *testing.T) {

--- a/internal/form_builder_test.go
+++ b/internal/form_builder_test.go
@@ -1,8 +1,8 @@
 package openai //nolint:testpackage // testing private field
 
 import (
-	"github.com/sashabaranov/go-openai/internal/test"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	"github.com/alejandrojnm/go-openai/internal/test"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 
 	"bytes"
 	"errors"

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -1,7 +1,7 @@
 package test
 
 import (
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 
 	"net/http"
 	"os"

--- a/jsonschema/json_test.go
+++ b/jsonschema/json_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/sashabaranov/go-openai/jsonschema"
+	"github.com/alejandrojnm/go-openai/jsonschema"
 )
 
 func TestDefinition_MarshalJSON(t *testing.T) {

--- a/jsonschema/validate_test.go
+++ b/jsonschema/validate_test.go
@@ -3,7 +3,7 @@ package jsonschema_test
 import (
 	"testing"
 
-	"github.com/sashabaranov/go-openai/jsonschema"
+	"github.com/alejandrojnm/go-openai/jsonschema"
 )
 
 func Test_Validate(t *testing.T) {

--- a/messages_test.go
+++ b/messages_test.go
@@ -7,9 +7,9 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/internal/test"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	"github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/internal/test"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 )
 
 var emptyStr = ""

--- a/models_test.go
+++ b/models_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	"github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 )
 
 const testFineTuneModelID = "fine-tune-model-id"

--- a/moderation_test.go
+++ b/moderation_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	"github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 )
 
 // TestModeration Tests the moderations endpoint of the API using the mocked server.

--- a/openai_test.go
+++ b/openai_test.go
@@ -1,8 +1,8 @@
 package openai_test
 
 import (
-	"github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/internal/test"
+	"github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/internal/test"
 )
 
 func setupOpenAITestServer() (client *openai.Client, server *test.ServerTest, teardown func()) {

--- a/run_test.go
+++ b/run_test.go
@@ -3,8 +3,8 @@ package openai_test
 import (
 	"context"
 
-	openai "github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	openai "github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 
 	"encoding/json"
 	"fmt"

--- a/speech_test.go
+++ b/speech_test.go
@@ -11,9 +11,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/internal/test"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	"github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/internal/test"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 )
 
 func TestSpeechIntegration(t *testing.T) {

--- a/stream_reader.go
+++ b/stream_reader.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	utils "github.com/sashabaranov/go-openai/internal"
+	utils "github.com/alejandrojnm/go-openai/internal"
 )
 
 var (

--- a/stream_reader_test.go
+++ b/stream_reader_test.go
@@ -6,9 +6,9 @@ import (
 	"errors"
 	"testing"
 
-	utils "github.com/sashabaranov/go-openai/internal"
-	"github.com/sashabaranov/go-openai/internal/test"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	utils "github.com/alejandrojnm/go-openai/internal"
+	"github.com/alejandrojnm/go-openai/internal/test"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 )
 
 var errTestUnmarshalerFailed = errors.New("test unmarshaler failed")

--- a/stream_test.go
+++ b/stream_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	"github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 )
 
 func TestCompletionsStreamWrongModel(t *testing.T) {

--- a/thread_test.go
+++ b/thread_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"testing"
 
-	openai "github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	openai "github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 )
 
 // TestThread Tests the thread endpoint of the API using the mocked server.

--- a/vector_store_test.go
+++ b/vector_store_test.go
@@ -3,8 +3,8 @@ package openai_test
 import (
 	"context"
 
-	openai "github.com/sashabaranov/go-openai"
-	"github.com/sashabaranov/go-openai/internal/test/checks"
+	openai "github.com/alejandrojnm/go-openai"
+	"github.com/alejandrojnm/go-openai/internal/test/checks"
 
 	"encoding/json"
 	"fmt"


### PR DESCRIPTION
**Describe the change**
This pull request includes changes to the `chat.go` file to integrate the `jsonschema` package for handling JSON schemas in chat completion responses. The most important changes include adding the new import and updating the type of the `Schema` field in the `ChatCompletionResponseFormatJSONSchema` struct.

Integration of `jsonschema` package:

* [`chat.go`](diffhunk://#diff-370ab673a241352de53b0935336bf24d154c95cf931c6d7906cd289140a71ae2R8-R9): Added the `jsonschema` package to the import list.
* [`chat.go`](diffhunk://#diff-370ab673a241352de53b0935336bf24d154c95cf931c6d7906cd289140a71ae2L209-R211): Changed the `Schema` field type in the `ChatCompletionResponseFormatJSONSchema` struct from `json.Marshaler` to `jsonschema.Definition`.

Improvements to JSON schema handling:

* [`chat.go`](diffhunk://#diff-370ab673a241352de53b0935336bf24d154c95cf931c6d7906cd289140a71ae2R8-R9): Added the `jsonschema` package to the imports.
* [`chat.go`](diffhunk://#diff-370ab673a241352de53b0935336bf24d154c95cf931c6d7906cd289140a71ae2L209-R211): Changed the `Schema` field type in the `ChatCompletionResponseFormatJSONSchema` struct from `json.Marshaler` to `jsonschema.Definition`. or what feature it adds.

**Provide OpenAI documentation link**
[Provide a relevant API doc from https://platform.openai.com/docs/api-reference
](https://platform.openai.com/docs/guides/structured-outputs?lang=node.js&context=with_parse)

**Describe your solution**
The solution was use jsonschema.Definition

**Tests**
Nothing to test, all the tests pass locally 

Issue: #884
