### PR TITLE
Improve unit test coverage

### DIFF
--- a/image_test.go
+++ b/image_test.go
@@ -165,10 +165,13 @@ func (testNamedReader) Name() string { return "named.txt" }
 func TestWrapReader(t *testing.T) {
 	r := bytes.NewBufferString("data")
 	wrapped := WrapReader(r, "file.png", "image/png")
-	f := wrapped.(interface {
+	f, ok := wrapped.(interface {
 		Name() string
 		ContentType() string
 	})
+	if !ok {
+		t.Fatal("wrapped reader missing Name or ContentType")
+	}
 	if f.Name() != "file.png" {
 		t.Fatalf("expected name file.png, got %s", f.Name())
 	}
@@ -179,10 +182,13 @@ func TestWrapReader(t *testing.T) {
 	// test name from underlying reader
 	nr := testNamedReader{Reader: bytes.NewBufferString("d")}
 	wrapped = WrapReader(nr, "", "text/plain")
-	f = wrapped.(interface {
+	f, ok = wrapped.(interface {
 		Name() string
 		ContentType() string
 	})
+	if !ok {
+		t.Fatal("wrapped named reader missing Name or ContentType")
+	}
 	if f.Name() != "named.txt" {
 		t.Fatalf("expected name named.txt, got %s", f.Name())
 	}
@@ -192,7 +198,10 @@ func TestWrapReader(t *testing.T) {
 
 	// no name provided
 	wrapped = WrapReader(bytes.NewBuffer(nil), "", "")
-	f2 := wrapped.(interface{ Name() string })
+	f2, ok := wrapped.(interface{ Name() string })
+	if !ok {
+		t.Fatal("wrapped anonymous reader missing Name")
+	}
 	if f2.Name() != "" {
 		t.Fatalf("expected empty name, got %s", f2.Name())
 	}

--- a/image_test.go
+++ b/image_test.go
@@ -4,6 +4,7 @@ import (
 	utils "github.com/sashabaranov/go-openai/internal"
 	"github.com/sashabaranov/go-openai/internal/test/checks"
 
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -155,4 +156,44 @@ func TestVariImageFormBuilderFailures(t *testing.T) {
 	}
 	_, err = client.CreateVariImage(ctx, req)
 	checks.ErrorIs(t, err, mockFailedErr, "CreateImage should return error if form builder fails")
+}
+
+type testNamedReader struct{ io.Reader }
+
+func (testNamedReader) Name() string { return "named.txt" }
+
+func TestWrapReader(t *testing.T) {
+	r := bytes.NewBufferString("data")
+	wrapped := WrapReader(r, "file.png", "image/png")
+	f := wrapped.(interface {
+		Name() string
+		ContentType() string
+	})
+	if f.Name() != "file.png" {
+		t.Fatalf("expected name file.png, got %s", f.Name())
+	}
+	if f.ContentType() != "image/png" {
+		t.Fatalf("expected content type image/png, got %s", f.ContentType())
+	}
+
+	// test name from underlying reader
+	nr := testNamedReader{Reader: bytes.NewBufferString("d")}
+	wrapped = WrapReader(nr, "", "text/plain")
+	f = wrapped.(interface {
+		Name() string
+		ContentType() string
+	})
+	if f.Name() != "named.txt" {
+		t.Fatalf("expected name named.txt, got %s", f.Name())
+	}
+	if f.ContentType() != "text/plain" {
+		t.Fatalf("expected content type text/plain, got %s", f.ContentType())
+	}
+
+	// no name provided
+	wrapped = WrapReader(bytes.NewBuffer(nil), "", "")
+	f2 := wrapped.(interface{ Name() string })
+	if f2.Name() != "" {
+		t.Fatalf("expected empty name, got %s", f2.Name())
+	}
 }

--- a/internal/error_accumulator_test.go
+++ b/internal/error_accumulator_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	openai "github.com/sashabaranov/go-openai/internal"
+	"github.com/sashabaranov/go-openai/internal/test"
 	"github.com/sashabaranov/go-openai/internal/test/checks"
 )
 
@@ -29,4 +30,10 @@ func TestDefaultErrorAccumulator_EmptyBuffer(t *testing.T) {
 	if len(ea.Bytes()) != 0 {
 		t.Fatal("Buffer should be empty initially")
 	}
+}
+
+func TestDefaultErrorAccumulator_WriteError(t *testing.T) {
+	ea := &openai.DefaultErrorAccumulator{Buffer: &test.FailingErrorBuffer{}}
+	err := ea.Write([]byte("fail"))
+	checks.ErrorIs(t, err, test.ErrTestErrorAccumulatorWriteFailed, "Write should propagate buffer errors")
 }

--- a/internal/form_builder_test.go
+++ b/internal/form_builder_test.go
@@ -161,3 +161,17 @@ func TestWriteField(t *testing.T) {
 		checks.NoError(t, err, "should write field without error")
 	})
 }
+
+func TestCreateFormFile(t *testing.T) {
+	buf := &bytes.Buffer{}
+	builder := NewFormBuilder(buf)
+
+	err := builder.createFormFile("file", bytes.NewBufferString("data"), "")
+	if err == nil {
+		t.Fatal("expected error for empty filename")
+	}
+
+	builder = NewFormBuilder(&failingWriter{})
+	err = builder.createFormFile("file", bytes.NewBufferString("data"), "name")
+	checks.ErrorIs(t, err, errMockFailingWriterError, "should propagate writer error")
+}

--- a/internal/request_builder_test.go
+++ b/internal/request_builder_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"reflect"
 	"testing"
@@ -57,5 +58,31 @@ func TestRequestBuilderReturnsRequestWhenRequestOfArgsIsNil(t *testing.T) {
 	got, _ := b.Build(ctx, method, url, nil, nil)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Build() got = %v, want %v", got, want)
+	}
+}
+
+func TestRequestBuilderWithReaderBodyAndHeader(t *testing.T) {
+	b := NewRequestBuilder()
+	ctx := context.Background()
+	method := http.MethodPost
+	url := "/reader"
+	bodyContent := "hello"
+	body := bytes.NewBufferString(bodyContent)
+	header := http.Header{"X-Test": []string{"val"}}
+
+	req, err := b.Build(ctx, method, url, body, header)
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	gotBody, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("cannot read body: %v", err)
+	}
+	if string(gotBody) != bodyContent {
+		t.Fatalf("expected body %q, got %q", bodyContent, string(gotBody))
+	}
+	if req.Header.Get("X-Test") != "val" {
+		t.Fatalf("expected header set to val, got %q", req.Header.Get("X-Test"))
 	}
 }


### PR DESCRIPTION
## Summary
- increase error accumulator test coverage
- add form builder createFormFile tests
- validate RequestBuilder with reader body and header
- test WrapReader helper

## Testing
- `go test ./... -coverprofile=coverage.out`

------
https://chatgpt.com/codex/tasks/task_e_686f9af573a0832597ccc164b5cb56c2