### PR TITLE
Configure Codecov to ignore examples & test helpers

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  ignore:
+    - "examples/**"
+    - "internal/test/**"


### PR DESCRIPTION
## Summary
- add `.codecov.yml` with ignore patterns for `examples/**` and `internal/test/**`

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68710cf9ed748325aeb54b78898c29a4