### PR TITLE
Enable Go 1.18 compatibility check

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
         go-version: '1.24'
     - name: Run vet
       run: |
-        go vet .
+        go vet -stdversion ./...
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v7
       with:


### PR DESCRIPTION
## Summary
- run `go vet` with the new stdversion analyzer across all packages

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6871338845048325bbe6cf1ed7d968fe