### PR TITLE
Support Google VertexAI Gemini-specific parameters

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -311,8 +311,8 @@ type ChatCompletionRequest struct {
 	ServiceTier ServiceTier `json:"service_tier,omitempty"`
 	// Support Google VertexAI Gemini-specific parameters
 	// https://cloud.google.com/vertex-ai/generative-ai/docs/migrate/openai/overview#extra_body_features
-	ExtraBody   map[string]any `json:"extra_body,omitempty"`
-	ExtraPart   map[string]any `json:"extra_part,omitempty"`
+	ExtraBody map[string]any `json:"extra_body,omitempty"`
+	ExtraPart map[string]any `json:"extra_part,omitempty"`
 }
 
 type StreamOptions struct {


### PR DESCRIPTION
**Describe the change**
Support Google VertexAI Gemini-specific parameters. 

**Provide OpenAI documentation link**

https://cloud.google.com/vertex-ai/generative-ai/docs/migrate/openai/overview#gemini-specific_parameters

**Describe your solution**
Just add two fields to `ChatCompletionRequest` struct

**Tests**
I did not add any tests.

**Additional context**
nothing