### PR TITLE
Support extra_body parameters

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -257,6 +257,11 @@ type ChatCompletionRequestExtensions struct {
 	// ensuring predictable and consistent outputs in scenarios where specific
 	// choices are required.
 	GuidedChoice []string `json:"guided_choice,omitempty"`
+	// ExtraBody provides configuration options for the generation process in Gemini API.
+	// Additional configuration parameters to control model behavior. Will be passed directly to the Gemini API.
+	// Such as thinking mode for Gemini. "extra_body": {"google": {"thinking_config": {"include_thoughts": true}}}
+	// https://ai.google.dev/gemini-api/docs/openai
+	ExtraBody map[string]any `json:"extra_body,omitempty"`
 }
 
 // ChatCompletionRequest represents a request structure for chat completion API.

--- a/chat.go
+++ b/chat.go
@@ -487,6 +487,7 @@ func (c *Client) CreateChatCompletion(
 		http.MethodPost,
 		c.fullURL(urlSuffix, withModel(request.Model)),
 		withBody(request),
+		withExtraBody(request.ExtraBody),
 	)
 	if err != nil {
 		return

--- a/chat.go
+++ b/chat.go
@@ -257,11 +257,6 @@ type ChatCompletionRequestExtensions struct {
 	// ensuring predictable and consistent outputs in scenarios where specific
 	// choices are required.
 	GuidedChoice []string `json:"guided_choice,omitempty"`
-	// ExtraBody provides configuration options for the generation process in Gemini API.
-	// Additional configuration parameters to control model behavior. Will be passed directly to the Gemini API.
-	// Such as thinking mode for Gemini. "extra_body": {"google": {"thinking_config": {"include_thoughts": true}}}
-	// https://ai.google.dev/gemini-api/docs/openai
-	ExtraBody map[string]any `json:"extra_body,omitempty"`
 }
 
 // ChatCompletionRequest represents a request structure for chat completion API.
@@ -330,6 +325,11 @@ type ChatCompletionRequest struct {
 	// We recommend hashing their username or email address, in order to avoid sending us any identifying information.
 	// https://platform.openai.com/docs/api-reference/chat/create#chat_create-safety_identifier
 	SafetyIdentifier string `json:"safety_identifier,omitempty"`
+	// ExtraBody provides configuration options for the generation process in Gemini API.
+	// Additional configuration parameters to control model behavior. Will be passed directly to the Gemini API.
+	// Such as thinking mode for Gemini. "extra_body": {"google": {"thinking_config": {"include_thoughts": true}}}
+	// https://ai.google.dev/gemini-api/docs/openai
+	ExtraBody map[string]any `json:"extra_body,omitempty"`
 	// Embedded struct for non-OpenAI extensions
 	ChatCompletionRequestExtensions
 }

--- a/chat.go
+++ b/chat.go
@@ -482,12 +482,28 @@ func (c *Client) CreateChatCompletion(
 		return
 	}
 
+	// The body map is used to dynamically construct the request payload for the chat completion API.
+	// Instead of relying on a fixed struct, the body map allows for flexible inclusion of fields
+	// based on their presence, avoiding unnecessary or empty fields in the request.
+	extraBody := request.ExtraBody
+	request.ExtraBody = nil
+
+	// Serialize request to JSON
+	jsonData, err := json.Marshal(request)
+	if err != nil {
+		return
+	}
+
+	// Deserialize JSON to map[string]any
+	var body map[string]any
+	_ = json.Unmarshal(jsonData, &body)
+
 	req, err := c.newRequest(
 		ctx,
 		http.MethodPost,
 		c.fullURL(urlSuffix, withModel(request.Model)),
-		withBody(request),
-		withExtraBody(request.ExtraBody),
+		withBody(body),           // Main request body.
+		withExtraBody(extraBody), // Merge ExtraBody fields.
 	)
 	if err != nil {
 		return

--- a/chat_stream.go
+++ b/chat_stream.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 )
 
@@ -91,11 +92,28 @@ func (c *Client) CreateChatCompletionStream(
 		return
 	}
 
+	// The body map is used to dynamically construct the request payload for the chat completion API.
+	// Instead of relying on a fixed struct, the body map allows for flexible inclusion of fields
+	// based on their presence, avoiding unnecessary or empty fields in the request.
+	extraBody := request.ExtraBody
+	request.ExtraBody = nil
+
+	// Serialize request to JSON
+	jsonData, err := json.Marshal(request)
+	if err != nil {
+		return
+	}
+
+	// Deserialize JSON to map[string]any
+	var body map[string]any
+	_ = json.Unmarshal(jsonData, &body)
+
 	req, err := c.newRequest(
 		ctx,
 		http.MethodPost,
 		c.fullURL(urlSuffix, withModel(request.Model)),
-		withBody(request),
+		withBody(body),           // Main request body.
+		withExtraBody(extraBody), // Merge ExtraBody fields.
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**Describe the change**
add extra_body param support in ChatCompletionRequestExtensions

**Provide OpenAI documentation link**
https://ai.google.dev/gemini-api/docs/openai#thinking

```
curl "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions" \
-H "Content-Type: application/json" \
-H "Authorization: Bearer GEMINI_API_KEY" \
-d '{
    "model": "gemini-2.5-flash",
      "messages": [{"role": "user", "content": "Explain to me how AI works"}],
      "extra_body": {
        "google": {
           "thinking_config": {
             "include_thoughts": true
           }
        }
      }
    }'
```