### PR TITLE
[BREAKING_CHANGES] refactor: change metadata type from map[string]string to map[string]any

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -262,7 +262,7 @@ type ChatCompletionRequest struct {
 	// Controls effort on reasoning for reasoning models. It can be set to "low", "medium", or "high".
 	ReasoningEffort string `json:"reasoning_effort,omitempty"`
 	// Metadata to store with the completion.
-	Metadata map[string]string `json:"metadata,omitempty"`
+	Metadata map[string]any `json:"metadata,omitempty"`
 }
 
 type StreamOptions struct {

--- a/messages.go
+++ b/messages.go
@@ -162,7 +162,7 @@ func (c *Client) RetrieveMessage(
 func (c *Client) ModifyMessage(
 	ctx context.Context,
 	threadID, messageID string,
-	metadata map[string]string,
+	metadata map[string]any,
 ) (msg Message, err error) {
 	urlSuffix := fmt.Sprintf("/threads/%s/%s/%s", threadID, messagesSuffix, messageID)
 	req, err := c.newRequest(ctx, http.MethodPost, c.fullURL(urlSuffix),

--- a/messages_test.go
+++ b/messages_test.go
@@ -233,7 +233,7 @@ func TestMessages(t *testing.T) {
 	}
 
 	msg, err = client.ModifyMessage(ctx, threadID, messageID,
-		map[string]string{
+		map[string]any{
 			"foo": "bar",
 		})
 	checks.NoError(t, err, "ModifyMessage error")


### PR DESCRIPTION
**Describe the change**
We use Litellm and Langfuse and I realized that the `map[string]string` data type in the metadata field is insufficient to pass some trace fields (e.g. tags, trace_metadata) from the metadata. It is possible to make metadata type `map[string]any` for more complex data types. There is no statement in the OpenAI document stating that metadata must be of type `map[string]string`

**Provide OpenAI documentation link**
[Litellm Langfuse Integration](https://docs.litellm.ai/docs/observability/langfuse_integration#set-custom-trace-id-trace-user-id-trace-metadata-trace-version-trace-release-and-tags)
[OpenAI Metadata](https://platform.openai.com/docs/api-reference/chat/create#chat-create-metadata) -> _Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a **structured** format, and querying for objects via API or the dashboard._

**Describe your solution**
I changed the type of the metadata field in `ChatCompletionRequest` and `ModifyMessage` to `map[string]any`

**Tests**
I ran the tests locally.

Issue: -
