### PR TITLE
Add Verbosity parameter to Chat Completion Request

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -320,6 +320,10 @@ type ChatCompletionRequest struct {
 	ChatTemplateKwargs map[string]any `json:"chat_template_kwargs,omitempty"`
 	// Specifies the latency tier to use for processing the request.
 	ServiceTier ServiceTier `json:"service_tier,omitempty"`
+	// Verbosity determines how many output tokens are generated.
+	// Lowering the number of tokens reduces overall latency.
+	// It can be set to "low", "medium", or "high".
+	Verbosity string `json:"verbosity,omitempty"`
 	// Embedded struct for non-OpenAI extensions
 	ChatCompletionRequestExtensions
 }

--- a/chat.go
+++ b/chat.go
@@ -320,9 +320,11 @@ type ChatCompletionRequest struct {
 	ChatTemplateKwargs map[string]any `json:"chat_template_kwargs,omitempty"`
 	// Specifies the latency tier to use for processing the request.
 	ServiceTier ServiceTier `json:"service_tier,omitempty"`
-	// Verbosity determines how many output tokens are generated.
-	// Lowering the number of tokens reduces overall latency.
-	// It can be set to "low", "medium", or "high".
+	// Verbosity determines how many output tokens are generated. Lowering the number of
+	// tokens reduces overall latency. It can be set to "low", "medium", or "high".
+	// Note: This field is only confirmed to work with gpt-5, gpt-5-mini and gpt-5-nano.
+	// Also, it is not in the API reference of chat completion at the time of writing,
+	// though it is supported by the API.
 	Verbosity string `json:"verbosity,omitempty"`
 	// A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
 	// The IDs should be a string that uniquely identifies each user.


### PR DESCRIPTION
## Add Verbosity parameter to Chat Completion Request

Verbosity - Constrains the verbosity of the model's response. Lower values will result in more concise responses, while higher values will result in more verbose responses. Currently supported values are low, medium, and high.

OpenAI Docs - https://platform.openai.com/docs/api-reference/chat/create#chat_create-verbosity


## Testing
✅ All existing tests pass