### PR TITLE
Add CompletionRequest.StreamOptions

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -194,6 +194,8 @@ type CompletionRequest struct {
 	Temperature     float32           `json:"temperature,omitempty"`
 	TopP            float32           `json:"top_p,omitempty"`
 	User            string            `json:"user,omitempty"`
+	// Options for streaming response. Only set this when you set stream: true.
+	StreamOptions *StreamOptions `json:"stream_options,omitempty"`
 }
 
 // CompletionChoice represents one of possible completions.


### PR DESCRIPTION
**Describe the change**

The legacy completion API supports [a `stream_options` object when `stream` is set to true](https://platform.openai.com/docs/api-reference/completions/create#completions-create-stream_options). This adds a StreamOptions property to the CompletionRequest struct to support this setting.

**Provide OpenAI documentation link**

https://platform.openai.com/docs/api-reference/completions/create#completions-create-stream_options

**Describe your solution**

This adds a `StreamOptions` property (marshaled as `stream_options`) to the `CompletionRequest` struct to expose the setting. This matches the `ChatCompletionRequest` property.

