### PR TITLE
Increase jsonschema test coverage

### DIFF
--- a/jsonschema/containsref_test.go
+++ b/jsonschema/containsref_test.go
@@ -1,0 +1,34 @@
+package jsonschema
+
+import "testing"
+
+// TestContainsRef ensures containsRef recursively searches definitions and items.
+func TestContainsRef(t *testing.T) {
+	schema := Definition{
+		Type: Object,
+		Properties: map[string]Definition{
+			"person": {Ref: "#/$defs/Person"},
+		},
+		Defs: map[string]Definition{
+			"Person": {
+				Type: Object,
+				Properties: map[string]Definition{
+					"friends": {
+						Type:  Array,
+						Items: &Definition{Ref: "#/$defs/Person"},
+					},
+				},
+			},
+		},
+	}
+
+	if !containsRef(schema, "#/$defs/Person") {
+		t.Fatal("expected to find reference in root")
+	}
+	if !containsRef(schema.Defs["Person"], "#/$defs/Person") {
+		t.Fatal("expected to find self reference in defs")
+	}
+	if containsRef(schema, "#/$defs/Unknown") {
+		t.Fatal("unexpected reference found")
+	}
+}

--- a/jsonschema/json_errors_test.go
+++ b/jsonschema/json_errors_test.go
@@ -1,0 +1,27 @@
+package jsonschema_test
+
+import (
+	"testing"
+
+	"github.com/sashabaranov/go-openai/jsonschema"
+)
+
+// TestGenerateSchemaForType_ErrorPaths verifies error handling for unsupported types.
+func TestGenerateSchemaForType_ErrorPaths(t *testing.T) {
+	type anon struct{ Ch chan int }
+	tests := []struct {
+		name string
+		v    any
+	}{
+		{"slice", []chan int{}},
+		{"anon struct", anon{}},
+		{"pointer", (*chan int)(nil)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := jsonschema.GenerateSchemaForType(tt.v); err == nil {
+				t.Errorf("expected error for %s", tt.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for error branches in jsonschema.GenerateSchemaForType
- cover containsRef recursion logic

## Testing
- `go test ./jsonschema -cover`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68713954b31483259e4f1e24fc78d4cb