### PR TITLE
Add support for O3-mini

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -392,8 +392,8 @@ func (c *Client) CreateChatCompletion(
 		return
 	}
 
-	reasoningValidator := NewReasoningValidator(request)
-	if err = reasoningValidator.Validate(); err != nil {
+	reasoningValidator := NewReasoningValidator()
+	if err = reasoningValidator.Validate(request); err != nil {
 		return
 	}
 

--- a/chat.go
+++ b/chat.go
@@ -392,11 +392,7 @@ func (c *Client) CreateChatCompletion(
 		return
 	}
 
-	if err = validateRequestForO1Models(request); err != nil {
-		return
-	}
-
-	if err = validateRequestForO3Models(request); err != nil {
+	if err = validateOSeriesRequest(request); err != nil {
 		return
 	}
 

--- a/chat.go
+++ b/chat.go
@@ -392,7 +392,8 @@ func (c *Client) CreateChatCompletion(
 		return
 	}
 
-	if err = validateOSeriesRequest(request); err != nil {
+	reasoningValidator := NewReasoningValidator(request)
+	if err = reasoningValidator.Validate(); err != nil {
 		return
 	}
 

--- a/chat.go
+++ b/chat.go
@@ -396,6 +396,10 @@ func (c *Client) CreateChatCompletion(
 		return
 	}
 
+	if err = validateRequestForO3Models(request); err != nil {
+		return
+	}
+
 	req, err := c.newRequest(
 		ctx,
 		http.MethodPost,

--- a/chat_stream.go
+++ b/chat_stream.go
@@ -80,7 +80,8 @@ func (c *Client) CreateChatCompletionStream(
 	}
 
 	request.Stream = true
-	if err = validateOSeriesRequest(request); err != nil {
+	reasoningValidator := NewReasoningValidator(request)
+	if err = reasoningValidator.Validate(); err != nil {
 		return
 	}
 

--- a/chat_stream.go
+++ b/chat_stream.go
@@ -84,6 +84,10 @@ func (c *Client) CreateChatCompletionStream(
 		return
 	}
 
+	if err = validateRequestForO3Models(request); err != nil {
+		return
+	}
+
 	req, err := c.newRequest(
 		ctx,
 		http.MethodPost,

--- a/chat_stream.go
+++ b/chat_stream.go
@@ -80,11 +80,7 @@ func (c *Client) CreateChatCompletionStream(
 	}
 
 	request.Stream = true
-	if err = validateRequestForO1Models(request); err != nil {
-		return
-	}
-
-	if err = validateRequestForO3Models(request); err != nil {
+	if err = validateOSeriesRequest(request); err != nil {
 		return
 	}
 

--- a/chat_stream.go
+++ b/chat_stream.go
@@ -80,8 +80,8 @@ func (c *Client) CreateChatCompletionStream(
 	}
 
 	request.Stream = true
-	reasoningValidator := NewReasoningValidator(request)
-	if err = reasoningValidator.Validate(); err != nil {
+	reasoningValidator := NewReasoningValidator()
+	if err = reasoningValidator.Validate(request); err != nil {
 		return
 	}
 

--- a/chat_stream_test.go
+++ b/chat_stream_test.go
@@ -792,6 +792,148 @@ func compareChatResponses(r1, r2 openai.ChatCompletionStreamResponse) bool {
 	return true
 }
 
+func TestCreateChatCompletionStreamWithReasoningModel(t *testing.T) {
+	client, server, teardown := setupOpenAITestServer()
+	defer teardown()
+	server.RegisterHandler("/v1/chat/completions", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+
+		dataBytes := []byte{}
+
+		//nolint:lll
+		dataBytes = append(dataBytes, []byte(`data: {"id":"1","object":"chat.completion.chunk","created":1729585728,"model":"o3-mini-2025-01-31","system_fingerprint":"fp_mini","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}`)...)
+		dataBytes = append(dataBytes, []byte("\n\n")...)
+
+		//nolint:lll
+		dataBytes = append(dataBytes, []byte(`data: {"id":"2","object":"chat.completion.chunk","created":1729585728,"model":"o3-mini-2025-01-31","system_fingerprint":"fp_mini","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}`)...)
+		dataBytes = append(dataBytes, []byte("\n\n")...)
+
+		//nolint:lll
+		dataBytes = append(dataBytes, []byte(`data: {"id":"3","object":"chat.completion.chunk","created":1729585728,"model":"o3-mini-2025-01-31","system_fingerprint":"fp_mini","choices":[{"index":0,"delta":{"content":" from"},"finish_reason":null}]}`)...)
+		dataBytes = append(dataBytes, []byte("\n\n")...)
+
+		//nolint:lll
+		dataBytes = append(dataBytes, []byte(`data: {"id":"4","object":"chat.completion.chunk","created":1729585728,"model":"o3-mini-2025-01-31","system_fingerprint":"fp_mini","choices":[{"index":0,"delta":{"content":" O3Mini"},"finish_reason":null}]}`)...)
+		dataBytes = append(dataBytes, []byte("\n\n")...)
+
+		//nolint:lll
+		dataBytes = append(dataBytes, []byte(`data: {"id":"5","object":"chat.completion.chunk","created":1729585728,"model":"o3-mini-2025-01-31","system_fingerprint":"fp_mini","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`)...)
+		dataBytes = append(dataBytes, []byte("\n\n")...)
+
+		dataBytes = append(dataBytes, []byte("data: [DONE]\n\n")...)
+
+		_, err := w.Write(dataBytes)
+		checks.NoError(t, err, "Write error")
+	})
+
+	stream, err := client.CreateChatCompletionStream(context.Background(), openai.ChatCompletionRequest{
+		MaxCompletionTokens: 2000,
+		Model:               openai.O3Mini20250131,
+		Messages: []openai.ChatCompletionMessage{
+			{
+				Role:    openai.ChatMessageRoleUser,
+				Content: "Hello!",
+			},
+		},
+		Stream: true,
+	})
+	checks.NoError(t, err, "CreateCompletionStream returned error")
+	defer stream.Close()
+
+	expectedResponses := []openai.ChatCompletionStreamResponse{
+		{
+			ID:                "1",
+			Object:            "chat.completion.chunk",
+			Created:           1729585728,
+			Model:             openai.O3Mini20250131,
+			SystemFingerprint: "fp_mini",
+			Choices: []openai.ChatCompletionStreamChoice{
+				{
+					Index: 0,
+					Delta: openai.ChatCompletionStreamChoiceDelta{
+						Role: "assistant",
+					},
+				},
+			},
+		},
+		{
+			ID:                "2",
+			Object:            "chat.completion.chunk",
+			Created:           1729585728,
+			Model:             openai.O3Mini20250131,
+			SystemFingerprint: "fp_mini",
+			Choices: []openai.ChatCompletionStreamChoice{
+				{
+					Index: 0,
+					Delta: openai.ChatCompletionStreamChoiceDelta{
+						Content: "Hello",
+					},
+				},
+			},
+		},
+		{
+			ID:                "3",
+			Object:            "chat.completion.chunk",
+			Created:           1729585728,
+			Model:             openai.O3Mini20250131,
+			SystemFingerprint: "fp_mini",
+			Choices: []openai.ChatCompletionStreamChoice{
+				{
+					Index: 0,
+					Delta: openai.ChatCompletionStreamChoiceDelta{
+						Content: " from",
+					},
+				},
+			},
+		},
+		{
+			ID:                "4",
+			Object:            "chat.completion.chunk",
+			Created:           1729585728,
+			Model:             openai.O3Mini20250131,
+			SystemFingerprint: "fp_mini",
+			Choices: []openai.ChatCompletionStreamChoice{
+				{
+					Index: 0,
+					Delta: openai.ChatCompletionStreamChoiceDelta{
+						Content: " O3Mini",
+					},
+				},
+			},
+		},
+		{
+			ID:                "5",
+			Object:            "chat.completion.chunk",
+			Created:           1729585728,
+			Model:             openai.O3Mini20250131,
+			SystemFingerprint: "fp_mini",
+			Choices: []openai.ChatCompletionStreamChoice{
+				{
+					Index:        0,
+					Delta:        openai.ChatCompletionStreamChoiceDelta{},
+					FinishReason: "stop",
+				},
+			},
+		},
+	}
+
+	for ix, expectedResponse := range expectedResponses {
+		b, _ := json.Marshal(expectedResponse)
+		t.Logf("%d: %s", ix, string(b))
+
+		receivedResponse, streamErr := stream.Recv()
+		checks.NoError(t, streamErr, "stream.Recv() failed")
+		if !compareChatResponses(expectedResponse, receivedResponse) {
+			t.Errorf("Stream response %v is %v, expected %v", ix, receivedResponse, expectedResponse)
+		}
+	}
+
+	_, streamErr := stream.Recv()
+	if !errors.Is(streamErr, io.EOF) {
+		t.Errorf("stream.Recv() did not return EOF in the end: %v", streamErr)
+	}
+}
+
 func compareChatStreamResponseChoices(c1, c2 openai.ChatCompletionStreamChoice) bool {
 	if c1.Index != c2.Index {
 		return false

--- a/chat_stream_test.go
+++ b/chat_stream_test.go
@@ -934,6 +934,31 @@ func TestCreateChatCompletionStreamWithReasoningModel(t *testing.T) {
 	}
 }
 
+func TestCreateChatCompletionStreamReasoningValidatorFails(t *testing.T) {
+	client, _, _ := setupOpenAITestServer()
+
+	stream, err := client.CreateChatCompletionStream(context.Background(), openai.ChatCompletionRequest{
+		MaxTokens: 100, // This will trigger the validator to fail
+		Model:     openai.O3Mini,
+		Messages: []openai.ChatCompletionMessage{
+			{
+				Role:    openai.ChatMessageRoleUser,
+				Content: "Hello!",
+			},
+		},
+		Stream: true,
+	})
+
+	if stream != nil {
+		t.Error("Expected nil stream when validation fails")
+		stream.Close()
+	}
+
+	if !errors.Is(err, openai.ErrReasoningModelMaxTokensDeprecated) {
+		t.Errorf("Expected ErrReasoningModelMaxTokensDeprecated, got: %v", err)
+	}
+}
+
 func compareChatStreamResponseChoices(c1, c2 openai.ChatCompletionStreamChoice) bool {
 	if c1.Index != c2.Index {
 		return false

--- a/chat_test.go
+++ b/chat_test.go
@@ -64,7 +64,7 @@ func TestO1ModelsChatCompletionsDeprecatedFields(t *testing.T) {
 				MaxTokens: 5,
 				Model:     openai.O1Preview,
 			},
-			expectedError: openai.ErrO3MaxTokensDeprecated,
+			expectedError: openai.ErrReasoningModelMaxTokensDeprecated,
 		},
 		{
 			name: "o1-mini_MaxTokens_deprecated",
@@ -72,7 +72,7 @@ func TestO1ModelsChatCompletionsDeprecatedFields(t *testing.T) {
 				MaxTokens: 5,
 				Model:     openai.O1Mini,
 			},
-			expectedError: openai.ErrO3MaxTokensDeprecated,
+			expectedError: openai.ErrReasoningModelMaxTokensDeprecated,
 		},
 	}
 
@@ -104,7 +104,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 				LogProbs:            true,
 				Model:               openai.O1Preview,
 			},
-			expectedError: openai.ErrO3BetaLimitationsLogprobs,
+			expectedError: openai.ErrReasoningModelLimitationsLogprobs,
 		},
 		{
 			name: "message_type_unsupported",
@@ -155,7 +155,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 				},
 				Temperature: float32(2),
 			},
-			expectedError: openai.ErrO3BetaLimitationsOther,
+			expectedError: openai.ErrReasoningModelLimitationsOther,
 		},
 		{
 			name: "set_top_unsupported",
@@ -173,7 +173,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 				Temperature: float32(1),
 				TopP:        float32(0.1),
 			},
-			expectedError: openai.ErrO3BetaLimitationsOther,
+			expectedError: openai.ErrReasoningModelLimitationsOther,
 		},
 		{
 			name: "set_n_unsupported",
@@ -192,7 +192,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 				TopP:        float32(1),
 				N:           2,
 			},
-			expectedError: openai.ErrO3BetaLimitationsOther,
+			expectedError: openai.ErrReasoningModelLimitationsOther,
 		},
 		{
 			name: "set_presence_penalty_unsupported",
@@ -209,7 +209,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 				},
 				PresencePenalty: float32(1),
 			},
-			expectedError: openai.ErrO3BetaLimitationsOther,
+			expectedError: openai.ErrReasoningModelLimitationsOther,
 		},
 		{
 			name: "set_frequency_penalty_unsupported",
@@ -226,7 +226,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 				},
 				FrequencyPenalty: float32(0.1),
 			},
