### PR TITLE
Add Support for File Attachments in Chat Completion Messages

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -81,17 +81,25 @@ type ChatMessageImageURL struct {
 	Detail ImageURLDetail `json:"detail,omitempty"`
 }
 
+type ChatMessageFile struct {
+	FileID   string `json:"file_id,omitempty"`
+	FileName string `json:"file_name,omitempty"`
+	FileData string `json:"file_data,omitempty"`
+}
+
 type ChatMessagePartType string
 
 const (
 	ChatMessagePartTypeText     ChatMessagePartType = "text"
 	ChatMessagePartTypeImageURL ChatMessagePartType = "image_url"
+	ChatMessagePartTypeFile     ChatMessagePartType = "file"
 )
 
 type ChatMessagePart struct {
 	Type     ChatMessagePartType  `json:"type,omitempty"`
 	Text     string               `json:"text,omitempty"`
 	ImageURL *ChatMessageImageURL `json:"image_url,omitempty"`
+	File     *ChatMessageFile     `json:"file,omitempty"`
 }
 
 type ChatCompletionMessage struct {


### PR DESCRIPTION
https://platform.openai.com/docs/guides/pdf-files?api-mode=chat

### Summary
This PR extends the chat completion API to support file attachments as message parts, view the ChatMessagePartTypeFile type.

### Changes made:
* Added a new struct, `ChatMessageFile`, with fields `FileID`, `FileName`, and `FileData` to represent file attachments. (`chat.go`, [chat.goR84-R102](diffhunk://#diff-370ab673a241352de53b0935336bf24d154c95cf931c6d7906cd289140a71ae2R84-R102))
* Introduced a new constant, `ChatMessagePartTypeFile`, to represent the file type in `ChatMessagePartType`. (`chat.go`, [chat.goR84-R102](diffhunk://#diff-370ab673a241352de53b0935336bf24d154c95cf931c6d7906cd289140a71ae2R84-R102))
* Updated the `ChatMessagePart` struct to include a `File` field of type `*ChatMessageFile` for handling file-related data. (`chat.go`, [chat.goR84-R102](diffhunk://#diff-370ab673a241352de53b0935336bf24d154c95cf931c6d7906cd289140a71ae2R84-R102))