### PR TITLE
Chat Completion API: add ReasoningEffort and new o1 models

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -258,6 +258,8 @@ type ChatCompletionRequest struct {
 	// Store can be set to true to store the output of this completion request for use in distillations and evals.
 	// https://platform.openai.com/docs/api-reference/chat/create#chat-create-store
 	Store bool `json:"store,omitempty"`
+	// Controls effort on reasoning for reasoning models. It can be set to "low", "medium", or "high".
+	ReasoningEffort string `json:"reasoning_effort,omitempty"`
 	// Metadata to store with the completion.
 	Metadata map[string]string `json:"metadata,omitempty"`
 }

--- a/completion.go
+++ b/completion.go
@@ -29,6 +29,8 @@ const (
 	O1Mini20240912        = "o1-mini-2024-09-12"
 	O1Preview             = "o1-preview"
 	O1Preview20240912     = "o1-preview-2024-09-12"
+	O1                    = "o1"
+	O120241217            = "o1-2024-12-17"
 	GPT432K0613           = "gpt-4-32k-0613"
 	GPT432K0314           = "gpt-4-32k-0314"
 	GPT432K               = "gpt-4-32k"

--- a/openai_test.go
+++ b/openai_test.go
@@ -31,7 +31,7 @@ func setupAzureTestServer() (client *openai.Client, server *test.ServerTest, tea
 // This function approximates based on the rule of thumb stated by OpenAI:
 // https://beta.openai.com/tokenizer
 //
-// TODO: implement an actual tokenizer for GPT-3 and Codex (once available)
+// TODO: implement an actual tokenizer for GPT-3 and Codex (once available).
 func numTokens(s string) int {
 	return int(float32(len(s)) / 4)
 }


### PR DESCRIPTION
**Describe the change**
The `reasoning_effort` controls the amount of reasoning done by OpenAI's new series of Reasoning models

**Provide OpenAI documentation link**
https://platform.openai.com/docs/api-reference/chat/create#chat-create-reasoning_effort

**Describe your solution**
Adds the optional parameter
Also added the new `o1` models

**Tests**
Tested locally with the `o1` model
