### PR TITLE
Fix for Edit Image content type requirement

### DIFF
--- a/internal/form_builder.go
+++ b/internal/form_builder.go
@@ -36,7 +36,6 @@ func (fb *DefaultFormBuilder) CreateFormFileReader(fieldname string, r io.Reader
 	return fb.createFormFile(fieldname, r, path.Base(filename))
 }
 
-
 var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
 
 func escapeQuotes(s string) string {


### PR DESCRIPTION
**Describe the change**
PR to fix #967 and #601 The OpenAI Edit Image endpoint `/v1/images/edits` only accepts specific image formats as seen in error responses like so:
`status: 400 Bad Request, message: Invalid file 'image': unsupported mimetype ('image/jpeg'). Supported file formats are 'image/png'`. Even though the API docs say other types are supported [https://platform.openai.com/docs/api-reference/images/createEdit](https://platform.openai.com/docs/api-reference/images/createEdit):
```
For gpt-image-1, each image should be a png, webp, or jpg file less than 25MB.
```

This is not true as of `4-28-25` I think because it is still stuck on DALLE mode which only allows PNGs.

**Describe your solution**
Pretty simple fix really, replaced the call to the default helper method which only does `application/octet-stream` with the code the helper method calls and set the content-type to `image/png`


**Tests**
I ran a modified version of the image example which calls the edit image endpoint instead using my forked version and it worked successfully.

