### PR TITLE
Support $ref and $defs in JSON Schema

### DIFF
--- a/jsonschema/json_test.go
+++ b/jsonschema/json_test.go
@@ -183,6 +183,17 @@ func TestDefinition_MarshalJSON(t *testing.T) {
 }
 
 func TestStructToSchema(t *testing.T) {
+	type Tweet struct {
+		Text string `json:"text"`
+	}
+
+	type Person struct {
+		Name    string   `json:"name,omitempty"`
+		Age     int      `json:"age,omitempty"`
+		Friends []Person `json:"friends,omitempty"`
+		Tweets  []Tweet  `json:"tweets,omitempty"`
+	}
+
 	tests := []struct {
 		name string
 		in   any
@@ -375,6 +386,65 @@ func TestStructToSchema(t *testing.T) {
 				},
 				"additionalProperties":false
 			}`,
+		},
+		{
+			name: "Test with $ref and $defs",
+			in: struct {
+				Person Person  `json:"person"`
+				Tweets []Tweet `json:"tweets"`
+			}{},
+			want: `{
+  "type" : "object",
+  "properties" : {
+    "person" : {
+      "$ref" : "#/$defs/Person"
+    },
+    "tweets" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/$defs/Tweet"
+      }
+    }
+  },
+  "required" : [ "person", "tweets" ],
+  "additionalProperties" : false,
+  "$defs" : {
+    "Person" : {
+      "type" : "object",
+      "properties" : {
+        "age" : {
+          "type" : "integer"
+        },
+        "friends" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/$defs/Person"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "tweets" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/$defs/Tweet"
+          }
+        }
+      },
+      "additionalProperties" : false
+    },
+    "Tweet" : {
+      "type" : "object",
+      "properties" : {
+        "text" : {
+          "type" : "string"
+        }
+      },
+      "required" : [ "text" ],
+      "additionalProperties" : false
+    }
+  }
+}`,
 		},
 	}
 

--- a/jsonschema/validate.go
+++ b/jsonschema/validate.go
@@ -5,26 +5,68 @@ import (
 	"errors"
 )
 
+func CollectDefs(def Definition) map[string]Definition {
+	result := make(map[string]Definition)
+	collectDefsRecursive(def, result, "#")
+	return result
+}
+
+func collectDefsRecursive(def Definition, result map[string]Definition, prefix string) {
+	for k, v := range def.Defs {
+		path := prefix + "/$defs/" + k
+		result[path] = v
+		collectDefsRecursive(v, result, path) // 嵌套
+	}
+	for k, sub := range def.Properties {
+		collectDefsRecursive(sub, result, prefix+"/properties/"+k)
+	}
+	if def.Items != nil {
+		collectDefsRecursive(*def.Items, result, prefix)
+	}
+}
+
 func VerifySchemaAndUnmarshal(schema Definition, content []byte, v any) error {
 	var data any
 	err := json.Unmarshal(content, &data)
 	if err != nil {
 		return err
 	}
-	if !Validate(schema, data) {
+	if !Validate(schema, data, WithDefs(CollectDefs(schema))) {
 		return errors.New("data validation failed against the provided schema")
 	}
 	return json.Unmarshal(content, &v)
 }
 
-func Validate(schema Definition, data any) bool {
+type validateArgs struct {
+	Defs map[string]Definition `json:"$defs,omitempty"` // 可选字段
+}
+
+type ValidateOption func(*validateArgs)
+
+func WithDefs(defs map[string]Definition) ValidateOption {
+	return func(option *validateArgs) {
+		option.Defs = defs
+	}
+}
+
+func Validate(schema Definition, data any, opts ...ValidateOption) bool {
+	args := validateArgs{}
+	for _, opt := range opts {
+		opt(&args)
+	}
+	if len(opts) == 0 {
+		args.Defs = CollectDefs(schema)
+	}
 	switch schema.Type {
 	case Object:
-		return validateObject(schema, data)
+		return validateObject(schema, data, args.Defs)
 	case Array:
-		return validateArray(schema, data)
+		return validateArray(schema, data, args.Defs)
 	case String:
-		_, ok := data.(string)
+		v, ok := data.(string)
+		if ok && len(schema.Enum) > 0 {
+			return contains(schema.Enum, v)
+		}
 		return ok
 	case Number: // float64 and int
 		_, ok := data.(float64)
@@ -45,11 +87,16 @@ func Validate(schema Definition, data any) bool {
 	case Null:
 		return data == nil
 	default:
+		if schema.Ref != "" && args.Defs != nil {
+			if v, ok := args.Defs[schema.Ref]; ok {
+				return Validate(v, data, WithDefs(args.Defs))
+			}
+		}
 		return false
 	}
 }
 
-func validateObject(schema Definition, data any) bool {
+func validateObject(schema Definition, data any, defs map[string]Definition) bool {
 	dataMap, ok := data.(map[string]any)
 	if !ok {
 		return false
@@ -61,7 +108,7 @@ func validateObject(schema Definition, data any) bool {
 	}
 	for key, valueSchema := range schema.Properties {
 		value, exists := dataMap[key]
-		if exists && !Validate(valueSchema, value) {
+		if exists && !Validate(valueSchema, value, WithDefs(defs)) {
 			return false
 		} else if !exists && contains(schema.Required, key) {
 			return false
@@ -70,13 +117,13 @@ func validateObject(schema Definition, data any) bool {
 	return true
 }
 
-func validateArray(schema Definition, data any) bool {
+func validateArray(schema Definition, data any, defs map[string]Definition) bool {
 	dataArray, ok := data.([]any)
 	if !ok {
 		return false
 	}
 	for _, item := range dataArray {
-		if !Validate(*schema.Items, item) {
+		if !Validate(*schema.Items, item, WithDefs(defs)) {
 			return false
 		}
 	}

--- a/jsonschema/validate.go
+++ b/jsonschema/validate.go
@@ -15,7 +15,7 @@ func collectDefsRecursive(def Definition, result map[string]Definition, prefix s
 	for k, v := range def.Defs {
 		path := prefix + "/$defs/" + k
 		result[path] = v
-		collectDefsRecursive(v, result, path) // 嵌套
+		collectDefsRecursive(v, result, path)
 	}
 	for k, sub := range def.Properties {
 		collectDefsRecursive(sub, result, prefix+"/properties/"+k)
@@ -38,7 +38,7 @@ func VerifySchemaAndUnmarshal(schema Definition, content []byte, v any) error {
 }
 
 type validateArgs struct {
-	Defs map[string]Definition `json:"$defs,omitempty"` // 可选字段
+	Defs map[string]Definition
 }
 
 type ValidateOption func(*validateArgs)


### PR DESCRIPTION
This PR implements $ref and $defs support in the JSON Schema validator.
Key features include:
* Resolves $ref references recursively.
* Supports nested $defs and path resolution.