### PR TITLE
feat: Add missing TTS models and voices

### DIFF
--- a/speech.go
+++ b/speech.go
@@ -43,6 +43,7 @@ type CreateSpeechRequest struct {
 	Model          SpeechModel          `json:"model"`
 	Input          string               `json:"input"`
 	Voice          SpeechVoice          `json:"voice"`
+	Instructions   string               `json:"instructions,omitempty"`    // Optional, Doesnt work with tts-1 or tts-1-hd.
 	ResponseFormat SpeechResponseFormat `json:"response_format,omitempty"` // Optional, default to mp3
 	Speed          float64              `json:"speed,omitempty"`           // Optional, default to 1.0
 }

--- a/speech.go
+++ b/speech.go
@@ -8,20 +8,24 @@ import (
 type SpeechModel string
 
 const (
-	TTSModel1      SpeechModel = "tts-1"
-	TTSModel1HD    SpeechModel = "tts-1-hd"
-	TTSModelCanary SpeechModel = "canary-tts"
+	TTSModel1         SpeechModel = "tts-1"
+	TTSModel1HD       SpeechModel = "tts-1-hd"
+	TTSModelGPT4oMini SpeechModel = "gpt-4o-mini-tts"
 )
 
 type SpeechVoice string
 
 const (
 	VoiceAlloy   SpeechVoice = "alloy"
+	VoiceAsh     SpeechVoice = "ash"
+	VoiceBallad  SpeechVoice = "ballad"
+	VoiceCoral   SpeechVoice = "coral"
 	VoiceEcho    SpeechVoice = "echo"
 	VoiceFable   SpeechVoice = "fable"
 	VoiceOnyx    SpeechVoice = "onyx"
 	VoiceNova    SpeechVoice = "nova"
 	VoiceShimmer SpeechVoice = "shimmer"
+	VoiceVerse   SpeechVoice = "verse"
 )
 
 type SpeechResponseFormat string

--- a/speech.go
+++ b/speech.go
@@ -10,6 +10,7 @@ type SpeechModel string
 const (
 	TTSModel1         SpeechModel = "tts-1"
 	TTSModel1HD       SpeechModel = "tts-1-hd"
+	TTSModelCanary    SpeechModel = "canary-tts"
 	TTSModelGPT4oMini SpeechModel = "gpt-4o-mini-tts"
 )
 


### PR DESCRIPTION
**Describe the change**
This adds the new OpenAI TTS model, includes a new instructions field, and adds missing speech voices.

**Provide OpenAI documentation link**
https://platform.openai.com/docs/api-reference/audio

**Describe your solution**
- Add `TTSModelGPT4oMini` to `SpeechModel` type
- Adds missing voices to `SpeechVoice` type
- Added an optional `instructions` field to the `CreateSpeechRequest` object, specific to the `gpt-4o-mini-tts` model.

**Tests**
No test changes were required. The `SpeechModel` and `SpeechVoice` types were already defined, and the `instructions` field is omitted when empty.