-			expectedError: openai.ErrO3BetaLimitationsOther,
+			expectedError: openai.ErrReasoningModelLimitationsOther,
 		},
 	}
 
@@ -258,7 +258,7 @@ func TestO3ModelsChatCompletionsBetaLimitations(t *testing.T) {
 				LogProbs:            true,
 				Model:               openai.O3Mini,
 			},
-			expectedError: openai.ErrO3BetaLimitationsLogprobs,
+			expectedError: openai.ErrReasoningModelLimitationsLogprobs,
 		},
 		{
 			name: "set_temperature_unsupported",
@@ -275,7 +275,7 @@ func TestO3ModelsChatCompletionsBetaLimitations(t *testing.T) {
 				},
 				Temperature: float32(2),
 			},
-			expectedError: openai.ErrO3BetaLimitationsOther,
+			expectedError: openai.ErrReasoningModelLimitationsOther,
 		},
 		{
 			name: "set_top_unsupported",
@@ -293,7 +293,7 @@ func TestO3ModelsChatCompletionsBetaLimitations(t *testing.T) {
 				Temperature: float32(1),
 				TopP:        float32(0.1),
 			},
-			expectedError: openai.ErrO3BetaLimitationsOther,
+			expectedError: openai.ErrReasoningModelLimitationsOther,
 		},
 		{
 			name: "set_n_unsupported",
@@ -312,7 +312,7 @@ func TestO3ModelsChatCompletionsBetaLimitations(t *testing.T) {
 				TopP:        float32(1),
 				N:           2,
 			},
-			expectedError: openai.ErrO3BetaLimitationsOther,
+			expectedError: openai.ErrReasoningModelLimitationsOther,
 		},
 		{
 			name: "set_presence_penalty_unsupported",
@@ -329,7 +329,7 @@ func TestO3ModelsChatCompletionsBetaLimitations(t *testing.T) {
 				},
 				PresencePenalty: float32(1),
 			},
