### PR TITLE
images/edits API support azure endpoint

### DIFF
--- a/client.go
+++ b/client.go
@@ -250,6 +250,8 @@ var azureDeploymentsEndpoints = []string{
 	"/audio/translations",
 	"/audio/speech",
 	"/images/generations",
+	"/images/edits",
+	"/images/variations",
 }
 
 // fullURL returns full URL for request.

--- a/image.go
+++ b/image.go
@@ -134,15 +134,15 @@ func (c *Client) CreateImage(ctx context.Context, request ImageRequest) (respons
 
 // ImageEditRequest represents the request structure for the image API.
 type ImageEditRequest struct {
-	Image          io.Reader `json:"image,omitempty"`
-	Mask           io.Reader `json:"mask,omitempty"`
-	Prompt         string    `json:"prompt,omitempty"`
-	Model          string    `json:"model,omitempty"`
-	N              int       `json:"n,omitempty"`
-	Size           string    `json:"size,omitempty"`
-	ResponseFormat string    `json:"response_format,omitempty"`
-	Quality        string    `json:"quality,omitempty"`
-	User           string    `json:"user,omitempty"`
+	Image          []io.Reader `json:"image,omitempty"`
+	Mask           io.Reader   `json:"mask,omitempty"`
+	Prompt         string      `json:"prompt,omitempty"`
+	Model          string      `json:"model,omitempty"`
+	N              int         `json:"n,omitempty"`
+	Size           string      `json:"size,omitempty"`
+	ResponseFormat string      `json:"response_format,omitempty"`
+	Quality        string      `json:"quality,omitempty"`
+	User           string      `json:"user,omitempty"`
 }
 
 // CreateEditImage - API call to create an image. This is the main endpoint of the DALL-E API.
@@ -150,10 +150,12 @@ func (c *Client) CreateEditImage(ctx context.Context, request ImageEditRequest) 
 	body := &bytes.Buffer{}
 	builder := c.createFormBuilder(body)
 
-	// image, filename is not required
-	err = builder.CreateFormFileReader("image", request.Image, "")
-	if err != nil {
-		return
+	for _, img := range request.Image {
+		// image, filename is not required
+		err = builder.CreateFormFileReader("image", img, "")
+		if err != nil {
+			return
+		}
 	}
 
 	// mask, it is optional

--- a/image.go
+++ b/image.go
@@ -134,7 +134,7 @@ func (c *Client) CreateImage(ctx context.Context, request ImageRequest) (respons
 
 // ImageEditRequest represents the request structure for the image API.
 type ImageEditRequest struct {
-	Image          []io.Reader `json:"image,omitempty"`
+	Images         []io.Reader `json:"images,omitempty"`
 	Mask           io.Reader   `json:"mask,omitempty"`
 	Prompt         string      `json:"prompt,omitempty"`
 	Model          string      `json:"model,omitempty"`
@@ -150,7 +150,7 @@ func (c *Client) CreateEditImage(ctx context.Context, request ImageEditRequest) 
 	body := &bytes.Buffer{}
 	builder := c.createFormBuilder(body)
 
-	for _, img := range request.Image {
+	for _, img := range request.Images {
 		// image, filename is not required
 		err = builder.CreateFormFileReader("image", img, "")
 		if err != nil {

--- a/image.go
+++ b/image.go
@@ -70,6 +70,10 @@ const (
 	CreateImageOutputFormatWEBP = "webp"
 )
 
+const (
+	minFileTypeLength = 6 // "image/"
+)
+
 // ImageRequest represents the request structure for the image API.
 type ImageRequest struct {
 	Prompt            string `json:"prompt,omitempty"`
@@ -159,12 +163,12 @@ func (c *Client) CreateEditImage(ctx context.Context, request ImageEditRequest) 
 			return
 		}
 		fileType := http.DetectContentType(data)
-		if len(fileType) < 6 {
+		if len(fileType) < minFileTypeLength {
 			err = fmt.Errorf("invalid file type: %s", fileType)
 			return
 		}
 		// get file extension
-		ext := fileType[6:]
+		ext := fileType[minFileTypeLength:]
 		filename := fmt.Sprintf("%d.%s", i, ext)
 		err = builder.CreateFormFileReader("image", img, filename)
 		if err != nil {

--- a/image.go
+++ b/image.go
@@ -152,8 +152,7 @@ func (c *Client) CreateEditImage(ctx context.Context, request ImageEditRequest) 
 	builder := c.createFormBuilder(body)
 
 	for i, img := range request.Images {
-		// image, filename is not required
-		// 判断文件类型
+		// judge file type
 		var data []byte
 		data, err = io.ReadAll(img)
 		if err != nil {
@@ -164,7 +163,7 @@ func (c *Client) CreateEditImage(ctx context.Context, request ImageEditRequest) 
 			err = fmt.Errorf("invalid file type: %s", fileType)
 			return
 		}
-		// 截取文件类型后缀
+		// get file extension
 		ext := fileType[6:]
 		filename := fmt.Sprintf("%d.%s", i, ext)
 		err = builder.CreateFormFileReader("image", img, filename)

--- a/image_api_test.go
+++ b/image_api_test.go
@@ -100,7 +100,7 @@ func TestImageEdit(t *testing.T) {
 	defer mask.Close()
 
 	_, err = client.CreateEditImage(context.Background(), openai.ImageEditRequest{
-		Image:          origin,
+		Image:          []io.Reader{origin},
 		Mask:           mask,
 		Prompt:         "There is a turtle in the pool",
 		N:              3,
@@ -122,7 +122,7 @@ func TestImageEditWithoutMask(t *testing.T) {
 	defer origin.Close()
 
 	_, err = client.CreateEditImage(context.Background(), openai.ImageEditRequest{
-		Image:          origin,
+		Image:          []io.Reader{origin},
 		Prompt:         "There is a turtle in the pool",
 		N:              3,
 		Size:           openai.CreateImageSize1024x1024,

--- a/image_api_test.go
+++ b/image_api_test.go
@@ -100,7 +100,7 @@ func TestImageEdit(t *testing.T) {
 	defer mask.Close()
 
 	_, err = client.CreateEditImage(context.Background(), openai.ImageEditRequest{
-		Image:          []io.Reader{origin},
+		Images:         []io.Reader{origin},
 		Mask:           mask,
 		Prompt:         "There is a turtle in the pool",
 		N:              3,
@@ -122,7 +122,7 @@ func TestImageEditWithoutMask(t *testing.T) {
 	defer origin.Close()
 
 	_, err = client.CreateEditImage(context.Background(), openai.ImageEditRequest{
-		Image:          []io.Reader{origin},
+		Images:         []io.Reader{origin},
 		Prompt:         "There is a turtle in the pool",
 		N:              3,
 		Size:           openai.CreateImageSize1024x1024,


### PR DESCRIPTION
# change
，doc:


**Describe the change**
1、images/edits support azure endpoint
2、ImageEditRequest support multi images for model 'gpt-image-1'

**Provide OpenAI documentation link**
https://platform.openai.com/docs/api-reference/images/createEdit

**Describe your solution**


**Tests**
test unit

**Additional context**
Add any other context or screenshots or logs about your pull request here. If the pull request relates to an open issue, please link to it.


