### PR TITLE
valiate reqeust to gpt-5 series as reasoning

### DIFF
--- a/reasoning_validator.go
+++ b/reasoning_validator.go
@@ -41,8 +41,9 @@ func (v *ReasoningValidator) Validate(request ChatCompletionRequest) error {
 	o1Series := strings.HasPrefix(request.Model, "o1")
 	o3Series := strings.HasPrefix(request.Model, "o3")
 	o4Series := strings.HasPrefix(request.Model, "o4")
+	gpt5Series := strings.HasPrefix(request.Model, "gpt-5")
 
-	if !o1Series && !o3Series && !o4Series {
+	if !o1Series && !o3Series && !o4Series && !gpt5Series {
 		return nil
 	}
 


### PR DESCRIPTION
<img width="1021" height="956" alt="image" src="https://github.com/user-attachments/assets/59233483-8d40-4362-b746-4fd129acfd34" />

valiate reqeust to gpt-5 series as reasoning to avoid these errors:
-  Unsupported parameter: 'logprobs' is not supported with this model.
-  Unsupported parameter: 'top_p' is not supported with this model.
- Unsupported value: 'temperature' does not support 0.7 with this model. Only the default (1) value is supported.
- ...