-			expectedError: openai.ErrO3BetaLimitationsOther,
+			expectedError: openai.ErrReasoningModelLimitationsOther,
 		},
 		{
 			name: "set_frequency_penalty_unsupported",
@@ -346,7 +346,7 @@ func TestO3ModelsChatCompletionsBetaLimitations(t *testing.T) {
 				},
 				FrequencyPenalty: float32(0.1),
 			},
-			expectedError: openai.ErrO3BetaLimitationsOther,
+			expectedError: openai.ErrReasoningModelLimitationsOther,
 		},
 	}
 

--- a/chat_test.go
+++ b/chat_test.go
@@ -64,7 +64,7 @@ func TestO1ModelsChatCompletionsDeprecatedFields(t *testing.T) {
 				MaxTokens: 5,
 				Model:     openai.O1Preview,
 			},
-			expectedError: openai.ErrO1MaxTokensDeprecated,
+			expectedError: openai.ErrO3MaxTokensDeprecated,
 		},
 		{
 			name: "o1-mini_MaxTokens_deprecated",
@@ -72,7 +72,7 @@ func TestO1ModelsChatCompletionsDeprecatedFields(t *testing.T) {
 				MaxTokens: 5,
 				Model:     openai.O1Mini,
 			},
-			expectedError: openai.ErrO1MaxTokensDeprecated,
+			expectedError: openai.ErrO3MaxTokensDeprecated,
 		},
 	}
 
