### PR TITLE
fix: properly unmarshal JSON schema in ChatCompletionResponseFormatJSONSchema.schema

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -214,11 +214,15 @@ type ChatCompletionResponseFormat struct {
 	JSONSchema *ChatCompletionResponseFormatJSONSchema `json:"json_schema,omitempty"`
 }
 
+type JSONSchema interface {
+	json.Marshaler
+	json.Unmarshaler
+}
 type ChatCompletionResponseFormatJSONSchema struct {
-	Name        string         `json:"name"`
-	Description string         `json:"description,omitempty"`
-	Schema      json.Marshaler `json:"schema"`
-	Strict      bool           `json:"strict"`
+	Name        string     `json:"name"`
+	Description string     `json:"description,omitempty"`
+	Schema      JSONSchema `json:"schema"`
+	Strict      bool       `json:"strict"`
 }
 
 // ChatCompletionRequest represents a request structure for chat completion API.

--- a/jsonschema/json.go
+++ b/jsonschema/json.go
@@ -62,6 +62,16 @@ func (d *Definition) MarshalJSON() ([]byte, error) {
 	})
 }
 
+func (d *Definition) UnmarshalJSON(data []byte) error {
+	type Alias Definition
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(d),
+	}
+	return json.Unmarshal(data, &aux)
+}
+
 func (d *Definition) Unmarshal(content string, v any) error {
 	return VerifySchemaAndUnmarshal(*d, []byte(content), v)
 }


### PR DESCRIPTION
When handling the response format for ChatCompletionResponseFormatJSONSchema, the field
response_format.json_schema.schema fails to unmarshal properly

Issue: #1027
