### PR TITLE
feat: add support for image generation using `gpt-image-1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,13 +382,11 @@ func main() {
 		Model:             openai.CreateImageModelGptImage1,
 		Size:              openai.CreateImageSize1024x1024,
 		N:                 1,
-		Quality:           op
-enai.CreateImageQualityLow,
+		Quality:           openai.CreateImageQualityLow,
 		OutputCompression: 100,
 		OutputFormat:      openai.CreateImageOutputFormatJPEG,
 		// Moderation: 		 openai.CreateImageModerationLow,
 		// User: 					 "",
-
 	}
 
 	resp, err := c.CreateImage(ctx, req)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This library provides unofficial Go clients for [OpenAI API](https://platform.op
 
 * ChatGPT 4o, o1
 * GPT-3, GPT-4
-* DALL·E 2, DALL·E 3
+* DALL·E 2, DALL·E 3, GPT Image 1
 * Whisper
 
 ## Installation
@@ -354,6 +354,68 @@ func main() {
 	fmt.Println("The image was saved as example.png")
 }
 
+```
+</details>
+
+<details>
+<summary>GPT Image 1 image generation</summary>
+
+```go
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+func main() {
+	c := openai.NewClient("your token")
+	ctx := context.Background()
+
+	req := openai.ImageRequest{
+		Prompt:            "Parrot on a skateboard performing a trick. Large bold text \"SKATE MASTER\" banner at the bottom of the image. Cartoon style, natural light, high detail, 1:1 aspect ratio.",
+		Background:        openai.CreateImageBackgroundOpaque,
+		Model:             openai.CreateImageModelGptImage1,
+		Size:              openai.CreateImageSize1024x1024,
+		N:                 1,
+		Quality:           op
+enai.CreateImageQualityLow,
+		OutputCompression: 100,
+		OutputFormat:      openai.CreateImageOutputFormatJPEG,
+		// Moderation: 		 openai.CreateImageModerationLow,
+		// User: 					 "",
+
+	}
+
+	resp, err := c.CreateImage(ctx, req)
+	if err != nil {
+		fmt.Printf("Image creation Image generation with GPT Image 1error: %v\n", err)
+		return
+	}
+
+	fmt.Println("Image Base64:", resp.Data[0].B64JSON)
+
+	// Decode the base64 data
+	imgBytes, err := base64.StdEncoding.DecodeString(resp.Data[0].B64JSON)
+	if err != nil {
+		fmt.Printf("Base64 decode error: %v\n", err)
+		return
+	}
+
+	// Write image to file
+	outputPath := "generated_image.jpg"
+	err = os.WriteFile(outputPath, imgBytes, 0644)
+	if err != nil {
+		fmt.Printf("Failed to write image file: %v\n", err)
+		return
+	}
+
+	fmt.Printf("The image was saved as %s\n", outputPath)
+}
 ```
 </details>
 