@@ -104,7 +104,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 				LogProbs:            true,
 				Model:               openai.O1Preview,
 			},
-			expectedError: openai.ErrO1BetaLimitationsLogprobs,
+			expectedError: openai.ErrO3BetaLimitationsLogprobs,
 		},
 		{
 			name: "message_type_unsupported",
@@ -155,7 +155,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 				},
 				Temperature: float32(2),
 			},
-			expectedError: openai.ErrO1BetaLimitationsOther,
+			expectedError: openai.ErrO3BetaLimitationsOther,
 		},
 		{
 			name: "set_top_unsupported",
@@ -173,7 +173,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 				Temperature: float32(1),
 				TopP:        float32(0.1),
 			},
-			expectedError: openai.ErrO1BetaLimitationsOther,
+			expectedError: openai.ErrO3BetaLimitationsOther,
 		},
 		{
 			name: "set_n_unsupported",
@@ -192,7 +192,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 				TopP:        float32(1),
 				N:           2,
 			},
-			expectedError: openai.ErrO1BetaLimitationsOther,
+			expectedError: openai.ErrO3BetaLimitationsOther,
 		},
 		{
 			name: "set_presence_penalty_unsupported",
@@ -209,7 +209,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 				},
 				PresencePenalty: float32(1),
 			},
