### PR TITLE
add enum tag to jsonschema

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,6 +22,6 @@ jobs:
       with:
         version: v1.64.5
     - name: Run tests
-      run: go test -race -covermode=atomic -coverprofile=coverage.out -v .
+      run: go test -race -covermode=atomic -coverprofile=coverage.out -v ./...
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4

--- a/jsonschema/json.go
+++ b/jsonschema/json.go
@@ -46,6 +46,8 @@ type Definition struct {
 	// additionalProperties: false
 	// additionalProperties: jsonschema.Definition{Type: jsonschema.String}
 	AdditionalProperties any `json:"additionalProperties,omitempty"`
+	// Whether the schema is nullable or not.
+	Nullable bool `json:"nullable,omitempty"`
 }
 
 func (d *Definition) MarshalJSON() ([]byte, error) {
@@ -142,6 +144,11 @@ func reflectSchemaObject(t reflect.Type) (*Definition, error) {
 		enum := field.Tag.Get("enum")
 		if enum != "" {
 			item.Enum = strings.Split(enum, ",")
+		}
+
+		if n := field.Tag.Get("nullable"); n != "" {
+			nullable, _ := strconv.ParseBool(n)
+			item.Nullable = nullable
 		}
 
 		properties[jsonTag] = *item

--- a/jsonschema/json.go
+++ b/jsonschema/json.go
@@ -139,6 +139,11 @@ func reflectSchemaObject(t reflect.Type) (*Definition, error) {
 		if description != "" {
 			item.Description = description
 		}
+		enum := field.Tag.Get("enum")
+		if enum != "" {
+			item.Enum = strings.Split(enum, ",")
+		}
+
 		properties[jsonTag] = *item
 
 		if s := field.Tag.Get("required"); s != "" {

--- a/jsonschema/json_test.go
+++ b/jsonschema/json_test.go
@@ -17,7 +17,7 @@ func TestDefinition_MarshalJSON(t *testing.T) {
 		{
 			name: "Test with empty Definition",
 			def:  jsonschema.Definition{},
-			want: `{"properties":{}}`,
+			want: `{}`,
 		},
 		{
 			name: "Test with Definition properties set",
@@ -35,8 +35,7 @@ func TestDefinition_MarshalJSON(t *testing.T) {
    "description":"A string type",
    "properties":{
       "name":{
-         "type":"string",
-         "properties":{}
+         "type":"string"
       }
    }
 }`,
@@ -66,12 +65,10 @@ func TestDefinition_MarshalJSON(t *testing.T) {
          "type":"object",
          "properties":{
             "name":{
-               "type":"string",
-               "properties":{}
+               "type":"string"
             },
             "age":{
-               "type":"integer",
-               "properties":{}
+               "type":"integer"
             }
          }
       }
@@ -114,23 +111,19 @@ func TestDefinition_MarshalJSON(t *testing.T) {
          "type":"object",
          "properties":{
             "name":{
-               "type":"string",
-               "properties":{}
+               "type":"string"
             },
             "age":{
-               "type":"integer",
-               "properties":{}
+               "type":"integer"
             },
             "address":{
                "type":"object",
                "properties":{
                   "city":{
-                     "type":"string",
-                     "properties":{}
+                     "type":"string"
                   },
                   "country":{
-                     "type":"string",
-                     "properties":{}
+                     "type":"string"
                   }
                }
             }
@@ -155,15 +148,11 @@ func TestDefinition_MarshalJSON(t *testing.T) {
 			want: `{
    "type":"array",
    "items":{
-      "type":"string",
-      "properties":{
-         
-      }
+      "type":"string"
    },
    "properties":{
       "name":{
-         "type":"string",
-         "properties":{}
+         "type":"string"
       }
    }
 }`,

--- a/jsonschema/json_test.go
+++ b/jsonschema/json_test.go
@@ -309,6 +309,26 @@ func TestStructToSchema(t *testing.T) {
 				"additionalProperties":false
 			}`,
 		},
+		{
+			name: "Test with nullable tag",
+			in: struct {
+				Name *string `json:"name" nullable:"true"`
+			}{
+				Name: nil,
+			},
+			want: `{
+
+				"type":"object",
+				"properties":{
+					"name":{
+						"type":"string",
+						"nullable":true
+					}
+				},
+				"required":["name"],
+				"additionalProperties":false
+			}`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/jsonschema/json_test.go
+++ b/jsonschema/json_test.go
@@ -199,9 +199,9 @@ func TestStructToSchema(t *testing.T) {
 		{
 			name: "Test with struct containing many fields",
 			in: struct {
-				Name   string `json:"name"`
-				Age    int    `json:"age"`
-				Active bool   `json:"active"`
+				Name   string  `json:"name"`
+				Age    int     `json:"age"`
+				Active bool    `json:"active"`
 				Height float64 `json:"height"`
 				Cities []struct {
 					Name  string `json:"name"`
@@ -257,7 +257,7 @@ func TestStructToSchema(t *testing.T) {
 		{
 			name: "Test with description tag",
 			in: struct {
-				Name        string `json:"name" description:"The name of the person"`
+				Name string `json:"name" description:"The name of the person"`
 			}{
 				Name: "John Doe",
 			},
@@ -287,6 +287,25 @@ func TestStructToSchema(t *testing.T) {
 						"type":"string"
 					}
 				},
+				"additionalProperties":false
+			}`,
+		},
+		{
+			name: "Test with enum tag",
+			in: struct {
+				Color string `json:"color" enum:"red,green,blue"`
+			}{
+				Color: "red",
+			},
+			want: `{
+				"type":"object",
+				"properties":{
+					"color":{
+						"type":"string",
+						"enum":["red","green","blue"]
+					}
+				},
+				"required":["color"],
 				"additionalProperties":false
 			}`,
 		},


### PR DESCRIPTION
> A similar PR may already be submitted!
> Please search among the [Pull request](https://github.com/sashabaranov/go-openai/pulls) before creating one.

There is another issue, #912. It seems to have been abandoned.


**Describe the change**

When creating a JSON schema from a `struct`, a new tag `enum` can be used to see the `Enum` field.

For example,

```go
type Car struct {
  Color string `json:"color" enum:"red,green,blue"`
}
```

This will see the `Enum` on the field definition would be `Enum = []string{"red","green","blue"}`.

This is implementation is being [used](https://github.com/jtarchie/outrageous/blob/519dce0dc981b0bf37e41890dc49b6ec6859970e/assert/assert.go#L24).


**Provide OpenAI documentation link**
Provide a relevant API doc from https://platform.openai.com/docs/api-reference


**Describe your solution**

See change above.


**Tests**

1. A heads up, the tests on Github Actions are not running these tests. I've added support to this PR to ensure it runs correctly.
1. I've added tests for the enum field in the `json_test.go`. This also required adding some other tests for struct to schema definition.
1. Because of `omitempty`, I've updated the tests to reflect this.

**Additional context**
n/a
