### PR TITLE
Increase test coverage

### DIFF
--- a/internal/form_builder_test.go
+++ b/internal/form_builder_test.go
@@ -8,6 +8,7 @@ import (
 
 	"bytes"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -174,4 +175,16 @@ func TestCreateFormFile(t *testing.T) {
 	builder = NewFormBuilder(&failingWriter{})
 	err = builder.createFormFile("file", bytes.NewBufferString("data"), "name")
 	checks.ErrorIs(t, err, errMockFailingWriterError, "should propagate writer error")
+}
+
+func TestCreateFormFileSuccess(t *testing.T) {
+	buf := &bytes.Buffer{}
+	builder := NewFormBuilder(buf)
+
+	err := builder.createFormFile("file", bytes.NewBufferString("data"), "foo.txt")
+	checks.NoError(t, err, "createFormFile should succeed")
+
+	if !strings.Contains(buf.String(), "filename=\"foo.txt\"") {
+		t.Fatalf("expected filename header, got %q", buf.String())
+	}
 }

--- a/internal/request_builder_test.go
+++ b/internal/request_builder_test.go
@@ -86,3 +86,11 @@ func TestRequestBuilderWithReaderBodyAndHeader(t *testing.T) {
 		t.Fatalf("expected header set to val, got %q", req.Header.Get("X-Test"))
 	}
 }
+
+func TestRequestBuilderInvalidURL(t *testing.T) {
+	b := NewRequestBuilder()
+	_, err := b.Build(context.Background(), http.MethodGet, ":", nil, nil)
+	if err == nil {
+		t.Fatal("expected error for invalid URL")
+	}
+}


### PR DESCRIPTION
## Summary
- add success case to form builder tests
- ensure request builder handles invalid URLs

## Testing
- `go test ./... -coverprofile=coverage.out`

------
https://chatgpt.com/codex/tasks/task_e_6870f366accc832585223d9f49b216bf