### PR TITLE
fix: return read error when ErrorResponse has nil Error field

### DIFF
--- a/stream_reader.go
+++ b/stream_reader.go
@@ -64,7 +64,7 @@ func (stream *streamReader[T]) processLines() ([]byte, error) {
 		rawLine, readErr := stream.reader.ReadBytes('\n')
 		if readErr != nil || hasErrorPrefix {
 			respErr := stream.unmarshalError()
-			if respErr != nil {
+			if respErr != nil && respErr.Error != nil {
 				return nil, fmt.Errorf("error, %w", respErr.Error)
 			}
 			return nil, readErr

--- a/stream_reader_test.go
+++ b/stream_reader_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"io"
 	"testing"
 
 	utils "github.com/sashabaranov/go-openai/internal"
@@ -74,5 +75,35 @@ func TestStreamReaderRecvRaw(t *testing.T) {
 	}
 	if !bytes.Equal(rawLine, []byte("{\"key\": \"value\"}")) {
 		t.Fatalf("Did not return raw line: %v", string(rawLine))
+	}
+}
+
+// TestStreamReaderReturnsReadErrWhenErrorResponseHasNilError tests that when
+// unmarshalError returns an ErrorResponse with a nil Error field (e.g., when
+// unmarshaling an empty JSON object "{}"), the original read error is returned
+// instead of "error, <nil>". This fixes issue #1060.
+func TestStreamReaderReturnsReadErrWhenErrorResponseHasNilError(t *testing.T) {
+	// Create a stream that will return io.EOF on read (simulating context cancellation)
+	// with an error accumulator that contains an empty JSON object
+	stream := &streamReader[ChatCompletionStreamResponse]{
+		reader:         bufio.NewReader(bytes.NewReader([]byte{})), // empty reader returns io.EOF
+		errAccumulator: utils.NewErrorAccumulator(),
+		unmarshaler:    &utils.JSONUnmarshaler{},
+	}
+
+	// Write an empty JSON object to the error accumulator
+	// This will unmarshal to ErrorResponse{Error: nil}
+	err := stream.errAccumulator.Write([]byte("{}"))
+	if err != nil {
+		t.Fatalf("Failed to write to error accumulator: %v", err)
+	}
+
+	// Call processLines which should return io.EOF, not "error, <nil>"
+	_, err = stream.processLines()
+	if err == nil {
+		t.Fatal("Expected error but got nil")
+	}
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("Expected io.EOF but got: %v", err)
 	}
 }


### PR DESCRIPTION
```markdown
## Summary

Fixes #1060

When streaming is cancelled (e.g., via context cancellation), `stream.Recv()` returns `"error, <nil>"` instead of propagating the original read error (like `io.EOF`).

## Root Cause

In `stream_reader.go` line 66-68, when `ReadBytes('\n')` returns an error (like `io.EOF` on context cancellation), `unmarshalError()` is called. If the error accumulator contains an empty JSON object `{}`, it unmarshals to `&ErrorResponse{Error: nil}`. Since `respErr != nil` is true (the struct pointer exists), but `respErr.Error` is nil, `fmt.Errorf("error, %w", respErr.Error)` produces `"error, <nil>"`.

## Solution

Add a nil check for `respErr.Error`:

```go
if respErr != nil && respErr.Error != nil {
    return nil, fmt.Errorf("error, %w", respErr.Error)
}
```

This ensures the original read error is properly propagated when there's no actual API error to report.

## Changes

- `stream_reader.go`: Added nil check for `respErr.Error` before formatting error message
- stream_reader_test.go: Added test case `TestStreamReaderReturnsReadErrWhenErrorResponseHasNilError` to verify the fix

## Testing

All existing tests pass, and the new test verifies that `io.EOF` is properly returned instead of `"error, <nil>"`.
