### PR TITLE
fix: add MaxLength field to jsonschema.Definition

### DIFF
--- a/jsonschema/json.go
+++ b/jsonschema/json.go
@@ -48,6 +48,8 @@ type Definition struct {
 	AdditionalProperties any `json:"additionalProperties,omitempty"`
 	// Whether the schema is nullable or not.
 	Nullable bool `json:"nullable,omitempty"`
+	// MaxLength specifies the maximum length of a string.
+	MaxLength int `json:"maxLength,omitempty"`
 
 	// Ref Reference to a definition in $defs or external schema.
 	Ref string `json:"$ref,omitempty"`

--- a/jsonschema/json_test.go
+++ b/jsonschema/json_test.go
@@ -157,6 +157,17 @@ func TestDefinition_MarshalJSON(t *testing.T) {
 				}
 			}`,
 		},
+		{
+			name: "Test with MaxLength",
+			def: jsonschema.Definition{
+				Type:      jsonschema.String,
+				MaxLength: 100,
+			},
+			want: `{
+				"type":"string",
+				"maxLength":100
+			}`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #1006

## Changes
- Add `MaxLength` field to `jsonschema.Definition` struct with JSON tag `maxLength`
- Add test case to verify MaxLength serialization