### PR TITLE
fix: handle SSE error events from providers like Groq

### DIFF
--- a/stream_reader_test.go
+++ b/stream_reader_test.go
@@ -81,7 +81,8 @@ func TestStreamReaderRecvRaw(t *testing.T) {
 func TestStreamReaderParsesErrorEvents(t *testing.T) {
 	// Test case simulating Groq's error event format
 	errorEvent := `event: error
-data: {"error":{"message":"Invalid tool_call: tool \"name_unknown\" does not exist.","type":"invalid_request_error","code":"invalid_tool_call"}}
+data: {"error":{"message":"Invalid tool_call: tool \"name_unknown\" does not exist.",` +
+		`"type":"invalid_request_error","code":"invalid_tool_call"}}
 
 `
 	stream := &streamReader[ChatCompletionStreamResponse]{
@@ -98,8 +99,8 @@ data: {"error":{"message":"Invalid tool_call: tool \"name_unknown\" does not exi
 	}
 
 	// Verify it's an APIError
-	apiErr, ok := err.(*APIError)
-	if !ok {
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
 		t.Fatalf("Expected APIError type but got %T: %v", err, err)
 	}
 
@@ -145,8 +146,8 @@ data: [DONE]
 	}
 
 	// Verify it's an APIError
-	apiErr, ok := err.(*APIError)
-	if !ok {
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
 		t.Fatalf("Expected APIError type but got %T: %v", err, err)
 	}
 
@@ -175,8 +176,8 @@ data: {"error":{"message":"Second error","type":"error_type_2"}}
 	if err1 == nil {
 		t.Fatal("Expected first error but got nil")
 	}
-	apiErr1, ok := err1.(*APIError)
-	if !ok {
+	var apiErr1 *APIError
+	if !errors.As(err1, &apiErr1) {
 		t.Fatalf("Expected APIError type but got %T: %v", err1, err1)
 	}
 	if apiErr1.Message != "First error" {
@@ -188,8 +189,8 @@ data: {"error":{"message":"Second error","type":"error_type_2"}}
 	if err2 == nil {
 		t.Fatal("Expected second error but got nil")
 	}
-	apiErr2, ok := err2.(*APIError)
-	if !ok {
+	var apiErr2 *APIError
+	if !errors.As(err2, &apiErr2) {
 		t.Fatalf("Expected APIError type but got %T: %v", err2, err2)
 	}
 	if apiErr2.Message != "Second error" {


### PR DESCRIPTION
This PR fixes SSE (Server-Sent Events) error parsing for providers that use explicit event types in their error responses, such as Groq.

Currently, when Groq sends error events with an "event: error" prefix, the library fails to parse them correctly, returning "unexpected end of JSON input" instead of the actual error details.

While OpenAI's official documentation doesn't explicitly document their SSE error format, this change maintains compatibility with OpenAI's implementation while adding support for the standard SSE format used by other providers.

Related: https://platform.openai.com/docs/api-reference/streaming

## Solution

  The solution modifies the SSE stream parser to:
  1. Extract only the JSON portion after "data: " when parsing error events
  2. Skip non-data lines (like "event: error") instead of accumulating them
  3. Reset the error accumulator after each error to prevent data corruption across multiple errors
  4. Maintain full backward compatibility with OpenAI's simpler error format

  The implementation handles both formats transparently without requiring configuration:
  - OpenAI format: data: {"error": {...}}
  - Groq/standard SSE format: event: error\ndata: {"error": {...}}

## Tests

Added three comprehensive test cases:
- TestStreamReaderParsesErrorEvents: Validates parsing of Groq's error event format
- TestStreamReaderHandlesErrorEventWithExtraData: Tests mixed content streams with errors
- TestStreamReaderResetsErrorAccumulator: Ensures error accumulator is properly reset

All existing tests continue to pass, maintaining backward compatibility.

## Additional context

This issue was discovered when using the library with Groq's API for tool calling. When the model makes invalid tool calls, Groq returns error events that the current implementation cannot parse.

Example error from Groq:

```
event: error
data: {"error":{"message":"Invalid tool_call: tool \"name_unknown\" does not exist.","type":"invalid_request_error","code":"invalid_tool_call"}}
```

The fix ensures these errors are properly surfaced to the application instead of being masked as EOF or parsing errors.