### PR TITLE
[BREAKING_CHANGES]remove dot from azure model mapper func

### DIFF
--- a/config.go
+++ b/config.go
@@ -70,7 +70,7 @@ func DefaultAzureConfig(apiKey, baseURL string) ClientConfig {
 		APIType:    APITypeAzure,
 		APIVersion: "2023-05-15",
 		AzureModelMapperFunc: func(model string) string {
-			return regexp.MustCompile(`[:]`).ReplaceAllString(model, "")
+			return regexp.MustCompile(`:`).ReplaceAllString(model, "")
 		},
 
 		HTTPClient: &http.Client{},

--- a/config.go
+++ b/config.go
@@ -70,7 +70,7 @@ func DefaultAzureConfig(apiKey, baseURL string) ClientConfig {
 		APIType:    APITypeAzure,
 		APIVersion: "2023-05-15",
 		AzureModelMapperFunc: func(model string) string {
-			return regexp.MustCompile(`[.:]`).ReplaceAllString(model, "")
+			return regexp.MustCompile(`[:]`).ReplaceAllString(model, "")
 		},
 
 		HTTPClient: &http.Client{},


### PR DESCRIPTION
A similar PR may already be submitted!
Please search among the [Pull request](https://github.com/sashabaranov/go-openai/pulls) before creating one.

If your changes introduce breaking changes, please prefix the title of your pull request with "[BREAKING_CHANGES]". This allows for clear identification of such changes in the 'What's Changed' section on the release page, making it developer-friendly.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.

**Describe the change**
for models such as gpt-4.1 the azure mapper function by default changes it to gpt-41 which makes bad request even if users create an Azure deployment with deployment name same as the model name (gpt-4.1)



**Describe your solution**
Allow putting dot in the deployment name as it's allowed in urls.


Issue: No issue.
