### PR TITLE
Add GuidedChoice to ChatCompletionRequest

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -248,7 +248,7 @@ func (r *ChatCompletionResponseFormatJSONSchema) UnmarshalJSON(data []byte) erro
 	return nil
 }
 
-// NonOpenAIExtensions contains non-standard OpenAI API extensions
+// NonOpenAIExtensions contains non-standard OpenAI API extensions.
 type NonOpenAIExtensions struct {
 	// GuidedChoice restricts output to a set of predefined choices.
 	GuidedChoice []string `json:"guided_choice,omitempty"`

--- a/chat.go
+++ b/chat.go
@@ -248,7 +248,7 @@ func (r *ChatCompletionResponseFormatJSONSchema) UnmarshalJSON(data []byte) erro
 	return nil
 }
 
-// ChatCompletionRequestExtensions contains non-standard OpenAI API extensions.
+// ChatCompletionRequestExtensions contains third-party OpenAI API extensions (e.g., vendor-specific implementations like vLLM).
 type ChatCompletionRequestExtensions struct {
 	// GuidedChoice is a vLLM-specific extension that restricts the model's output
 	// to one of the predefined string choices provided in this field. This feature

--- a/chat.go
+++ b/chat.go
@@ -248,6 +248,12 @@ func (r *ChatCompletionResponseFormatJSONSchema) UnmarshalJSON(data []byte) erro
 	return nil
 }
 
+// NonOpenAIExtensions contains non-standard OpenAI API extensions
+type NonOpenAIExtensions struct {
+	// GuidedChoice restricts output to a set of predefined choices.
+	GuidedChoice []string `json:"guided_choice,omitempty"`
+}
+
 // ChatCompletionRequest represents a request structure for chat completion API.
 type ChatCompletionRequest struct {
 	Model    string                  `json:"model"`
@@ -309,8 +315,8 @@ type ChatCompletionRequest struct {
 	ChatTemplateKwargs map[string]any `json:"chat_template_kwargs,omitempty"`
 	// Specifies the latency tier to use for processing the request.
 	ServiceTier ServiceTier `json:"service_tier,omitempty"`
-	// GuidedChoice restricts output to a set of predefined choices.
-	GuidedChoice []string `json:"guided_choice,omitempty"`
+	// Embedded struct for non-OpenAI extensions
+	NonOpenAIExtensions `json:",inline"`
 }
 
 type StreamOptions struct {

--- a/chat.go
+++ b/chat.go
@@ -250,7 +250,11 @@ func (r *ChatCompletionResponseFormatJSONSchema) UnmarshalJSON(data []byte) erro
 
 // ChatCompletionRequestExtensions contains non-standard OpenAI API extensions.
 type ChatCompletionRequestExtensions struct {
-	// GuidedChoice restricts output to a set of predefined choices.
+	// GuidedChoice is a vLLM-specific extension that restricts the model's output
+	// to one of the predefined string choices provided in this field. This feature
+	// is used to constrain the model's responses to a controlled set of options,
+	// ensuring predictable and consistent outputs in scenarios where specific
+	// choices are required.
 	GuidedChoice []string `json:"guided_choice,omitempty"`
 }
 

--- a/chat.go
+++ b/chat.go
@@ -248,8 +248,8 @@ func (r *ChatCompletionResponseFormatJSONSchema) UnmarshalJSON(data []byte) erro
 	return nil
 }
 
-// NonOpenAIExtensions contains non-standard OpenAI API extensions.
-type NonOpenAIExtensions struct {
+// ChatCompletionRequestExtensions contains non-standard OpenAI API extensions.
+type ChatCompletionRequestExtensions struct {
 	// GuidedChoice restricts output to a set of predefined choices.
 	GuidedChoice []string `json:"guided_choice,omitempty"`
 }
@@ -316,7 +316,7 @@ type ChatCompletionRequest struct {
 	// Specifies the latency tier to use for processing the request.
 	ServiceTier ServiceTier `json:"service_tier,omitempty"`
 	// Embedded struct for non-OpenAI extensions
-	NonOpenAIExtensions `json:",inline"`
+	ChatCompletionRequestExtensions
 }
 
 type StreamOptions struct {

--- a/chat.go
+++ b/chat.go
@@ -309,6 +309,8 @@ type ChatCompletionRequest struct {
 	ChatTemplateKwargs map[string]any `json:"chat_template_kwargs,omitempty"`
 	// Specifies the latency tier to use for processing the request.
 	ServiceTier ServiceTier `json:"service_tier,omitempty"`
+	// GuidedChoice restricts output to a set of predefined choices.
+	GuidedChoice []string `json:"guided_choice,omitempty"`
 }
 
 type StreamOptions struct {


### PR DESCRIPTION
**Describe the change**
Adds guided_choice param support to chat completions

**Provide OpenAI documentation link**
[Structured output vLLM support](https://docs.vllm.ai/en/latest/features/structured_outputs.html#online-serving-openai-api)

```
curl --request post \
  --url http://localhost:8000/v1/chat/completions \
  --header 'Content-Type: application/json' \
  --data '{
    "model": "llama3-3b",
    "messages": [
        {
            "role": "user",
            "content": "Classify this sentiment: vLLM is great!"
        }
    ],
    "guided_choice": [
        "negative",
        "positive"
    ]
}'
```
