### PR TITLE
feat: Add MIMEType field to ChatMessageImageURL

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -77,8 +77,9 @@ const (
 )
 
 type ChatMessageImageURL struct {
-	URL    string         `json:"url,omitempty"`
-	Detail ImageURLDetail `json:"detail,omitempty"`
+	URL      string         `json:"url,omitempty"`
+	Detail   ImageURLDetail `json:"detail,omitempty"`
+	MIMEType string         `json:"mime_type,omitempty"`
 }
 
 type ChatMessagePartType string

--- a/chat_test.go
+++ b/chat_test.go
@@ -804,6 +804,38 @@ func TestMultipartChatCompletions(t *testing.T) {
 	checks.NoError(t, err, "CreateAzureChatCompletion error")
 }
 
+// TestChatMessageImageURLMIMEType tests the MIMEType field in ChatMessageImageURL
+func TestChatMessageImageURLMIMEType(t *testing.T) {
+	client, server, teardown := setupAzureTestServer()
+	defer teardown()
+	server.RegisterHandler("/openai/deployments/*", handleChatCompletionEndpoint)
+
+	_, err := client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
+		MaxTokens: 5,
+		Model:     openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{
+				Role: openai.ChatMessageRoleUser,
+				MultiContent: []openai.ChatMessagePart{
+					{
+						Type: openai.ChatMessagePartTypeText,
+						Text: "Hello!",
+					},
+					{
+						Type: openai.ChatMessagePartTypeImageURL,
+						ImageURL: &openai.ChatMessageImageURL{
+							URL:      "URL",
+							Detail:   openai.ImageURLDetailLow,
+							MIMEType: "image/png",
+						},
+					},
+				},
+			},
+		},
+	})
+	checks.NoError(t, err, "CreateAzureChatCompletion error")
+}
+
 func TestMultipartChatMessageSerialization(t *testing.T) {
 	jsonText := `[{"role":"system","content":"system-message"},` +
 		`{"role":"user","content":[{"type":"text","text":"nice-text"},` +

--- a/chat_test.go
+++ b/chat_test.go
@@ -804,7 +804,6 @@ func TestMultipartChatCompletions(t *testing.T) {
 	checks.NoError(t, err, "CreateAzureChatCompletion error")
 }
 
-// TestChatMessageImageURLMIMEType tests the MIMEType field in ChatMessageImageURL
 func TestChatMessageImageURLMIMEType(t *testing.T) {
 	client, server, teardown := setupAzureTestServer()
 	defer teardown()


### PR DESCRIPTION
1. Added MIMEType field to ChatMessageImageURL struct
2. allowing users to specify the MIME type of image URLs in multi-content messages.

3. relevant API doc 
https://platform.openai.com/docs/api-reference/uploads/create