### PR TITLE
feat: support topk

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -214,6 +214,7 @@ type CompletionRequest struct {
 	Suffix          string            `json:"suffix,omitempty"`
 	Temperature     float32           `json:"temperature,omitempty"`
 	TopP            float32           `json:"top_p,omitempty"`
+	TopK            int               `json:"top_k,omitempty"`
 	User            string            `json:"user,omitempty"`
 	// Options for streaming response. Only set this when you set stream: true.
 	StreamOptions *StreamOptions `json:"stream_options,omitempty"`


### PR DESCRIPTION
**Describe the change**

TopK is well-used paramater for provider which uses OpenAI-compatible API format. This commit add the `top_k` parameter.

**Provide OpenAI documentation link**
Provide a relevant API doc from https://platform.openai.com/docs/api-reference

**Describe your solution**

Add `top_k` as new parameter

**Tests**
-

**Additional context**

Some evidence that top_k is well used
- https://openrouter.ai/docs/api-reference/parameters
- https://docs.vllm.ai/en/v0.6.4/dev/sampling_params.html

Issue: #641