### PR TITLE
Add support for cache control in ChatCompletionMessage

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -92,6 +92,16 @@ type ChatMessagePart struct {
 	ImageURL *ChatMessageImageURL `json:"image_url,omitempty"`
 }
 
+type CacheControlType string
+
+const (
+	CacheControlTypeEphemeral CacheControlType = "ephemeral"
+)
+
+type CacheControl struct {
+	Type CacheControlType `json:"type,omitempty"`
+}
+
 type ChatCompletionMessage struct {
 	Role         string `json:"role"`
 	Content      string `json:"content,omitempty"`
@@ -111,6 +121,9 @@ type ChatCompletionMessage struct {
 
 	// For Role=tool prompts this should be set to the ID given in the assistant's prior request to call a tool.
 	ToolCallID string `json:"tool_call_id,omitempty"`
+
+	// CacheControl is used to control the caching behavior of the message. Used by Litellm.
+	CacheControl *CacheControl `json:"cache_control,omitempty"`
 }
 
 func (m ChatCompletionMessage) MarshalJSON() ([]byte, error) {
@@ -127,6 +140,7 @@ func (m ChatCompletionMessage) MarshalJSON() ([]byte, error) {
 			FunctionCall *FunctionCall     `json:"function_call,omitempty"`
 			ToolCalls    []ToolCall        `json:"tool_calls,omitempty"`
 			ToolCallID   string            `json:"tool_call_id,omitempty"`
+			CacheControl *CacheControl     `json:"cache_control,omitempty"`
 		}(m)
 		return json.Marshal(msg)
 	}
@@ -140,6 +154,7 @@ func (m ChatCompletionMessage) MarshalJSON() ([]byte, error) {
 		FunctionCall *FunctionCall     `json:"function_call,omitempty"`
 		ToolCalls    []ToolCall        `json:"tool_calls,omitempty"`
 		ToolCallID   string            `json:"tool_call_id,omitempty"`
+		CacheControl *CacheControl     `json:"cache_control,omitempty"`
 	}(m)
 	return json.Marshal(msg)
 }
@@ -154,6 +169,7 @@ func (m *ChatCompletionMessage) UnmarshalJSON(bs []byte) error {
 		FunctionCall *FunctionCall `json:"function_call,omitempty"`
 		ToolCalls    []ToolCall    `json:"tool_calls,omitempty"`
 		ToolCallID   string        `json:"tool_call_id,omitempty"`
+		CacheControl *CacheControl `json:"cache_control,omitempty"`
 	}{}
 
 	if err := json.Unmarshal(bs, &msg); err == nil {
@@ -169,6 +185,7 @@ func (m *ChatCompletionMessage) UnmarshalJSON(bs []byte) error {
 		FunctionCall *FunctionCall     `json:"function_call,omitempty"`
 		ToolCalls    []ToolCall        `json:"tool_calls,omitempty"`
 		ToolCallID   string            `json:"tool_call_id,omitempty"`
+		CacheControl *CacheControl     `json:"cache_control,omitempty"`
 	}{}
 	if err := json.Unmarshal(bs, &multiMsg); err != nil {
 		return err


### PR DESCRIPTION
**Describe the change**
Fixes #897 many openai compatible apis use this key to let users control token caching for models that support it.

**Provide OpenAI documentation link**
Not a openai feature, but common in openai compatible endpoints. https://docs.litellm.ai/docs/completion/prompt_caching#anthropic-example

**Describe your solution**
Add the extra keys