-			expectedError: openai.ErrO1BetaLimitationsOther,
+			expectedError: openai.ErrO3BetaLimitationsOther,
 		},
 		{
 			name: "set_frequency_penalty_unsupported",
@@ -226,7 +226,7 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 				},
 				FrequencyPenalty: float32(0.1),
 			},
-			expectedError: openai.ErrO1BetaLimitationsOther,
+			expectedError: openai.ErrO3BetaLimitationsOther,
 		},
 	}
 

--- a/completion.go
+++ b/completion.go
@@ -2,31 +2,7 @@ package openai
 
 import (
 	"context"
-	"errors"
 	"net/http"
-)
-
-var (
-	// Deprecated: use ErrReasoningModelMaxTokensDeprecated instead.
-	ErrO1MaxTokensDeprecated                   = errors.New("this model is not supported MaxTokens, please use MaxCompletionTokens")                               //nolint:lll
-	ErrCompletionUnsupportedModel              = errors.New("this model is not supported with this method, please use CreateChatCompletion client method instead") //nolint:lll
-	ErrCompletionStreamNotSupported            = errors.New("streaming is not supported with this method, please use CreateCompletionStream")                      //nolint:lll
-	ErrCompletionRequestPromptTypeNotSupported = errors.New("the type of CompletionRequest.Prompt only supports string and []string")                              //nolint:lll
-)
-
-var (
-	ErrO1BetaLimitationsMessageTypes = errors.New("this model has beta-limitations, user and assistant messages only, system messages are not supported")       //nolint:lll
-	ErrO1BetaLimitationsTools        = errors.New("this model has beta-limitations, tools, function calling, and response format parameters are not supported") //nolint:lll
-	// Deprecated: use ErrReasoningModelLimitations* instead.
-	ErrO1BetaLimitationsLogprobs = errors.New("this model has beta-limitations, logprobs not supported")                                                                               //nolint:lll
-	ErrO1BetaLimitationsOther    = errors.New("this model has beta-limitations, temperature, top_p and n are fixed at 1, while presence_penalty and frequency_penalty are fixed at 0") //nolint:lll
-)
-
-var (
-	//nolint:lll
-	ErrReasoningModelMaxTokensDeprecated = errors.New("this model is not supported MaxTokens, please use MaxCompletionTokens")
-	ErrReasoningModelLimitationsLogprobs = errors.New("this model has beta-limitations, logprobs not supported")                                                                               //nolint:lll
-	ErrReasoningModelLimitationsOther    = errors.New("this model has beta-limitations, temperature, top_p and n are fixed at 1, while presence_penalty and frequency_penalty are fixed at 0") //nolint:lll
 )
 
 // GPT3 Defines the models provided by OpenAI to use when generating
