### PR TITLE
Fix missing json.Unmarshal error check

### DIFF
--- a/embeddings.go
+++ b/embeddings.go
@@ -268,8 +268,7 @@ func (c *Client) CreateEmbeddings(
 
 	// Deserialize JSON to map[string]any
 	var body map[string]any
-	err = json.Unmarshal(jsonData, &body)
-	if err != nil {
+	if err = json.Unmarshal(jsonData, &body); err != nil {
 		return
 	}
 

--- a/embeddings.go
+++ b/embeddings.go
@@ -268,7 +268,10 @@ func (c *Client) CreateEmbeddings(
 
 	// Deserialize JSON to map[string]any
 	var body map[string]any
-	_ = json.Unmarshal(jsonData, &body)
+	err = json.Unmarshal(jsonData, &body)
+	if err != nil {
+		return
+	}
 
 	req, err := c.newRequest(
 		ctx,

--- a/embeddings_test.go
+++ b/embeddings_test.go
@@ -15,6 +15,13 @@ import (
 	"github.com/sashabaranov/go-openai/internal/test/checks"
 )
 
+// badMarshaler produces invalid JSON when marshaled.
+type badMarshaler struct{}
+
+func (badMarshaler) MarshalJSON() ([]byte, error) {
+	return []byte("{"), nil
+}
+
 func TestEmbedding(t *testing.T) {
 	embeddedModels := []openai.EmbeddingModel{
 		openai.AdaSimilarity,
@@ -324,4 +331,22 @@ func TestDotProduct(t *testing.T) {
 	if !errors.Is(err, openai.ErrVectorLengthMismatch) {
 		t.Errorf("Expected Vector Length Mismatch Error, but got: %v", err)
 	}
+}
+
+// TestCreateEmbeddings_UnmarshalError verifies that an error is returned when
+// the JSON bytes produced by marshaling the request cannot be unmarshaled back
+// into a map.
+func TestCreateEmbeddings_UnmarshalError(t *testing.T) {
+	client, server, teardown := setupOpenAITestServer()
+	defer teardown()
+
+	server.RegisterHandler("/v1/embeddings", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"data":[]}`)
+	})
+
+	_, err := client.CreateEmbeddings(context.Background(), openai.EmbeddingRequest{
+		Input: badMarshaler{},
+	})
+	checks.HasError(t, err, "CreateEmbeddings should fail on unmarshal error")
 }


### PR DESCRIPTION
## Summary
- check error from `json.Unmarshal` when preparing extra request body
- test the unmarshal error is returned

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68715d61a164832584ed7f158df96435