### PR TITLE
feat: add Anthropic API support with custom version header

### DIFF
--- a/client.go
+++ b/client.go
@@ -185,6 +185,8 @@ func (c *Client) setCommonHeaders(req *http.Request) {
 	// Azure API Key authentication
 	if c.config.APIType == APITypeAzure || c.config.APIType == APITypeCloudflareAzure {
 		req.Header.Set(AzureAPIKeyHeader, c.config.authToken)
+	} else if c.config.APIType == APITypeAnthropic {
+		req.Header.Set("anthropic-version", c.config.APIVersion)
 	} else if c.config.authToken != "" {
 		// OpenAI or Azure AD authentication
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.authToken))

--- a/client.go
+++ b/client.go
@@ -182,15 +182,19 @@ func sendRequestStream[T streamable](client *Client, req *http.Request) (*stream
 
 func (c *Client) setCommonHeaders(req *http.Request) {
 	// https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference#authentication
-	// Azure API Key authentication
-	if c.config.APIType == APITypeAzure || c.config.APIType == APITypeCloudflareAzure {
+	switch c.config.APIType {
+	case APITypeAzure, APITypeCloudflareAzure:
+		// Azure API Key authentication
 		req.Header.Set(AzureAPIKeyHeader, c.config.authToken)
-	} else if c.config.APIType == APITypeAnthropic {
+	case APITypeAnthropic:
 		req.Header.Set("anthropic-version", c.config.APIVersion)
-	} else if c.config.authToken != "" {
+	default:
 		// OpenAI or Azure AD authentication
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.authToken))
+		if c.config.authToken != "" {
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.authToken))
+		}
 	}
+
 	if c.config.OrgID != "" {
 		req.Header.Set("OpenAI-Organization", c.config.OrgID)
 	}

--- a/client.go
+++ b/client.go
@@ -187,9 +187,10 @@ func (c *Client) setCommonHeaders(req *http.Request) {
 		// Azure API Key authentication
 		req.Header.Set(AzureAPIKeyHeader, c.config.authToken)
 	case APITypeAnthropic:
+		// https://docs.anthropic.com/en/api/versioning
 		req.Header.Set("anthropic-version", c.config.APIVersion)
+	case APITypeOpenAI, APITypeAzureAD:
 	default:
-		// OpenAI or Azure AD authentication
 		if c.config.authToken != "" {
 			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.authToken))
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -39,6 +39,21 @@ func TestClient(t *testing.T) {
 	}
 }
 
