### PR TITLE
[BREAKING_CHANGES] Stop stripping dots in azure model mapper

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"net/http"
 	"regexp"
+	"strings"
 )
 
 const (
@@ -70,7 +71,11 @@ func DefaultAzureConfig(apiKey, baseURL string) ClientConfig {
 		APIType:    APITypeAzure,
 		APIVersion: "2023-05-15",
 		AzureModelMapperFunc: func(model string) string {
-			return regexp.MustCompile(`[.:]`).ReplaceAllString(model, "")
+			// only 3.5 models have the "." stripped in their names
+			if strings.Contains(model, "3.5") {
+				return regexp.MustCompile(`[.:]`).ReplaceAllString(model, "")
+			}
+			return strings.ReplaceAll(model, ":", "")
 		},
 
 		HTTPClient: &http.Client{},

--- a/config_test.go
+++ b/config_test.go
@@ -21,6 +21,10 @@ func TestGetAzureDeploymentByModel(t *testing.T) {
 			Expect: "gpt-35-turbo-0301",
 		},
 		{
+			Model:  "gpt-4.1",
+			Expect: "gpt-4.1",
+		},
+		{
 			Model:  "text-embedding-ada-002",
 			Expect: "text-embedding-ada-002",
 		},


### PR DESCRIPTION
Dots (.) are valid model and deployments names in Azure AI Foundry deployments for all models newer than 3.5, and without customization the deployment name matches the model name so it seems sensible to leave them in for non 3.5 models.

I kept the original : stripping in place, not entirely sure what that was originally there for but i haven't found issues around it for now

Similar almost complete PR found here, but the original author closed it: https://github.com/sashabaranov/go-openai/pull/1004

Fixes this issue: #978