### PR TITLE
feat(audio): add chunking_strategy field to AudioRequest

### DIFF
--- a/audio.go
+++ b/audio.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -20,11 +21,12 @@ const (
 type AudioResponseFormat string
 
 const (
-	AudioResponseFormatJSON        AudioResponseFormat = "json"
-	AudioResponseFormatText        AudioResponseFormat = "text"
-	AudioResponseFormatSRT         AudioResponseFormat = "srt"
-	AudioResponseFormatVerboseJSON AudioResponseFormat = "verbose_json"
-	AudioResponseFormatVTT         AudioResponseFormat = "vtt"
+	AudioResponseFormatJSON         AudioResponseFormat = "json"
+	AudioResponseFormatText         AudioResponseFormat = "text"
+	AudioResponseFormatSRT          AudioResponseFormat = "srt"
+	AudioResponseFormatVerboseJSON  AudioResponseFormat = "verbose_json"
+	AudioResponseFormatVTT          AudioResponseFormat = "vtt"
+	AudioResponseFormatDiarizedJSON AudioResponseFormat = "diarized_json"
 )
 
 type TranscriptionTimestampGranularity string
@@ -33,6 +35,40 @@ const (
 	TranscriptionTimestampGranularityWord    TranscriptionTimestampGranularity = "word"
 	TranscriptionTimestampGranularitySegment TranscriptionTimestampGranularity = "segment"
 )
+
+// AudioChunkingStrategyType defines the chunking strategy for audio transcription.
+type AudioChunkingStrategyType string
+
+// Chunking strategy types for audio transcription.
+const (
+	AudioChunkingStrategyAuto      AudioChunkingStrategyType = "auto"       // Server normalizes loudness and uses VAD
+	AudioChunkingStrategyServerVAD AudioChunkingStrategyType = "server_vad" // Custom VAD parameters
+)
+
+// TranscriptionChunkingStrategy controls how audio is cut into chunks.
+// When Type is ChunkingStrategyAuto ("auto"), the form field contains the literal string "auto".
+// When Type is ChunkingStrategyServerVAD ("server_vad"), the form field contains a JSON object with VAD parameters.
+// Required for gpt-4o-transcribe-diarize model on audio longer than 30 seconds.
+type TranscriptionChunkingStrategy struct {
+	// Type is AudioChunkingStrategyAuto or AudioChunkingStrategyServerVAD.
+	Type AudioChunkingStrategyType `json:"type"`
+	// PrefixPaddingMs is padding before detected speech (ms).
+	PrefixPaddingMs int `json:"prefix_padding_ms,omitempty"`
+	// SilenceDurationMs is silence threshold for chunk boundaries (ms).
+	SilenceDurationMs int `json:"silence_duration_ms,omitempty"`
+	// Threshold is VAD detection sensitivity (0.0-1.0).
+	Threshold float32 `json:"threshold,omitempty"`
+}
+
+// toFormValue returns the string representation for multipart form submission.
+// "auto" is sent as literal string; "server_vad" is sent as JSON object.
+func (s TranscriptionChunkingStrategy) toFormValue() string {
+	if s.Type == AudioChunkingStrategyAuto {
+		return string(AudioChunkingStrategyAuto)
+	}
+	data, _ := json.Marshal(s)
+	return string(data)
+}
 
 // AudioRequest represents a request structure for audio API.
 type AudioRequest struct {
@@ -49,6 +85,8 @@ type AudioRequest struct {
 	Language               string // Only for transcription.
 	Format                 AudioResponseFormat
 	TimestampGranularities []TranscriptionTimestampGranularity // Only for transcription.
+	// ChunkingStrategy controls audio chunking. Required for diarization models on audio >30s.
+	ChunkingStrategy *TranscriptionChunkingStrategy
 }
 
 // AudioResponse represents a response structure for audio API.
@@ -79,6 +117,34 @@ type AudioResponse struct {
 	httpHeader
 }
 
+// AudioUsage represents usage statistics for audio API calls.
+type AudioUsage struct {
+	Type    string `json:"type"`              // "duration" or "tokens"
+	Seconds int    `json:"seconds,omitempty"` // Duration in seconds (for duration-based billing)
+}
+
+// DiarizedSegment represents a speaker-annotated segment from diarized transcription.
+type DiarizedSegment struct {
+	Type    string  `json:"type"`    // "transcript.text.segment"
+	ID      string  `json:"id"`      // Segment identifier (e.g., "seg_001")
+	Start   float64 `json:"start"`   // Start time in seconds
+	End     float64 `json:"end"`     // End time in seconds
+	Text    string  `json:"text"`    // Transcript text for this segment
+	Speaker string  `json:"speaker"` // Speaker label (e.g., "agent", "A")
+}
+
+// DiarizedAudioResponse represents a diarized transcription response.
+// Returned when using gpt-4o-transcribe-diarize model with diarized_json format.
+type DiarizedAudioResponse struct {
+	Task     string            `json:"task"`     // "transcribe"
+	Duration float64           `json:"duration"` // Audio duration in seconds
+	Text     string            `json:"text"`     // Full transcript with speaker prefixes
+	Segments []DiarizedSegment `json:"segments"` // Speaker-annotated segments
+	Usage    *AudioUsage       `json:"usage,omitempty"`
+
+	httpHeader
+}
+
 type audioTextResponse struct {
 	Text string `json:"text"`
 
@@ -98,6 +164,39 @@ func (c *Client) CreateTranscription(
 	request AudioRequest,
 ) (response AudioResponse, err error) {
 	return c.callAudioAPI(ctx, request, "transcriptions")
+}
+
+// CreateDiarizedTranscription transcribes audio with speaker diarization.
+// Use with gpt-4o-transcribe-diarize model and AudioResponseFormatDiarizedJSON format.
+// Requires ChunkingStrategy for audio longer than 30 seconds.
+func (c *Client) CreateDiarizedTranscription(
+	ctx context.Context,
+	request AudioRequest,
+) (response DiarizedAudioResponse, err error) {
+	var formBody bytes.Buffer
+	builder := c.createFormBuilder(&formBody)
+
+	if err = audioMultipartForm(request, builder); err != nil {
+		return DiarizedAudioResponse{}, err
+	}
+
+	urlSuffix := "/audio/transcriptions"
+	req, err := c.newRequest(
+		ctx,
+		http.MethodPost,
+		c.fullURL(urlSuffix, withModel(request.Model)),
+		withBody(&formBody),
+		withContentType(builder.FormDataContentType()),
+	)
+	if err != nil {
+		return DiarizedAudioResponse{}, err
+	}
+
+	err = c.sendRequest(req, &response)
+	if err != nil {
+		return DiarizedAudioResponse{}, err
+	}
+	return
 }
 
 // CreateTranslation — API call to translate audio into English.
@@ -148,7 +247,8 @@ func (c *Client) callAudioAPI(
 
 // HasJSONResponse returns true if the response format is JSON.
 func (r AudioRequest) HasJSONResponse() bool {
-	return r.Format == "" || r.Format == AudioResponseFormatJSON || r.Format == AudioResponseFormatVerboseJSON
+	return r.Format == "" || r.Format == AudioResponseFormatJSON ||
+		r.Format == AudioResponseFormatVerboseJSON || r.Format == AudioResponseFormatDiarizedJSON
 }
 
 // audioMultipartForm creates a form with audio file contents and the name of the model to use for
@@ -196,17 +296,37 @@ func audioMultipartForm(request AudioRequest, b utils.FormBuilder) error {
 		}
 	}
 
-	if len(request.TimestampGranularities) > 0 {
-		for _, tg := range request.TimestampGranularities {
-			err = b.WriteField("timestamp_granularities[]", string(tg))
-			if err != nil {
-				return fmt.Errorf("writing timestamp_granularities[]: %w", err)
-			}
-		}
+	if err = writeTimestampGranularities(request.TimestampGranularities, b); err != nil {
+		return err
+	}
+
+	if err = writeChunkingStrategy(request.ChunkingStrategy, b); err != nil {
+		return err
 	}
 
 	// Close the multipart writer
 	return b.Close()
+}
+
+// writeTimestampGranularities writes the timestamp_granularities[] fields if provided.
+func writeTimestampGranularities(granularities []TranscriptionTimestampGranularity, b utils.FormBuilder) error {
+	for _, tg := range granularities {
+		if err := b.WriteField("timestamp_granularities[]", string(tg)); err != nil {
+			return fmt.Errorf("writing timestamp_granularities[]: %w", err)
+		}
+	}
+	return nil
+}
+
+// writeChunkingStrategy writes the chunking_strategy field if provided.
+func writeChunkingStrategy(cs *TranscriptionChunkingStrategy, b utils.FormBuilder) error {
+	if cs == nil {
+		return nil
+	}
+	if err := b.WriteField("chunking_strategy", cs.toFormValue()); err != nil {
+		return fmt.Errorf("writing chunking_strategy: %w", err)
+	}
+	return nil
 }
 
 // createFileField creates the "file" form field from either an existing file or by using the reader.

--- a/audio_api_test.go
+++ b/audio_api_test.go
@@ -3,6 +3,7 @@ package openai_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"mime"
@@ -154,6 +155,339 @@ func handleAudioEndpoint(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if _, err = w.Write([]byte(`{"body": "hello"}`)); err != nil {
+		http.Error(w, "failed to write body", http.StatusInternalServerError)
+		return
+	}
+}
+
+func TestTranscriptionChunkingStrategy_JSONMarshal(t *testing.T) {
+	t.Parallel()
+
+	// Note: Form serialization in audioMultipartForm handles "auto" as literal string.
+	// This test verifies standard JSON marshaling behavior.
+	tests := []struct {
+		name string
+		cs   openai.TranscriptionChunkingStrategy
+		want string
+	}{
+		{
+			name: "auto serializes as object",
+			cs:   openai.TranscriptionChunkingStrategy{Type: openai.AudioChunkingStrategyAuto},
+			want: `{"type":"auto"}`,
+		},
+		{
+			name: "server_vad with parameters",
+			cs: openai.TranscriptionChunkingStrategy{
+				Type:              openai.AudioChunkingStrategyServerVAD,
+				PrefixPaddingMs:   300,
+				SilenceDurationMs: 500,
+				Threshold:         0.5,
+			},
+			want: `{"type":"server_vad","prefix_padding_ms":300,"silence_duration_ms":500,"threshold":0.5}`,
+		},
+		{
+			name: "server_vad without optional params",
+			cs:   openai.TranscriptionChunkingStrategy{Type: openai.AudioChunkingStrategyServerVAD},
+			want: `{"type":"server_vad"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := json.Marshal(tt.cs)
+			if err != nil {
+				t.Fatalf("json.Marshal() error = %v", err)
+			}
+			if string(got) != tt.want {
+				t.Errorf("json.Marshal() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAudioRequest_HasJSONResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		format openai.AudioResponseFormat
+		want   bool
+	}{
+		{"empty format defaults to JSON", "", true},
+		{"json format", openai.AudioResponseFormatJSON, true},
+		{"verbose_json format", openai.AudioResponseFormatVerboseJSON, true},
+		{"diarized_json format", openai.AudioResponseFormatDiarizedJSON, true},
+		{"text format", openai.AudioResponseFormatText, false},
+		{"srt format", openai.AudioResponseFormatSRT, false},
+		{"vtt format", openai.AudioResponseFormatVTT, false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			req := openai.AudioRequest{Format: tt.format}
+			if got := req.HasJSONResponse(); got != tt.want {
+				t.Errorf("HasJSONResponse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateDiarizedTranscription(t *testing.T) {
+	client, server, teardown := setupOpenAITestServer()
+	defer teardown()
+	server.RegisterHandler("/v1/audio/transcriptions", handleDiarizedAudioEndpoint)
+
+	ctx := context.Background()
+
+	t.Run("with file path", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "audio.mp3")
+		test.CreateTestFile(t, path)
+
+		resp, err := client.CreateDiarizedTranscription(ctx, openai.AudioRequest{
+			FilePath: path,
+			Model:    "gpt-4o-transcribe-diarize",
+			Format:   openai.AudioResponseFormatDiarizedJSON,
+		})
+		checks.NoError(t, err, "CreateDiarizedTranscription error")
+
+		if resp.Task != "transcribe" {
+			t.Errorf("Task = %q, want %q", resp.Task, "transcribe")
+		}
+		if resp.Duration != 10.5 {
+			t.Errorf("Duration = %v, want %v", resp.Duration, 10.5)
+		}
+		if len(resp.Segments) != 2 {
+			t.Errorf("len(Segments) = %d, want %d", len(resp.Segments), 2)
+		}
+		if resp.Segments[0].Speaker != "A" {
+			t.Errorf("Segments[0].Speaker = %q, want %q", resp.Segments[0].Speaker, "A")
+		}
+		if resp.Usage == nil {
+			t.Error("Usage should not be nil")
+		} else if resp.Usage.Seconds != 11 {
+			t.Errorf("Usage.Seconds = %d, want %d", resp.Usage.Seconds, 11)
+		}
+	})
+
+	t.Run("with reader", func(t *testing.T) {
+		resp, err := client.CreateDiarizedTranscription(ctx, openai.AudioRequest{
+			FilePath: "audio.mp3",
+			Reader:   bytes.NewBuffer([]byte("audio data")),
+			Model:    "gpt-4o-transcribe-diarize",
+			Format:   openai.AudioResponseFormatDiarizedJSON,
+		})
+		checks.NoError(t, err, "CreateDiarizedTranscription error")
+
+		if resp.Text == "" {
+			t.Error("Text should not be empty")
+		}
+	})
+}
+
+func TestCreateDiarizedTranscription_WithChunkingStrategy(t *testing.T) {
+	var receivedChunkingStrategy string
+	client, server, teardown := setupOpenAITestServer()
+	defer teardown()
+	server.RegisterHandler("/v1/audio/transcriptions", func(w http.ResponseWriter, r *http.Request) {
+		err := r.ParseMultipartForm(1024 * 1024)
+		if err != nil {
+			http.Error(w, "failed to parse form", http.StatusBadRequest)
+			return
+		}
+		receivedChunkingStrategy = r.FormValue("chunking_strategy")
+		_, _ = w.Write([]byte(diarizedResponse))
+	})
+
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "audio.mp3")
+	test.CreateTestFile(t, path)
+
+	t.Run("auto chunking", func(t *testing.T) {
+		_, err := client.CreateDiarizedTranscription(ctx, openai.AudioRequest{
+			FilePath: path,
+			Model:    "gpt-4o-transcribe-diarize",
+			Format:   openai.AudioResponseFormatDiarizedJSON,
+			ChunkingStrategy: &openai.TranscriptionChunkingStrategy{
+				Type: openai.AudioChunkingStrategyAuto,
+			},
+		})
+		checks.NoError(t, err, "CreateDiarizedTranscription error")
+
+		if receivedChunkingStrategy == "" {
+			t.Fatal("chunking_strategy field was not sent")
+		}
+
+		// "auto" is sent as literal string, not JSON
+		if receivedChunkingStrategy != "auto" {
+			t.Errorf("chunking_strategy = %q, want %q", receivedChunkingStrategy, "auto")
+		}
+	})
+
+	t.Run("server_vad with parameters", func(t *testing.T) {
+		_, err := client.CreateDiarizedTranscription(ctx, openai.AudioRequest{
+			FilePath: path,
+			Model:    "gpt-4o-transcribe-diarize",
+			Format:   openai.AudioResponseFormatDiarizedJSON,
+			ChunkingStrategy: &openai.TranscriptionChunkingStrategy{
+				Type:              openai.AudioChunkingStrategyServerVAD,
+				PrefixPaddingMs:   300,
+				SilenceDurationMs: 500,
+				Threshold:         0.5,
+			},
+		})
+		checks.NoError(t, err, "CreateDiarizedTranscription error")
+
+		// "server_vad" serializes as a JSON object
+		var cs openai.TranscriptionChunkingStrategy
+		err = json.Unmarshal([]byte(receivedChunkingStrategy), &cs)
+		if err != nil {
+			t.Fatalf("failed to parse chunking_strategy: %v", err)
+		}
+		if cs.Type != openai.AudioChunkingStrategyServerVAD {
+			t.Errorf("ChunkingStrategy.Type = %q, want %q", cs.Type, openai.AudioChunkingStrategyServerVAD)
+		}
+		if cs.PrefixPaddingMs != 300 {
+			t.Errorf("ChunkingStrategy.PrefixPaddingMs = %d, want %d", cs.PrefixPaddingMs, 300)
+		}
+		if cs.SilenceDurationMs != 500 {
+			t.Errorf("ChunkingStrategy.SilenceDurationMs = %d, want %d", cs.SilenceDurationMs, 500)
+		}
+		if cs.Threshold != 0.5 {
+			t.Errorf("ChunkingStrategy.Threshold = %v, want %v", cs.Threshold, 0.5)
+		}
+	})
+
+	t.Run("nil chunking strategy", func(t *testing.T) {
+		receivedChunkingStrategy = "" // reset
+		_, err := client.CreateDiarizedTranscription(ctx, openai.AudioRequest{
+			FilePath:         path,
+			Model:            "gpt-4o-transcribe-diarize",
+			Format:           openai.AudioResponseFormatDiarizedJSON,
+			ChunkingStrategy: nil,
+		})
+		checks.NoError(t, err, "CreateDiarizedTranscription error")
+
+		if receivedChunkingStrategy != "" {
+			t.Errorf("chunking_strategy should not be sent when nil, got %q", receivedChunkingStrategy)
+		}
+	})
+}
+
+func TestCreateDiarizedTranscription_FileNotFound(t *testing.T) {
+	t.Parallel()
+
+	client, server, teardown := setupOpenAITestServer()
+	defer teardown()
+	server.RegisterHandler("/v1/audio/transcriptions", handleDiarizedAudioEndpoint)
+
+	_, err := client.CreateDiarizedTranscription(context.Background(), openai.AudioRequest{
+		FilePath: "/nonexistent/path/audio.mp3",
+		Model:    "gpt-4o-transcribe-diarize",
+	})
+	if err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+	if !strings.Contains(err.Error(), "no such file") {
+		t.Errorf("expected 'no such file' error, got: %v", err)
+	}
+}
+
+func TestCreateDiarizedTranscription_HTTPError(t *testing.T) {
+	t.Parallel()
+
+	client, server, teardown := setupOpenAITestServer()
+	defer teardown()
+	server.RegisterHandler("/v1/audio/transcriptions", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error": {"message": "invalid api key", "type": "auth_error"}}`))
+	})
+
+	path := filepath.Join(t.TempDir(), "audio.mp3")
+	test.CreateTestFile(t, path)
+
+	_, err := client.CreateDiarizedTranscription(context.Background(), openai.AudioRequest{
+		FilePath: path,
+		Model:    "gpt-4o-transcribe-diarize",
+	})
+	if err == nil {
+		t.Fatal("expected error for unauthorized request")
+	}
+}
+
+const diarizedResponse = `{
+	"task": "transcribe",
+	"duration": 10.5,
+	"text": "[A]: Hello. [B]: Hi there.",
+	"segments": [
+		{
+			"type": "transcript.text.segment",
+			"id": "seg_001",
+			"start": 0.0,
+			"end": 1.5,
+			"text": "Hello.",
+			"speaker": "A"
+		},
+		{
+			"type": "transcript.text.segment",
+			"id": "seg_002",
+			"start": 2.0,
+			"end": 3.5,
+			"text": "Hi there.",
+			"speaker": "B"
+		}
+	],
+	"usage": {
+		"type": "duration",
+		"seconds": 11
+	}
+}`
+
+func handleDiarizedAudioEndpoint(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		http.Error(w, "failed to parse media type", http.StatusBadRequest)
+		return
+	}
+
+	if !strings.HasPrefix(mediaType, "multipart") {
+		http.Error(w, "request is not multipart", http.StatusBadRequest)
+		return
+	}
+
+	boundary, ok := params["boundary"]
+	if !ok {
+		http.Error(w, "no boundary in params", http.StatusBadRequest)
+		return
+	}
+
+	fileData := &bytes.Buffer{}
+	mr := multipart.NewReader(r.Body, boundary)
+	part, err := mr.NextPart()
+	if err != nil && errors.Is(err, io.EOF) {
+		http.Error(w, "error accessing file", http.StatusBadRequest)
+		return
+	}
+	if _, err = io.Copy(fileData, part); err != nil {
+		http.Error(w, "failed to copy file", http.StatusInternalServerError)
+		return
+	}
+
+	if len(fileData.Bytes()) == 0 {
+		http.Error(w, "received empty file data", http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if _, err = w.Write([]byte(diarizedResponse)); err != nil {
 		http.Error(w, "failed to write body", http.StatusInternalServerError)
 		return
 	}

--- a/audio_test.go
+++ b/audio_test.go
@@ -30,6 +30,9 @@ func TestAudioWithFailingFormBuilder(t *testing.T) {
 			TranscriptionTimestampGranularitySegment,
 			TranscriptionTimestampGranularityWord,
 		},
+		ChunkingStrategy: &TranscriptionChunkingStrategy{
+			Type: AudioChunkingStrategyAuto,
+		},
 	}
 
 	mockFailedErr := fmt.Errorf("mock form builder fail")
@@ -53,7 +56,10 @@ func TestAudioWithFailingFormBuilder(t *testing.T) {
 		return nil
 	}
 
-	failOn := []string{"model", "prompt", "temperature", "language", "response_format", "timestamp_granularities[]"}
+	failOn := []string{
+		"model", "prompt", "temperature", "language",
+		"response_format", "timestamp_granularities[]", "chunking_strategy",
+	}
 	for _, failingField := range failOn {
 		failForField = failingField
 		mockFailedErr = fmt.Errorf("mock form builder fail on field %s", failingField)
@@ -232,6 +238,65 @@ func TestCallAudioAPISendRequestErrorText(t *testing.T) {
 	// Use a non-JSON response format to exercise the text path.
 	req := AudioRequest{FilePath: path, Model: Whisper1, Format: AudioResponseFormatText}
 	_, err := client.callAudioAPI(context.Background(), req, "translations")
+	if err == nil {
+		t.Fatal("expected error but got none")
+	}
+	if !errors.Is(err, errHTTP) {
+		t.Errorf("expected error %v, got %v", errHTTP, err)
+	}
+}
+
+func TestCreateDiarizedTranscriptionMultipartFormError(t *testing.T) {
+	client := NewClient("test-token")
+	errForm := errors.New("mock create form file failure")
+	client.createFormBuilder = func(_ io.Writer) utils.FormBuilder {
+		return &failingFormBuilder{err: errForm}
+	}
+
+	req := AudioRequest{FilePath: "fake.mp3", Reader: bytes.NewBuffer([]byte("dummy")), Model: "gpt-4o-transcribe-diarize"}
+	_, err := client.CreateDiarizedTranscription(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error but got none")
+	}
+	if !errors.Is(err, errForm) {
+		t.Errorf("expected error %v, got %v", errForm, err)
+	}
+}
+
+func TestCreateDiarizedTranscriptionNewRequestError(t *testing.T) {
+	client := NewClient("test-token")
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "file.mp3")
+	if err := os.WriteFile(path, []byte("content"), 0644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+
+	errBuild := errors.New("mock build failure")
+	client.requestBuilder = &failingAudioRequestBuilder{err: errBuild}
+
+	req := AudioRequest{FilePath: path, Model: "gpt-4o-transcribe-diarize"}
+	_, err := client.CreateDiarizedTranscription(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error but got none")
+	}
+	if !errors.Is(err, errBuild) {
+		t.Errorf("expected error %v, got %v", errBuild, err)
+	}
+}
+
+func TestCreateDiarizedTranscriptionSendRequestError(t *testing.T) {
+	client := NewClient("test-token")
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "file.mp3")
+	if err := os.WriteFile(path, []byte("content"), 0644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+
+	errHTTP := errors.New("mock HTTPClient failure")
+	client.config.HTTPClient = &errorHTTPClient{err: errHTTP}
+
+	req := AudioRequest{FilePath: path, Model: "gpt-4o-transcribe-diarize"}
+	_, err := client.CreateDiarizedTranscription(context.Background(), req)
 	if err == nil {
 		t.Fatal("expected error but got none")
 	}


### PR DESCRIPTION
## Summary

Adds `chunking_strategy` field to `AudioRequest` and full speaker diarization support:

- `ChunkingStrategy *TranscriptionChunkingStrategy` field in `AudioRequest`
- `AudioChunkingStrategyAuto` and `AudioChunkingStrategyServerVAD` constants
- `AudioResponseFormatDiarizedJSON` response format
- `CreateDiarizedTranscription` method with `DiarizedAudioResponse` return type
- `DiarizedSegment` and `AudioUsage` types for response parsing

Closes #1101

## Usage

```go
resp, err := client.CreateDiarizedTranscription(ctx, openai.AudioRequest{
    Model:    "gpt-4o-transcribe-diarize",
    FilePath: "audio.mp3",
    Format:   openai.AudioResponseFormatDiarizedJSON,
    ChunkingStrategy: &openai.TranscriptionChunkingStrategy{
        Type: openai.AudioChunkingStrategyAuto,
    },
})
```

## Test plan

- [x] `go test -race -cover ./...` passes (99.5% coverage)
- [x] `go vet ./...` passes
- [x] `staticcheck ./...` passes
- [x] `golangci-lint run` passes (only pre-existing issues in unrelated files)