### PR TITLE
Improve image.go test coverage to 100%

### DIFF
--- a/image_test.go
+++ b/image_test.go
@@ -40,122 +40,237 @@ func (fb *mockFormBuilder) FormDataContentType() string {
 }
 
 func TestImageFormBuilderFailures(t *testing.T) {
-	config := DefaultConfig("")
-	config.BaseURL = ""
-	client := NewClientWithConfig(config)
-
-	mockBuilder := &mockFormBuilder{}
-	client.createFormBuilder = func(io.Writer) utils.FormBuilder {
-		return mockBuilder
-	}
 	ctx := context.Background()
-
-	req := ImageEditRequest{
-		Mask: &os.File{},
-	}
-
 	mockFailedErr := fmt.Errorf("mock form builder fail")
-	mockBuilder.mockCreateFormFileReader = func(string, io.Reader, string) error {
-		return mockFailedErr
-	}
-	_, err := client.CreateEditImage(ctx, req)
-	checks.ErrorIs(t, err, mockFailedErr, "CreateImage should return error if form builder fails")
 
-	mockBuilder.mockCreateFormFileReader = func(name string, _ io.Reader, _ string) error {
-		if name == "mask" {
-			return mockFailedErr
+	newClient := func(fb *mockFormBuilder) *Client {
+		cfg := DefaultConfig("")
+		cfg.BaseURL = ""
+		c := NewClientWithConfig(cfg)
+		c.createFormBuilder = func(io.Writer) utils.FormBuilder { return fb }
+		return c
+	}
+
+	tests := []struct {
+		name  string
+		setup func(*mockFormBuilder)
+		req   ImageEditRequest
+	}{
+		{
+			name: "image",
+			setup: func(fb *mockFormBuilder) {
+				fb.mockCreateFormFileReader = func(string, io.Reader, string) error { return mockFailedErr }
+				fb.mockWriteField = func(string, string) error { return nil }
+				fb.mockClose = func() error { return nil }
+			},
+			req: ImageEditRequest{Image: bytes.NewBuffer(nil), Mask: bytes.NewBuffer(nil)},
+		},
+		{
+			name: "mask",
+			setup: func(fb *mockFormBuilder) {
+				fb.mockCreateFormFileReader = func(name string, _ io.Reader, _ string) error {
+					if name == "mask" {
+						return mockFailedErr
+					}
+					return nil
+				}
+				fb.mockWriteField = func(string, string) error { return nil }
+				fb.mockClose = func() error { return nil }
+			},
+			req: ImageEditRequest{Image: bytes.NewBuffer(nil), Mask: bytes.NewBuffer(nil)},
+		},
+		{
+			name: "prompt",
+			setup: func(fb *mockFormBuilder) {
+				fb.mockCreateFormFileReader = func(string, io.Reader, string) error { return nil }
+				fb.mockWriteField = func(field, _ string) error {
+					if field == "prompt" {
+						return mockFailedErr
+					}
+					return nil
+				}
+				fb.mockClose = func() error { return nil }
+			},
+			req: ImageEditRequest{Image: bytes.NewBuffer(nil), Mask: bytes.NewBuffer(nil)},
+		},
+		{
+			name: "n",
+			setup: func(fb *mockFormBuilder) {
+				fb.mockCreateFormFileReader = func(string, io.Reader, string) error { return nil }
+				fb.mockWriteField = func(field, _ string) error {
+					if field == "n" {
+						return mockFailedErr
+					}
+					return nil
+				}
+				fb.mockClose = func() error { return nil }
+			},
+			req: ImageEditRequest{Image: bytes.NewBuffer(nil), Mask: bytes.NewBuffer(nil)},
+		},
+		{
+			name: "size",
+			setup: func(fb *mockFormBuilder) {
+				fb.mockCreateFormFileReader = func(string, io.Reader, string) error { return nil }
+				fb.mockWriteField = func(field, _ string) error {
+					if field == "size" {
+						return mockFailedErr
+					}
+					return nil
+				}
+				fb.mockClose = func() error { return nil }
+			},
+			req: ImageEditRequest{Image: bytes.NewBuffer(nil), Mask: bytes.NewBuffer(nil)},
+		},
+		{
+			name: "response_format",
+			setup: func(fb *mockFormBuilder) {
+				fb.mockCreateFormFileReader = func(string, io.Reader, string) error { return nil }
+				fb.mockWriteField = func(field, _ string) error {
+					if field == "response_format" {
+						return mockFailedErr
+					}
+					return nil
+				}
+				fb.mockClose = func() error { return nil }
+			},
+			req: ImageEditRequest{Image: bytes.NewBuffer(nil), Mask: bytes.NewBuffer(nil)},
+		},
+		{
+			name: "close",
+			setup: func(fb *mockFormBuilder) {
+				fb.mockCreateFormFileReader = func(string, io.Reader, string) error { return nil }
+				fb.mockWriteField = func(string, string) error { return nil }
+				fb.mockClose = func() error { return mockFailedErr }
+			},
+			req: ImageEditRequest{Image: bytes.NewBuffer(nil), Mask: bytes.NewBuffer(nil)},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fb := &mockFormBuilder{}
+			tc.setup(fb)
+			client := newClient(fb)
+			_, err := client.CreateEditImage(ctx, tc.req)
+			checks.ErrorIs(t, err, mockFailedErr, "CreateEditImage should return error if form builder fails")
+		})
+	}
+
+	t.Run("new request", func(t *testing.T) {
+		fb := &mockFormBuilder{
+			mockCreateFormFileReader: func(string, io.Reader, string) error { return nil },
+			mockWriteField:           func(string, string) error { return nil },
+			mockClose:                func() error { return nil },
 		}
-		return nil
-	}
-	_, err = client.CreateEditImage(ctx, req)
-	checks.ErrorIs(t, err, mockFailedErr, "CreateImage should return error if form builder fails")
+		client := newClient(fb)
+		client.requestBuilder = &failingRequestBuilder{}
 
-	mockBuilder.mockCreateFormFile = func(string, *os.File) error {
-		return nil
-	}
-
-	var failForField string
-	mockBuilder.mockWriteField = func(fieldname, _ string) error {
-		if fieldname == failForField {
-			return mockFailedErr
-		}
-		return nil
-	}
-
-	failForField = "prompt"
-	_, err = client.CreateEditImage(ctx, req)
-	checks.ErrorIs(t, err, mockFailedErr, "CreateImage should return error if form builder fails")
-
-	failForField = "n"
-	_, err = client.CreateEditImage(ctx, req)
-	checks.ErrorIs(t, err, mockFailedErr, "CreateImage should return error if form builder fails")
-
-	failForField = "size"
-	_, err = client.CreateEditImage(ctx, req)
-	checks.ErrorIs(t, err, mockFailedErr, "CreateImage should return error if form builder fails")
-
-	failForField = "response_format"
-	_, err = client.CreateEditImage(ctx, req)
-	checks.ErrorIs(t, err, mockFailedErr, "CreateImage should return error if form builder fails")
-
-	failForField = ""
-	mockBuilder.mockClose = func() error {
-		return mockFailedErr
-	}
-	_, err = client.CreateEditImage(ctx, req)
-	checks.ErrorIs(t, err, mockFailedErr, "CreateImage should return error if form builder fails")
+		_, err := client.CreateEditImage(ctx, ImageEditRequest{Image: bytes.NewBuffer(nil), Mask: bytes.NewBuffer(nil)})
+		checks.ErrorIs(t, err, errTestRequestBuilderFailed, "CreateEditImage should return error if request builder fails")
+	})
 }
 
 func TestVariImageFormBuilderFailures(t *testing.T) {
-	config := DefaultConfig("")
-	config.BaseURL = ""
-	client := NewClientWithConfig(config)
-
-	mockBuilder := &mockFormBuilder{}
-	client.createFormBuilder = func(io.Writer) utils.FormBuilder {
-		return mockBuilder
-	}
 	ctx := context.Background()
-
-	req := ImageVariRequest{}
-
 	mockFailedErr := fmt.Errorf("mock form builder fail")
-	mockBuilder.mockCreateFormFileReader = func(string, io.Reader, string) error {
-		return mockFailedErr
-	}
-	_, err := client.CreateVariImage(ctx, req)
-	checks.ErrorIs(t, err, mockFailedErr, "CreateVariImage should return error if form builder fails")
 
-	mockBuilder.mockCreateFormFileReader = func(string, io.Reader, string) error {
-		return nil
+	newClient := func(fb *mockFormBuilder) *Client {
+		cfg := DefaultConfig("")
+		cfg.BaseURL = ""
+		c := NewClientWithConfig(cfg)
+		c.createFormBuilder = func(io.Writer) utils.FormBuilder { return fb }
+		return c
 	}
 
-	var failForField string
-	mockBuilder.mockWriteField = func(fieldname, _ string) error {
-		if fieldname == failForField {
-			return mockFailedErr
+	tests := []struct {
+		name  string
+		setup func(*mockFormBuilder)
+		req   ImageVariRequest
+	}{
+		{
+			name: "image",
+			setup: func(fb *mockFormBuilder) {
+				fb.mockCreateFormFileReader = func(string, io.Reader, string) error { return mockFailedErr }
+				fb.mockWriteField = func(string, string) error { return nil }
+				fb.mockClose = func() error { return nil }
+			},
+			req: ImageVariRequest{Image: bytes.NewBuffer(nil)},
+		},
+		{
+			name: "n",
+			setup: func(fb *mockFormBuilder) {
+				fb.mockCreateFormFileReader = func(string, io.Reader, string) error { return nil }
+				fb.mockWriteField = func(field string, _ string) error {
+					if field == "n" {
+						return mockFailedErr
+					}
+					return nil
+				}
+				fb.mockClose = func() error { return nil }
+			},
+			req: ImageVariRequest{Image: bytes.NewBuffer(nil)},
+		},
+		{
+			name: "size",
+			setup: func(fb *mockFormBuilder) {
+				fb.mockCreateFormFileReader = func(string, io.Reader, string) error { return nil }
+				fb.mockWriteField = func(field string, _ string) error {
+					if field == "size" {
+						return mockFailedErr
+					}
+					return nil
+				}
+				fb.mockClose = func() error { return nil }
+			},
+			req: ImageVariRequest{Image: bytes.NewBuffer(nil)},
+		},
+		{
+			name: "response_format",
+			setup: func(fb *mockFormBuilder) {
+				fb.mockCreateFormFileReader = func(string, io.Reader, string) error { return nil }
+				fb.mockWriteField = func(field string, _ string) error {
+					if field == "response_format" {
+						return mockFailedErr
+					}
+					return nil
+				}
+				fb.mockClose = func() error { return nil }
+			},
+			req: ImageVariRequest{Image: bytes.NewBuffer(nil)},
+		},
+		{
+			name: "close",
+			setup: func(fb *mockFormBuilder) {
+				fb.mockCreateFormFileReader = func(string, io.Reader, string) error { return nil }
+				fb.mockWriteField = func(string, string) error { return nil }
+				fb.mockClose = func() error { return mockFailedErr }
+			},
+			req: ImageVariRequest{Image: bytes.NewBuffer(nil)},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fb := &mockFormBuilder{}
+			tc.setup(fb)
+			client := newClient(fb)
+			_, err := client.CreateVariImage(ctx, tc.req)
+			checks.ErrorIs(t, err, mockFailedErr, "CreateVariImage should return error if form builder fails")
+		})
+	}
+
+	t.Run("new request", func(t *testing.T) {
+		fb := &mockFormBuilder{
+			mockCreateFormFileReader: func(string, io.Reader, string) error { return nil },
+			mockWriteField:           func(string, string) error { return nil },
+			mockClose:                func() error { return nil },
 		}
-		return nil
-	}
+		client := newClient(fb)
+		client.requestBuilder = &failingRequestBuilder{}
 
-	failForField = "n"
-	_, err = client.CreateVariImage(ctx, req)
-	checks.ErrorIs(t, err, mockFailedErr, "CreateVariImage should return error if form builder fails")
-
-	failForField = "size"
-	_, err = client.CreateVariImage(ctx, req)
-	checks.ErrorIs(t, err, mockFailedErr, "CreateVariImage should return error if form builder fails")
-
-	failForField = "response_format"
-	_, err = client.CreateVariImage(ctx, req)
-	checks.ErrorIs(t, err, mockFailedErr, "CreateVariImage should return error if form builder fails")
-
-	failForField = ""
-	mockBuilder.mockClose = func() error {
-		return mockFailedErr
-	}
-	_, err = client.CreateVariImage(ctx, req)
-	checks.ErrorIs(t, err, mockFailedErr, "CreateImage should return error if form builder fails")
+		_, err := client.CreateVariImage(ctx, ImageVariRequest{Image: bytes.NewBuffer(nil)})
+		checks.ErrorIs(t, err, errTestRequestBuilderFailed, "CreateVariImage should return error if request builder fails")
+	})
 }
 
 type testNamedReader struct{ io.Reader }


### PR DESCRIPTION
## Summary
- rewrite image tests
- exercise all error branches in `CreateEditImage` and `CreateVariImage`
- add failing request builder cases

## Testing
- `go test ./... -coverprofile=coverage.out`

------
https://chatgpt.com/codex/tasks/task_e_6871278401f883259b6baffa0e97a8a4