### PR TITLE
Fix: Corrected typo in o4-mini model name and fixed endpoint map

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -21,7 +21,7 @@ const (
 	O3Mini                  = "o3-mini"
 	O3Mini20250131          = "o3-mini-2025-01-31"
 	O4Mini                  = "o4-mini"
-	O4Mini2020416           = "o4-mini-2025-04-16"
+	O4Mini20250416          = "o4-mini-2025-04-16"
 	GPT432K0613             = "gpt-4-32k-0613"
 	GPT432K0314             = "gpt-4-32k-0314"
 	GPT432K                 = "gpt-4-32k"
@@ -104,7 +104,7 @@ var disabledModelsForEndpoints = map[string]map[string]bool{
 		O3Mini:                  true,
 		O3Mini20250131:          true,
 		O4Mini:                  true,
-		O4Mini2020416:           true,
+		O4Mini20250416:          true,
 		O3:                      true,
 		O320250416:              true,
 		GPT3Dot5Turbo:           true,


### PR DESCRIPTION
**Describe the change**
Someone typo'd the O4 mini model name in #968. Fixed it in this PR.

**Provide OpenAI documentation link**
N/A

**Describe your solution**
Self-explanatory

**Tests**
Tests didn't need to be updated as this was a variable naming change only. The underlying model name was correct.

**Additional context**
[See this issue](https://github.com/sashabaranov/go-openai/issues/982)
