### PR TITLE
Add support for Chat Completion Service Tier

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -280,6 +280,8 @@ type ChatCompletionRequest struct {
 	// Such as think mode for qwen3. "chat_template_kwargs": {"enable_thinking": false}
 	// https://qwen.readthedocs.io/en/latest/deployment/vllm.html#thinking-non-thinking-modes
 	ChatTemplateKwargs map[string]any `json:"chat_template_kwargs,omitempty"`
+	// Specifies the latency tier to use for processing the request.
+	ServiceTier ServiceTier `json:"service_tier,omitempty"`
 }
 
 type StreamOptions struct {
@@ -363,6 +365,14 @@ const (
 	FinishReasonNull          FinishReason = "null"
 )
 
+type ServiceTier string
+
+const (
+	ServiceTierAuto    ServiceTier = "auto"
+	ServiceTierDefault ServiceTier = "default"
+	ServiceTierFlex    ServiceTier = "flex"
+)
+
 func (r FinishReason) MarshalJSON() ([]byte, error) {
 	if r == FinishReasonNull || r == "" {
 		return []byte("null"), nil
@@ -395,6 +405,7 @@ type ChatCompletionResponse struct {
 	Usage               Usage                  `json:"usage"`
 	SystemFingerprint   string                 `json:"system_fingerprint"`
 	PromptFilterResults []PromptFilterResult   `json:"prompt_filter_results,omitempty"`
+	ServiceTier         ServiceTier            `json:"service_tier,omitempty"`
 
 	httpHeader
 }

--- a/chat.go
+++ b/chat.go
@@ -368,9 +368,10 @@ const (
 type ServiceTier string
 
 const (
-	ServiceTierAuto    ServiceTier = "auto"
-	ServiceTierDefault ServiceTier = "default"
-	ServiceTierFlex    ServiceTier = "flex"
+	ServiceTierAuto     ServiceTier = "auto"
+	ServiceTierDefault  ServiceTier = "default"
+	ServiceTierFlex     ServiceTier = "flex"
+	ServiceTierPriority ServiceTier = "priority"
 )
 
 func (r FinishReason) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
**Describe the change**

This adds support for specifying the Service Tier in a chat completion request.

**Provide OpenAI documentation link**

https://platform.openai.com/docs/api-reference/chat/create#chat-create-service_tier

**Describe your solution**

- Added `service_tier` to the chat completion request and response
- Added consts for the possible `service_tier` values, based on the [documentation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-service_tier)
  - The `priority` value is only available to enterprise customers and isn't in the API Reference. It is documented here: https://openai.com/api-priority-processing/

**Tests**

- Manually tested calling the chat completion endpoint with the `service_tier` to `flex`.
- Manually regression tested calling the endpoint without `service_tier` set.

**Additional Context**

The `service_tier` property is needed to use flex and priority processing: 
- https://platform.openai.com/docs/guides/flex-processing
- https://openai.com/api-priority-processing/
