### PR TITLE
Increase test coverage

### DIFF
--- a/examples/chatbot/main_test.go
+++ b/examples/chatbot/main_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+type rewriteTransport struct {
+	host string
+	rt   http.RoundTripper
+}
+
+func (t rewriteTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.URL.Scheme = "http"
+	r.URL.Host = t.host
+	return t.rt.RoundTrip(r)
+}
+
+func setup(t *testing.T, path, resp string) (*httptest.Server, func()) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == path {
+			w.Header().Set("Content-Type", "application/json")
+			if _, err := io.WriteString(w, resp); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	orig := http.DefaultTransport
+	http.DefaultTransport = rewriteTransport{host: strings.TrimPrefix(server.URL, "http://"), rt: orig}
+	return server, func() { http.DefaultTransport = orig; server.Close() }
+}
+
+func TestMainExample(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test")
+	_, cleanup := setup(t, "/v1/chat/completions", `{"choices":[{"message":{"content":"hi"}}]}`)
+	defer cleanup()
+
+	r, w, _ := os.Pipe()
+	if _, err := w.Write([]byte("hello\n")); err != nil {
+		t.Fatalf("write stdin: %v", err)
+	}
+	w.Close()
+	oldStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin; r.Close() }()
+
+	main()
+}

--- a/examples/completion-with-tool/main_test.go
+++ b/examples/completion-with-tool/main_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type rewriteTransport struct {
+	host string
+	rt   http.RoundTripper
+}
+
+func (t rewriteTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.URL.Scheme = "http"
+	r.URL.Host = t.host
+	return t.rt.RoundTrip(r)
+}
+
+func setupToolServer(t *testing.T) (*httptest.Server, func()) {
+	t.Helper()
+	count := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		var err error
+		if count == 0 {
+			_, err = io.WriteString(w,
+				`{"choices":[{"message":{"tool_calls":[{"id":"1","function":{"name":"get_current_weather","arguments":"{}"}}]}}]}`)
+		} else {
+			_, err = io.WriteString(w, `{"choices":[{"message":{"content":"done"}}]}`)
+		}
+		if err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		count++
+	}))
+	orig := http.DefaultTransport
+	http.DefaultTransport = rewriteTransport{host: strings.TrimPrefix(server.URL, "http://"), rt: orig}
+	return server, func() { http.DefaultTransport = orig; server.Close() }
+}
+
+func TestMainExample(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test")
+	_, cleanup := setupToolServer(t)
+	defer cleanup()
+	main()
+}

--- a/examples/completion/main_test.go
+++ b/examples/completion/main_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type rewriteTransport struct {
+	host string
+	rt   http.RoundTripper
+}
+
+func (t rewriteTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.URL.Scheme = "http"
+	r.URL.Host = t.host
+	return t.rt.RoundTrip(r)
+}
+
+func setup(t *testing.T, path, resp string) (*httptest.Server, func()) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == path {
+			w.Header().Set("Content-Type", "application/json")
+			if _, err := io.WriteString(w, resp); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	orig := http.DefaultTransport
+	http.DefaultTransport = rewriteTransport{host: strings.TrimPrefix(server.URL, "http://"), rt: orig}
+	return server, func() { http.DefaultTransport = orig; server.Close() }
+}
+
+func TestMainExample(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test")
+	_, cleanup := setup(t, "/v1/completions", `{"choices":[{"text":"hi"}]}`)
+	defer cleanup()
+	main()
+}

--- a/examples/images/main_test.go
+++ b/examples/images/main_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type rewriteTransport struct {
+	host string
+	rt   http.RoundTripper
+}
+
+func (t rewriteTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.URL.Scheme = "http"
+	r.URL.Host = t.host
+	return t.rt.RoundTrip(r)
+}
+
+func setup(t *testing.T, path, resp string) (*httptest.Server, func()) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == path {
+			w.Header().Set("Content-Type", "application/json")
+			if _, err := io.WriteString(w, resp); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	orig := http.DefaultTransport
+	http.DefaultTransport = rewriteTransport{host: strings.TrimPrefix(server.URL, "http://"), rt: orig}
+	return server, func() { http.DefaultTransport = orig; server.Close() }
+}
+
+func TestMainExample(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test")
+	_, cleanup := setup(t, "/v1/images/generations", `{"data":[{"url":"example"}]}`)
+	defer cleanup()
+	main()
+}

