### PR TITLE
Add support for audio and video input

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -93,7 +93,8 @@ const (
 )
 
 /* reference:
- * 	https://bailian.console.aliyun.com/?spm=5176.29597918.J_SEsSjsNv72yRuRFS2VknO.2.191e7b08wdOQzD&tab=api#/api/?type=model&url=2712576
+ * 	https://bailian.console.aliyun.com/
+ * 		?spm=5176.29597918.J_SEsSjsNv72yRuRFS2VknO.2.191e7b08wdOQzD&tab=api#/api/?type=model&url=2712576
  * 	https://help.aliyun.com/zh/model-studio/qwen-omni#423736d367a7x
  */
 type InputAudio struct {
@@ -362,6 +363,7 @@ type ChatCompletionRequest struct {
 
 type customChatCompletionRequest ChatCompletionRequest
 
+const TrailingLen = 2 // length of "}\n"
 func (r *ChatCompletionRequest) MarshalJSON() ([]byte, error) {
 	if len(r.Extensions) == 0 {
 		return json.Marshal((*customChatCompletionRequest)(r))
@@ -372,7 +374,7 @@ func (r *ChatCompletionRequest) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	// remove the trailing "}\n"
-	buf.Truncate(buf.Len() - 2)
+	buf.Truncate(buf.Len() - TrailingLen)
 	// record the current position
 	pos := buf.Len()
 	// append extensions

--- a/chat_stream.go
+++ b/chat_stream.go
@@ -5,7 +5,9 @@ import (
 	"net/http"
 )
 
-// reference: https://bailian.console.aliyun.com/?spm=5176.29597918.J_SEsSjsNv72yRuRFS2VknO.2.191e7b08wdOQzD&tab=api#/api/?type=model&url=2712576
+/* reference: https://bailian.console.aliyun.com/
+ * ?spm=5176.29597918.J_SEsSjsNv72yRuRFS2VknO.2.191e7b08wdOQzD&tab=api#/api/?type=model&url=2712576
+ */
 type OutputAudio struct {
 	Transcript string `json:"transcript"` // streamed text content
 	Data       string `json:"data"`       // base64-encoded audio data
@@ -23,8 +25,9 @@ type ChatCompletionStreamChoiceDelta struct {
 	// which is not in the official documentation.
 	// the doc from deepseek:
 	// - https://api-docs.deepseek.com/api/create-chat-completion#responses
-	ReasoningContent string       `json:"reasoning_content,omitempty"`
-	Audio            *OutputAudio `json:"audio,omitempty"` // Audio is used for audio responses, if supported by the model, such as "qwen-omni".
+	ReasoningContent string `json:"reasoning_content,omitempty"`
+	// Audio is used for audio responses, if supported by the model, such as "qwen-omni".
+	Audio *OutputAudio `json:"audio,omitempty"`
 }
 
 type ChatCompletionStreamChoiceLogprobs struct {


### PR DESCRIPTION
Add input support for ModelScope audio and video, so that Qwen3's audio or visual large models can be invoked.
API reference: https://bailian.console.aliyun.com/?spm=5176.29597918.J_SEsSjsNv72yRuRFS2VknO.2.191e7b08wdOQzD&tab=api#/api/?type=model&url=2712576