### PR TITLE
add ChatTemplateKwargs to ChatCompletionRequest

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -275,6 +275,8 @@ type ChatCompletionRequest struct {
 	Metadata map[string]string `json:"metadata,omitempty"`
 	// Configuration for a predicted output.
 	Prediction *Prediction `json:"prediction,omitempty"`
+	// ExtraBody provides a way to add non-standard parameters to the request body. such as think mode for qwen3
+	ChatTemplateKwargs map[string]interface{} `json:"chat_template_kwargs,omitempty"`
 }
 
 type StreamOptions struct {


### PR DESCRIPTION
**Describe the change**
add chat_template_kwargs param support 

**Provide OpenAI documentation link**
[vllm qwen3 thinking modes](https://qwen.readthedocs.io/en/latest/deployment/vllm.html#thinking-non-thinking-modes
)

`curl http://localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d '{
  "model": "Qwen/Qwen3-8B",
  "messages": [
    {"role": "user", "content": "Give me a short introduction to large language models."}
  ],
  "temperature": 0.7,
  "top_p": 0.8,
  "top_k": 20,
  "max_tokens": 8192,
  "presence_penalty": 1.5,
  "chat_template_kwargs": {"enable_thinking": false}
}'`