### PR TITLE
fix: remove validateO1Specific

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,8 +19,6 @@ jobs:
         go vet .
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v6
-      with:
-        version: latest
     - name: Run tests
       run: go test -race -covermode=atomic -coverprofile=coverage.out -v .
     - name: Upload coverage reports to Codecov

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: '1.22'
     - name: Run vet
       run: |
         go vet .

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         go vet .
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v4
+      uses: golangci/golangci-lint-action@v6
       with:
         version: latest
     - name: Run tests

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.64.4
+        version: v1.63.4
     - name: Run tests
       run: go test -race -covermode=atomic -coverprofile=coverage.out -v .
     - name: Upload coverage reports to Codecov

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,12 +13,14 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '1.21'
     - name: Run vet
       run: |
         go vet .
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v6
+      with:
+        version: v1.64.4
     - name: Run tests
       run: go test -race -covermode=atomic -coverprofile=coverage.out -v .
     - name: Upload coverage reports to Codecov

--- a/chat_test.go
+++ b/chat_test.go
@@ -107,40 +107,6 @@ func TestO1ModelsChatCompletionsBetaLimitations(t *testing.T) {
 			expectedError: openai.ErrReasoningModelLimitationsLogprobs,
 		},
 		{
-			name: "message_type_unsupported",
-			in: openai.ChatCompletionRequest{
-				MaxCompletionTokens: 1000,
-				Model:               openai.O1Mini,
-				Messages: []openai.ChatCompletionMessage{
-					{
-						Role: openai.ChatMessageRoleSystem,
-					},
-				},
-			},
-			expectedError: openai.ErrO1BetaLimitationsMessageTypes,
-		},
-		{
-			name: "tool_unsupported",
-			in: openai.ChatCompletionRequest{
-				MaxCompletionTokens: 1000,
-				Model:               openai.O1Mini,
-				Messages: []openai.ChatCompletionMessage{
-					{
-						Role: openai.ChatMessageRoleUser,
-					},
-					{
-						Role: openai.ChatMessageRoleAssistant,
-					},
-				},
-				Tools: []openai.Tool{
-					{
-						Type: openai.ToolTypeFunction,
-					},
-				},
-			},
-			expectedError: openai.ErrO1BetaLimitationsTools,
-		},
-		{
 			name: "set_temperature_unsupported",
 			in: openai.ChatCompletionRequest{
 				MaxCompletionTokens: 1000,

--- a/reasoning_validator.go
+++ b/reasoning_validator.go
@@ -28,16 +28,6 @@ var (
 	ErrReasoningModelLimitationsOther    = errors.New("this model has beta-limitations, temperature, top_p and n are fixed at 1, while presence_penalty and frequency_penalty are fixed at 0") //nolint:lll
 )
 
-var unsupportedToolsForO1Models = map[ToolType]struct{}{
-	ToolTypeFunction: {},
-}
-
-var availableMessageRoleForO1Models = map[string]struct{}{
-	ChatMessageRoleUser:      {},
-	ChatMessageRoleAssistant: {},
-	ChatMessageRoleDeveloper: {},
-}
-
 // ReasoningValidator handles validation for o-series model requests.
 type ReasoningValidator struct{}
 
@@ -57,12 +47,6 @@ func (v *ReasoningValidator) Validate(request ChatCompletionRequest) error {
 
 	if err := v.validateReasoningModelParams(request); err != nil {
 		return err
-	}
-
-	if o1Series {
-		if err := v.validateO1Specific(request); err != nil {
-			return err
-		}
 	}
 
 	return nil
@@ -92,21 +76,5 @@ func (v *ReasoningValidator) validateReasoningModelParams(request ChatCompletion
 		return ErrReasoningModelLimitationsOther
 	}
 
-	return nil
-}
-
-// validateO1Specific checks O1-specific limitations.
-func (v *ReasoningValidator) validateO1Specific(request ChatCompletionRequest) error {
-	for _, m := range request.Messages {
-		if _, found := availableMessageRoleForO1Models[m.Role]; !found {
-			return ErrO1BetaLimitationsMessageTypes
-		}
-	}
-
-	for _, t := range request.Tools {
-		if _, found := unsupportedToolsForO1Models[t.Type]; found {
-			return ErrO1BetaLimitationsTools
-		}
-	}
 	return nil
 }


### PR DESCRIPTION
In the latest openai o1 release o1-2024-12-17, Function calling is supported, and I test that system roles can be passed

see: https://openai.com/index/o1-and-new-tools-for-developers/