--- a/examples/voice-to-text/main_test.go
+++ b/examples/voice-to-text/main_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type rewriteTransport struct {
+	host string
+	rt   http.RoundTripper
+}
+
+func (t rewriteTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.URL.Scheme = "http"
+	r.URL.Host = t.host
+	return t.rt.RoundTrip(r)
+}
+
+func setup(t *testing.T, path, resp string) (*httptest.Server, func()) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == path {
+			w.Header().Set("Content-Type", "application/json")
+			if _, err := io.WriteString(w, resp); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	orig := http.DefaultTransport
+	http.DefaultTransport = rewriteTransport{host: strings.TrimPrefix(server.URL, "http://"), rt: orig}
+	return server, func() { http.DefaultTransport = orig; server.Close() }
+}
+
+func TestMainExample(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test")
+	_, cleanup := setup(t, "/v1/audio/transcriptions", `{"text":"ok"}`)
+	defer cleanup()
+	path := filepath.Join(t.TempDir(), "f.mp3")
+	if err := os.WriteFile(path, []byte("test"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	oldArgs := os.Args
+	os.Args = []string{"cmd", path}
+	defer func() { os.Args = oldArgs }()
+	main()
+}

--- a/internal/test/checks/checks_test.go
+++ b/internal/test/checks/checks_test.go
@@ -1,0 +1,25 @@
+package checks_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	checks "github.com/sashabaranov/go-openai/internal/test/checks"
+)
+
+func TestNoError(t *testing.T) {
+	checks.NoError(t, nil)
+	checks.NoErrorF(t, nil)
+	checks.HasError(t, errors.New("err"))
+}
+
+func TestErrorComparisons(t *testing.T) {
+	target := errors.New("target")
+	wrapped := fmt.Errorf("wrap: %w", target)
+
+	checks.ErrorIs(t, wrapped, target)
+	checks.ErrorIsF(t, wrapped, target, "%v")
+	checks.ErrorIsNot(t, errors.New("other"), target)
+	checks.ErrorIsNotf(t, errors.New("other"), target, "%v")
+}

--- a/internal/test/server_test.go
+++ b/internal/test/server_test.go
@@ -1,0 +1,62 @@
+package test_test
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	testpkg "github.com/sashabaranov/go-openai/internal/test"
+)
+
+func TestOpenAITestServerAuthAndHandler(t *testing.T) {
+	ts := testpkg.NewTestServer()
+	ts.RegisterHandler("/v1/test", func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := io.WriteString(w, "ok"); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	})
+	srv := ts.OpenAITestServer()
+	srv.Start()
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/v1/test", nil)
+	req.Header.Set("Authorization", "Bearer "+testpkg.GetTestToken())
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	body, _ := io.ReadAll(res.Body)
+	res.Body.Close()
+	if res.StatusCode != http.StatusOK || string(body) != "ok" {
+		t.Fatalf("unexpected response: %v %s", res.StatusCode, string(body))
+	}
+
+	req2, _ := http.NewRequest("GET", srv.URL+"/v1/test", nil)
+	res2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		t.Fatalf("request2 failed: %v", err)
+	}
+	if res2.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected unauthorized, got %v", res2.StatusCode)
+	}
+}
+
+func TestOpenAITestServerWildcard(t *testing.T) {
+	ts := testpkg.NewTestServer()
+	ts.RegisterHandler("/v1/items/*", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv := ts.OpenAITestServer()
+	srv.Start()
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/v1/items/123", nil)
+	req.Header.Set("api-key", testpkg.GetTestToken())
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if res.StatusCode != http.StatusNoContent {
+		t.Fatalf("unexpected status: %v", res.StatusCode)
+	}
+}

--- a/jsonschema/unmarshal_method_test.go
+++ b/jsonschema/unmarshal_method_test.go
@@ -1,0 +1,33 @@
+package jsonschema_test
+
+import (
+	"testing"
+
+	"github.com/sashabaranov/go-openai/jsonschema"
+)
+
+func TestDefinition_Unmarshal(t *testing.T) {
+	schema := jsonschema.Definition{
+		Type: jsonschema.Object,
+		Properties: map[string]jsonschema.Definition{
+			"name": {Type: jsonschema.String},
+			"age":  {Type: jsonschema.Integer},
+		},
+		Required: []string{"name", "age"},
+	}
+	var out struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}
+	err := schema.Unmarshal(`{"name":"Alice","age":25}`, &out)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if out.Name != "Alice" || out.Age != 25 {
+		t.Fatalf("unexpected result %+v", out)
+	}
+
+	if err2 := schema.Unmarshal(`{"name":"Bob"}`, &out); err2 == nil {
+		t.Fatalf("expected error for missing field")
+	}
+}


### PR DESCRIPTION
## Summary
- add helper tests for internal server and checks utils
- add example package tests to exercise CLI code paths
- exercise Definition.Unmarshal method
- fix golangci-lint errors

## Testing
- `golangci-lint run ./...`
- `go test ./... -coverprofile=coverage.out`
- `go tool cover -func=coverage.out | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_687100c017648325a05c726437a69c8a