### PR TITLE
Remove redundant typecheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -149,7 +149,6 @@ linters:
     - govet # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
     - ineffassign # Detects when assignments to existing variables are not used
     - staticcheck # Staticcheck is a go vet on steroids, applying a ton of static analysis checks
-    - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
     - unused # Checks Go code for unused constants, variables, functions and types
     ## disabled by default
     # - asasalint # Check for pass []any as any in variadic func(...any)


### PR DESCRIPTION
**Describe the change**

This PR removes redundant `typecheck` from the `linters.enable` list.

**Additional context**

`typecheck` is not a linter and it doesn't perform any analysis. It's just a way to identify, parse, and display compiling errors and some linter errors.

More info:

- https://golangci-lint.run/welcome/faq/#why-do-you-have-typecheck-errors
- https://golangci-lint.run/welcome/faq/#why-is-it-not-possible-to-skipignore-typecheck-errors