--- a/examples/images/main.go
+++ b/examples/images/main.go
@@ -37,15 +37,24 @@ func main() {
 	res, err := client.CreateImage(
 		context.Background(),
 		openai.ImageRequest{
-			Prompt:            "Parrot on a skateboard performing a trick. Large bold text \"SKATE MASTER\" banner at the bottom of the image. Cartoon style, natural light, high detail",
-			Background:        openai.CreateImageBackgroundTransparent,
-			Model:             openai.CreateImageModelGptImage1,
-			Size:              openai.CreateImageSize1024x1024,
-			N:                 1,
-			Quality:           openai.CreateImageQualityLow,
-			OutputCompression: 100,
+			Prompt:  "Parrot on a skateboard performing a trick. Large bold text \"SKATE MASTER\" banner at the bottom of the image. Cartoon style, natural light, high detail",
+			Model:   openai.CreateImageModelGptImage1,
+			Size:    openai.CreateImageSize1024x1024,
+			N:       1,
+			Quality: openai.CreateImageQualityLow,
+			// User: "", //
+
+			// Only for GPT Image 1
 			OutputFormat:      openai.CreateImageOutputFormatJPEG,
+			OutputCompression: 100,
+			Background:        openai.CreateImageBackgroundTransparent,
+			// Moderation: openai.CreateImageModerationLow,
+
+			// Only for dall-e-2 and dall-e-3
 			// ResponseFormat:    openai.CreateImageResponseFormatB64JSON,
+
+			// Only for dall-e 3
+			// Style: openai.CreateImageStyleVivid,
 		},
 	)
 
@@ -64,7 +73,6 @@ func main() {
 		return
 	}
 
-	// Save the image using the new function
 	outputPath, err := saveImageToFile(imageBytes, "examples/images", "generated_image.jpg")
 	if err != nil {
 		fmt.Printf("Error saving image: %v\n", err)

--- a/examples/images/main.go
+++ b/examples/images/main.go
@@ -2,27 +2,74 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/sashabaranov/go-openai"
 )
 
+// saveImageToFile saves image data to a file in the specified directory
+// Returns the full path where the image was saved or an error
+func saveImageToFile(imageData []byte, outputDir, filename string) (string, error) {
+	// Create output directory if it doesn't exist
+	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
+		err = os.Mkdir(outputDir, 0755)
+		if err != nil {
+			return "", fmt.Errorf("failed to create output directory: %w", err)
+		}
+	}
+
+	// Write the image data to a file
+	outputPath := filepath.Join(outputDir, filename)
+	err := os.WriteFile(outputPath, imageData, 0644)
+	if err != nil {
+		return "", fmt.Errorf("failed to write image file: %w", err)
+	}
+
+	return outputPath, nil
+}
+
 func main() {
 	client := openai.NewClient(os.Getenv("OPENAI_API_KEY"))
 
-	respUrl, err := client.CreateImage(
+	res, err := client.CreateImage(
 		context.Background(),
 		openai.ImageRequest{
-			Prompt:         "Parrot on a skateboard performs a trick, cartoon style, natural light, high detail",
-			Size:           openai.CreateImageSize256x256,
-			ResponseFormat: openai.CreateImageResponseFormatURL,
-			N:              1,
+			Prompt:            "Parrot on a skateboard performing a trick. Large bold text \"SKATE MASTER\" banner at the bottom of the image. Cartoon style, natural light, high detail",
+			Background:        openai.CreateImageBackgroundTransparent,
+			Model:             openai.CreateImageModelGptImage1,
+			Size:              openai.CreateImageSize1024x1024,
+			N:                 1,
+			Quality:           openai.CreateImageQualityLow,
+			OutputCompression: 100,
+			OutputFormat:      openai.CreateImageOutputFormatJPEG,
+			// ResponseFormat:    openai.CreateImageResponseFormatB64JSON,
 		},
 	)
+
 	if err != nil {
 		fmt.Printf("Image creation error: %v\n", err)
 		return
 	}
-	fmt.Println(respUrl.Data[0].URL)
+
+	// Decode the base64 data
+	imageBase64 := res.Data[0].B64JSON
+	fmt.Printf("Base64 data: %s\n", imageBase64)
+
+	imageBytes, err := base64.StdEncoding.DecodeString(res.Data[0].B64JSON)
+	if err != nil {
+		fmt.Printf("Base64 decode error: %v\n", err)
+		return
+	}
+
+	// Save the image using the new function
+	outputPath, err := saveImageToFile(imageBytes, "examples/images", "generated_image.jpg")
+	if err != nil {
+		fmt.Printf("Error saving image: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Image saved to: %s\n", outputPath)
 }

--- a/examples/images/main.go
+++ b/examples/images/main.go
@@ -2,82 +2,27 @@ package main
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/sashabaranov/go-openai"
 )
 
-// saveImageToFile saves image data to a file in the specified directory
-// Returns the full path where the image was saved or an error
-func saveImageToFile(imageData []byte, outputDir, filename string) (string, error) {
-	// Create output directory if it doesn't exist
-	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
-		err = os.Mkdir(outputDir, 0755)
-		if err != nil {
-			return "", fmt.Errorf("failed to create output directory: %w", err)
-		}
-	}
-
-	// Write the image data to a file
-	outputPath := filepath.Join(outputDir, filename)
-	err := os.WriteFile(outputPath, imageData, 0644)
-	if err != nil {
-		return "", fmt.Errorf("failed to write image file: %w", err)
-	}
-
-	return outputPath, nil
-}
-
 func main() {
 	client := openai.NewClient(os.Getenv("OPENAI_API_KEY"))
 
-	res, err := client.CreateImage(
+	respUrl, err := client.CreateImage(
 		context.Background(),
 		openai.ImageRequest{
-			Prompt:  "Parrot on a skateboard performing a trick. Large bold text \"SKATE MASTER\" banner at the bottom of the image. Cartoon style, natural light, high detail",
-			Model:   openai.CreateImageModelGptImage1,
-			Size:    openai.CreateImageSize1024x1024,
-			N:       1,
-			Quality: openai.CreateImageQualityLow,
-			// User: "", //
-
-			// Only for GPT Image 1
-			OutputFormat:      openai.CreateImageOutputFormatJPEG,
-			OutputCompression: 100,
-			Background:        openai.CreateImageBackgroundTransparent,
-			// Moderation: openai.CreateImageModerationLow,
-
-			// Only for dall-e-2 and dall-e-3
-			// ResponseFormat:    openai.CreateImageResponseFormatB64JSON,
-
-			// Only for dall-e 3
-			// Style: openai.CreateImageStyleVivid,
+			Prompt:         "Parrot on a skateboard performs a trick, cartoon style, natural light, high detail",
+			Size:           openai.CreateImageSize256x256,
+			ResponseFormat: openai.CreateImageResponseFormatURL,
+			N:              1,
 		},
 	)
-
 	if err != nil {
 		fmt.Printf("Image creation error: %v\n", err)
 		return
 	}
-
-	// Decode the base64 data
-	imageBase64 := res.Data[0].B64JSON
-	fmt.Printf("Base64 data: %s\n", imageBase64)
-
-	imageBytes, err := base64.StdEncoding.DecodeString(res.Data[0].B64JSON)
-	if err != nil {
-		fmt.Printf("Base64 decode error: %v\n", err)
-		return
-	}
-
-	outputPath, err := saveImageToFile(imageBytes, "examples/images", "generated_image.jpg")
-	if err != nil {
-		fmt.Printf("Error saving image: %v\n", err)
-		return
-	}
-
-	fmt.Printf("Image saved to: %s\n", outputPath)
+	fmt.Println(respUrl.Data[0].URL)
 }

--- a/image.go
+++ b/image.go
@@ -39,31 +39,31 @@ const (
 	CreateImageQualityHD       = "hd"
 	CreateImageQualityStandard = "standard"
 
-	// gpt-image-1 only
+	// gpt-image-1 only.
 	CreateImageQualityHigh   = "high"
 	CreateImageQualityMedium = "medium"
 	CreateImageQualityLow    = "low"
 )
 
 const (
-	// dall-e-3 only
+	// dall-e-3 only.
 	CreateImageStyleVivid   = "vivid"
 	CreateImageStyleNatural = "natural"
 )
 
 const (
-	// gpt-image-1 only
+	// gpt-image-1 only.
 	CreateImageBackgroundTransparent = "transparent"
 	CreateImageBackgroundOpaque      = "opaque"
 )
 
 const (
-	// gpt-image-1 only
+	// gpt-image-1 only.
 	CreateImageModerationLow = "low"
 )
 
 const (
-	// gpt-image-1 only
+	// gpt-image-1 only.
 	CreateImageOutputFormatPNG  = "png"
 	CreateImageOutputFormatJPEG = "jpeg"
 	CreateImageOutputFormatWEBP = "webp"

--- a/image.go
+++ b/image.go
@@ -13,49 +13,99 @@ const (
 	CreateImageSize256x256   = "256x256"
 	CreateImageSize512x512   = "512x512"
 	CreateImageSize1024x1024 = "1024x1024"
+
 	// dall-e-3 supported only.
 	CreateImageSize1792x1024 = "1792x1024"
 	CreateImageSize1024x1792 = "1024x1792"
+
+	// gpt-image-1 supported only.
+	CreateImageSize1536x1024 = "1536x1024" // Landscape
+	CreateImageSize1024x1536 = "1024x1536" // Portrait
 )
 
 const (
-	CreateImageResponseFormatURL     = "url"
+	// dall-e-2 and dall-e-3 only.
 	CreateImageResponseFormatB64JSON = "b64_json"
+	CreateImageResponseFormatURL     = "url"
 )
 
 const (
-	CreateImageModelDallE2 = "dall-e-2"
-	CreateImageModelDallE3 = "dall-e-3"
+	CreateImageModelDallE2    = "dall-e-2"
+	CreateImageModelDallE3    = "dall-e-3"
+	CreateImageModelGptImage1 = "gpt-image-1"
 )
 
 const (
 	CreateImageQualityHD       = "hd"
 	CreateImageQualityStandard = "standard"
+
+	// gpt-image-1 only
+	CreateImageQualityHigh   = "high"
+	CreateImageQualityMedium = "medium"
+	CreateImageQualityLow    = "low"
 )
 
 const (
+	// dall-e-3 only
 	CreateImageStyleVivid   = "vivid"
 	CreateImageStyleNatural = "natural"
 )
 
+const (
+	// gpt-image-1 only
+	CreateImageBackgroundTransparent = "transparent"
+	CreateImageBackgroundOpaque      = "opaque"
+)
+
+const (
+	// gpt-image-1 only
+	CreateImageModerationLow = "low"
+)
+
+const (
+	// gpt-image-1 only
+	CreateImageOutputFormatPNG  = "png"
+	CreateImageOutputFormatJPEG = "jpeg"
+	CreateImageOutputFormatWEBP = "webp"
+)
+
 // ImageRequest represents the request structure for the image API.
 type ImageRequest struct {
-	Prompt         string `json:"prompt,omitempty"`
-	Model          string `json:"model,omitempty"`
-	N              int    `json:"n,omitempty"`
-	Quality        string `json:"quality,omitempty"`
-	Size           string `json:"size,omitempty"`
-	Style          string `json:"style,omitempty"`
-	ResponseFormat string `json:"response_format,omitempty"`
-	User           string `json:"user,omitempty"`
+	Prompt            string `json:"prompt,omitempty"`
+	Model             string `json:"model,omitempty"`
+	N                 int    `json:"n,omitempty"`
+	Quality           string `json:"quality,omitempty"`
+	Size              string `json:"size,omitempty"`
+	Style             string `json:"style,omitempty"`
+	ResponseFormat    string `json:"response_format,omitempty"`
+	User              string `json:"user,omitempty"`
+	Background        string `json:"background,omitempty"`
+	Moderation        string `json:"moderation,omitempty"`
+	OutputCompression int    `json:"output_compression,omitempty"`
+	OutputFormat      string `json:"output_format,omitempty"`
 }
 
 // ImageResponse represents a response structure for image API.
 type ImageResponse struct {
 	Created int64                    `json:"created,omitempty"`
 	Data    []ImageResponseDataInner `json:"data,omitempty"`
+	Usage   ImageResponseUsage       `json:"usage,omitempty"`
 
 	httpHeader
+}
+
+// ImageResponseInputTokensDetails represents the token breakdown for input tokens.
+type ImageResponseInputTokensDetails struct {
+	TextTokens  int `json:"text_tokens,omitempty"`
+	ImageTokens int `json:"image_tokens,omitempty"`
+}
+
+// ImageResponseUsage represents the token usage information for image API.
+type ImageResponseUsage struct {
+	TotalTokens        int                             `json:"total_tokens,omitempty"`
+	InputTokens        int                             `json:"input_tokens,omitempty"`
+	OutputTokens       int                             `json:"output_tokens,omitempty"`
+	InputTokensDetails ImageResponseInputTokensDetails `json:"input_tokens_details,omitempty"`
 }
 
 // ImageResponseDataInner represents a response data structure for image API.
@@ -91,6 +141,8 @@ type ImageEditRequest struct {
 	N              int      `json:"n,omitempty"`
 	Size           string   `json:"size,omitempty"`
 	ResponseFormat string   `json:"response_format,omitempty"`
+	Quality        string   `json:"quality,omitempty"`
+	User           string   `json:"user,omitempty"`
 }
 
 // CreateEditImage - API call to create an image. This is the main endpoint of the DALL-E API.
@@ -159,6 +211,7 @@ type ImageVariRequest struct {
 	N              int      `json:"n,omitempty"`
 	Size           string   `json:"size,omitempty"`
 	ResponseFormat string   `json:"response_format,omitempty"`
+	User           string   `json:"user,omitempty"`
 }
 
 // CreateVariImage - API call to create an image variation. This is the main endpoint of the DALL-E API.


### PR DESCRIPTION
**Describe the change**

This PR adds support for the new `gpt-image-1` model from OpenAI, along with several missing constants and optional fields related to image generation.

**Provide OpenAI documentation link**

- https://platform.openai.com/docs/guides/image-generation?image-generation-model=gpt-image-1

- https://platform.openai.com/docs/api-reference/images

**Describe your solution**

- Added constant for the new `gpt-image-1` model.

- Included image sizes specific to the model: 1536x1024 (landscape), 1024x1536 (portrait).

- Added quality levels: low, medium, high.

- Added background options: transparent, opaque.

- Added moderation level: low.

- Added output formats: png, jpeg, webp.

- Updated the Request and Response structs to include optional fields from the OpenAI API response that were previously missing.

- Updated `README` file to include GPT Image 1. 

**Tests**

I tested the changes locally by modifying `examples/images/main.go` to generate an image using the `gpt-image-1` model and the new parameters. The request completed successfully, and the image was generated as expected.