+func TestSetCommonHeadersAnthropic(t *testing.T) {
+	config := DefaultAnthropicConfig("mock-token", "")
+	client := NewClientWithConfig(config)
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	client.setCommonHeaders(req)
+
+	if got := req.Header.Get("anthropic-version"); got != AnthropicAPIVersion {
+		t.Errorf("Expected anthropic-version header to be %q, got %q", AnthropicAPIVersion, got)
+	}
+}
+
 func TestDecodeResponse(t *testing.T) {
 	stringInput := ""
 

--- a/config.go
+++ b/config.go
@@ -20,6 +20,7 @@ const (
 	APITypeAzure           APIType = "AZURE"
 	APITypeAzureAD         APIType = "AZURE_AD"
 	APITypeCloudflareAzure APIType = "CLOUDFLARE_AZURE"
+	APITypeAnthropic       APIType = "ANTHROPIC"
 )
 
 const AzureAPIKeyHeader = "api-key"
@@ -37,7 +38,7 @@ type ClientConfig struct {
 	BaseURL              string
 	OrgID                string
 	APIType              APIType
-	APIVersion           string // required when APIType is APITypeAzure or APITypeAzureAD
+	APIVersion           string // required when APIType is APITypeAzure or APITypeAzureAD or APITypeAnthropic
 	AssistantVersion     string
 	AzureModelMapperFunc func(model string) string // replace model to azure deployment name func
 	HTTPClient           HTTPDoer
@@ -69,6 +70,23 @@ func DefaultAzureConfig(apiKey, baseURL string) ClientConfig {
 		AzureModelMapperFunc: func(model string) string {
 			return regexp.MustCompile(`[.:]`).ReplaceAllString(model, "")
 		},
+
+		HTTPClient: &http.Client{},
+
+		EmptyMessagesLimit: defaultEmptyMessagesLimit,
+	}
+}
+
+func DefaultAnthropicConfig(apiKey, baseURL string) ClientConfig {
+	if baseURL == "" {
+		baseURL = "https://api.anthropic.com/v1"
+	}
+	return ClientConfig{
+		authToken:  apiKey,
+		BaseURL:    baseURL,
+		OrgID:      "",
+		APIType:    APITypeAnthropic,
+		APIVersion: "2023-06-01",
 
 		HTTPClient: &http.Client{},
 

--- a/config.go
+++ b/config.go
@@ -11,6 +11,8 @@ const (
 
 	azureAPIPrefix         = "openai"
 	azureDeploymentsPrefix = "deployments"
+
+	AnthropicAPIVersion = "2023-06-01"
 )
 
 type APIType string
@@ -86,7 +88,7 @@ func DefaultAnthropicConfig(apiKey, baseURL string) ClientConfig {
 		BaseURL:    baseURL,
 		OrgID:      "",
 		APIType:    APITypeAnthropic,
-		APIVersion: "2023-06-01",
+		APIVersion: AnthropicAPIVersion,
 
 		HTTPClient: &http.Client{},
 

--- a/config_test.go
+++ b/config_test.go
@@ -71,7 +71,7 @@ func TestDefaultAnthropicConfig(t *testing.T) {
 		t.Errorf("Expected APIType to be %v, got %v", openai.APITypeAnthropic, config.APIType)
 	}
 
-	if config.APIVersion != "2023-06-01" {
+	if config.APIVersion != openai.AnthropicAPIVersion {
 		t.Errorf("Expected APIVersion to be 2023-06-01, got %v", config.APIVersion)
 	}
 
@@ -91,8 +91,8 @@ func TestDefaultAnthropicConfigWithEmptyValues(t *testing.T) {
 		t.Errorf("Expected APIType to be %v, got %v", openai.APITypeAnthropic, config.APIType)
 	}
 
-	if config.APIVersion != "2023-06-01" {
-		t.Errorf("Expected APIVersion to be 2023-06-01, got %v", config.APIVersion)
+	if config.APIVersion != openai.AnthropicAPIVersion {
+		t.Errorf("Expected APIVersion to be %s, got %v", openai.AnthropicAPIVersion, config.APIVersion)
 	}
 
 	expectedBaseURL := "https://api.anthropic.com/v1"

--- a/config_test.go
+++ b/config_test.go
@@ -60,3 +60,43 @@ func TestGetAzureDeploymentByModel(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultAnthropicConfig(t *testing.T) {
+	apiKey := "test-key"
+	baseURL := "https://api.anthropic.com/v1"
+
+	config := openai.DefaultAnthropicConfig(apiKey, baseURL)
+
+	if config.APIType != openai.APITypeAnthropic {
+		t.Errorf("Expected APIType to be %v, got %v", openai.APITypeAnthropic, config.APIType)
+	}
+
+	if config.APIVersion != "2023-06-01" {
+		t.Errorf("Expected APIVersion to be 2023-06-01, got %v", config.APIVersion)
+	}
+
+	if config.BaseURL != baseURL {
+		t.Errorf("Expected BaseURL to be %v, got %v", baseURL, config.BaseURL)
+	}
+
+	if config.EmptyMessagesLimit != 300 {
+		t.Errorf("Expected EmptyMessagesLimit to be 300, got %v", config.EmptyMessagesLimit)
+	}
+}
+
+func TestDefaultAnthropicConfigWithEmptyValues(t *testing.T) {
+	config := openai.DefaultAnthropicConfig("", "")
+
+	if config.APIType != openai.APITypeAnthropic {
+		t.Errorf("Expected APIType to be %v, got %v", openai.APITypeAnthropic, config.APIType)
+	}
+
+	if config.APIVersion != "2023-06-01" {
+		t.Errorf("Expected APIVersion to be 2023-06-01, got %v", config.APIVersion)
+	}
+
+	expectedBaseURL := "https://api.anthropic.com/v1"
+	if config.BaseURL != expectedBaseURL {
+		t.Errorf("Expected BaseURL to be %v, got %v", expectedBaseURL, config.BaseURL)
+	}
+}


### PR DESCRIPTION
**Describe the change**
Add support for Anthropic models.

**Provide documentation link**
Anthropic API requests require a custom header "anthropic-version". More details [here](https://docs.anthropic.com/en/api/versioning)

**Describe your solution**
Added new APITypeAnthropic with APIVersion = "2023-06-01" and baseURL of "https://api.anthropic.com/v1"

**Tests**
Checking correct APIVersion and default baseURL.

**Additional context**
Currently, trying to override the default config with Anthropic values, fails with a 404 not found error (because there's no request header "anthropic-version":"2023-06-01").