@@ -185,15 +161,6 @@ func checkPromptType(prompt any) bool {
 		}
 	}
 	return true // all items in the slice are string, so it is []string
-}
-
-var unsupportedToolsForO1Models = map[ToolType]struct{}{
-	ToolTypeFunction: {},
-}
-
-var availableMessageRoleForO1Models = map[string]struct{}{
-	ChatMessageRoleUser:      {},
-	ChatMessageRoleAssistant: {},
 }
 
 // CompletionRequest represents a request structure for completion API.

--- a/reasoning_validator.go
+++ b/reasoning_validator.go
@@ -1,0 +1,80 @@
+package openai
+
+import "strings"
+
+// ReasoningValidator handles validation for o-series model requests.
+type ReasoningValidator struct {
+	request ChatCompletionRequest
+}
+
+// NewReasoningValidator creates a new validator for o-series models.
+func NewReasoningValidator(req ChatCompletionRequest) *ReasoningValidator {
+	return &ReasoningValidator{
+		request: req,
+	}
+}
+
+// Validate performs all validation checks for o-series models.
+func (v *ReasoningValidator) Validate() error {
+	o1Series := strings.HasPrefix(v.request.Model, "o1")
+	o3Series := strings.HasPrefix(v.request.Model, "o3")
+
+	if !o1Series && !o3Series {
+		return nil
+	}
+
+	if err := v.validateReasoningModelParams(); err != nil {
+		return err
+	}
+
+	if o1Series {
+		if err := v.validateO1Specific(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateReasoningModelParams checks reasoning model parameters.
+func (v *ReasoningValidator) validateReasoningModelParams() error {
+	if v.request.MaxTokens > 0 {
+		return ErrReasoningModelMaxTokensDeprecated
+	}
+	if v.request.LogProbs {
+		return ErrReasoningModelLimitationsLogprobs
+	}
+	if v.request.Temperature > 0 && v.request.Temperature != 1 {
+		return ErrReasoningModelLimitationsOther
+	}
+	if v.request.TopP > 0 && v.request.TopP != 1 {
+		return ErrReasoningModelLimitationsOther
+	}
+	if v.request.N > 0 && v.request.N != 1 {
+		return ErrReasoningModelLimitationsOther
+	}
+	if v.request.PresencePenalty > 0 {
+		return ErrReasoningModelLimitationsOther
+	}
+	if v.request.FrequencyPenalty > 0 {
+		return ErrReasoningModelLimitationsOther
+	}
+
+	return nil
+}
+
+// validateO1Specific checks O1-specific limitations.
+func (v *ReasoningValidator) validateO1Specific() error {
+	for _, m := range v.request.Messages {
+		if _, found := availableMessageRoleForO1Models[m.Role]; !found {
+			return ErrO1BetaLimitationsMessageTypes
+		}
+	}
+
+	for _, t := range v.request.Tools {
+		if _, found := unsupportedToolsForO1Models[t.Type]; found {
+			return ErrO1BetaLimitationsTools
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
- Add support for the o3 mini set of models, including tests that match the constraints in OpenAI's API docs (https://platform.openai.com/docs/models#o3-mini).
