### PR TITLE
Add Prediction field

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -263,6 +263,8 @@ type ChatCompletionRequest struct {
 	ReasoningEffort string `json:"reasoning_effort,omitempty"`
 	// Metadata to store with the completion.
 	Metadata map[string]string `json:"metadata,omitempty"`
+	// Configuration for a predicted output.
+	Prediction *Prediction `json:"prediction,omitempty"`
 }
 
 type StreamOptions struct {
@@ -328,6 +330,11 @@ type LogProb struct {
 type LogProbs struct {
 	// Content is a list of message content tokens with log probability information.
 	Content []LogProb `json:"content"`
+}
+
+type Prediction struct {
+	Content string `json:"content"`
+	Type    string `json:"type"`
 }
 
 type FinishReason string

--- a/common.go
+++ b/common.go
@@ -13,8 +13,10 @@ type Usage struct {
 
 // CompletionTokensDetails Breakdown of tokens used in a completion.
 type CompletionTokensDetails struct {
-	AudioTokens     int `json:"audio_tokens"`
-	ReasoningTokens int `json:"reasoning_tokens"`
+	AudioTokens              int `json:"audio_tokens"`
+	ReasoningTokens          int `json:"reasoning_tokens"`
+	AcceptedPredictionTokens int `json:"accepted_prediction_tokens"`
+	RejectedPredictionTokens int `json:"rejected_prediction_tokens"`
 }
 
 // PromptTokensDetails Breakdown of tokens used in the prompt.


### PR DESCRIPTION
**Describe the change**

Adding the prediction field which allows for using [Predicted Outputs](https://platform.openai.com/docs/guides/predicted-outputs).

**Provide OpenAI documentation link**
https://platform.openai.com/docs/api-reference/chat/create#chat-create-prediction

**Describe your solution**
Adds the optional parameter and modifies the response to include how many prediction tokens it used

**Tests**
Briefly describe how you have tested these changes. If possible — please add integration tests.
Tested locally and verified that I received predicted tokens accepted in the response
<img width="585" alt="image" src="https://github.com/user-attachments/assets/d75f2e46-26a7-4d2c-b98f-4146b372ac11" />

Issue: #954 
