### PR TITLE
feat: support multiple images in CreateEditImage

### DIFF
--- a/image.go
+++ b/image.go
@@ -158,16 +158,18 @@ func (f file) ContentType() string {
 
 // ImageEditRequest represents the request structure for the image API.
 // Use WrapReader to wrap an io.Reader with filename and Content-type.
+// To send multiple images, populate Images instead of Image.
 type ImageEditRequest struct {
-	Image          io.Reader `json:"image,omitempty"`
-	Mask           io.Reader `json:"mask,omitempty"`
-	Prompt         string    `json:"prompt,omitempty"`
-	Model          string    `json:"model,omitempty"`
-	N              int       `json:"n,omitempty"`
-	Size           string    `json:"size,omitempty"`
-	ResponseFormat string    `json:"response_format,omitempty"`
-	Quality        string    `json:"quality,omitempty"`
-	User           string    `json:"user,omitempty"`
+	Image          io.Reader   `json:"image,omitempty"`
+	Images         []io.Reader `json:"images,omitempty"`
+	Mask           io.Reader   `json:"mask,omitempty"`
+	Prompt         string      `json:"prompt,omitempty"`
+	Model          string      `json:"model,omitempty"`
+	N              int         `json:"n,omitempty"`
+	Size           string      `json:"size,omitempty"`
+	ResponseFormat string      `json:"response_format,omitempty"`
+	Quality        string      `json:"quality,omitempty"`
+	User           string      `json:"user,omitempty"`
 }
 
 // CreateEditImage - API call to create an image. This is the main endpoint of the DALL-E API.
@@ -175,10 +177,19 @@ func (c *Client) CreateEditImage(ctx context.Context, request ImageEditRequest) 
 	body := &bytes.Buffer{}
 	builder := c.createFormBuilder(body)
 
-	// image, filename verification can be postponed
-	err = builder.CreateFormFileReader("image", request.Image, "")
-	if err != nil {
-		return
+	if len(request.Images) > 0 {
+		for _, img := range request.Images {
+			err = builder.CreateFormFileReader("image[]", img, "")
+			if err != nil {
+				return
+			}
+		}
+	} else {
+		// image, filename verification can be postponed
+		err = builder.CreateFormFileReader("image", request.Image, "")
+		if err != nil {
+			return
+		}
 	}
 
 	// mask, it is optional

--- a/image.go
+++ b/image.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
@@ -158,7 +159,7 @@ func (f file) ContentType() string {
 
 // ImageEditRequest represents the request structure for the image API.
 // Use WrapReader to wrap an io.Reader with filename and Content-type.
-// To send multiple images, populate Images instead of Image.
+// Populate Images (not Image) to send multiple images; the two fields are mutually exclusive.
 type ImageEditRequest struct {
 	Image          io.Reader   `json:"image,omitempty"`
 	Images         []io.Reader `json:"images,omitempty"`
@@ -178,7 +179,11 @@ func (c *Client) CreateEditImage(ctx context.Context, request ImageEditRequest) 
 	builder := c.createFormBuilder(body)
 
 	if len(request.Images) > 0 {
-		for _, img := range request.Images {
+		for i, img := range request.Images {
+			if img == nil {
+				err = fmt.Errorf("images[%d] is nil", i)
+				return
+			}
 			err = builder.CreateFormFileReader("image[]", img, "")
 			if err != nil {
 				return

--- a/image_test.go
+++ b/image_test.go
@@ -144,6 +144,31 @@ func TestImageFormBuilderFailures(t *testing.T) {
 			},
 			req: ImageEditRequest{Image: bytes.NewBuffer(nil), Mask: bytes.NewBuffer(nil)},
 		},
+		{
+			name: "images[0] fails",
+			setup: func(fb *mockFormBuilder) {
+				fb.mockCreateFormFileReader = func(string, io.Reader, string) error { return mockFailedErr }
+				fb.mockWriteField = func(string, string) error { return nil }
+				fb.mockClose = func() error { return nil }
+			},
+			req: ImageEditRequest{Images: []io.Reader{bytes.NewBuffer(nil), bytes.NewBuffer(nil)}},
+		},
+		{
+			name: "images[1] fails",
+			setup: func(fb *mockFormBuilder) {
+				callCount := 0
+				fb.mockCreateFormFileReader = func(string, io.Reader, string) error {
+					callCount++
+					if callCount > 1 {
+						return mockFailedErr
+					}
+					return nil
+				}
+				fb.mockWriteField = func(string, string) error { return nil }
+				fb.mockClose = func() error { return nil }
+			},
+			req: ImageEditRequest{Images: []io.Reader{bytes.NewBuffer(nil), bytes.NewBuffer(nil)}},
+		},
 	}
 
 	for _, tc := range tests {

--- a/image_test.go
+++ b/image_test.go
@@ -221,7 +221,7 @@ func TestCreateEditImageMultiImages(t *testing.T) {
 	_, err := c.CreateEditImage(ctx, req)
 	// request building fails but form building must have succeeded
 	if err == nil || !errors.Is(err, errTestRequestBuilderFailed) {
-		// if err is something else entirely, check form calls first
+		t.Fatalf("expected errTestRequestBuilderFailed, got %v", err)
 	}
 
 	if len(fieldNames) != 2 {

--- a/image_test.go
+++ b/image_test.go
@@ -6,6 +6,7 @@ import (
 
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -193,6 +194,44 @@ func TestImageFormBuilderFailures(t *testing.T) {
 		_, err := client.CreateEditImage(ctx, ImageEditRequest{Image: bytes.NewBuffer(nil), Mask: bytes.NewBuffer(nil)})
 		checks.ErrorIs(t, err, errTestRequestBuilderFailed, "CreateEditImage should return error if request builder fails")
 	})
+}
+
+func TestCreateEditImageMultiImages(t *testing.T) {
+	ctx := context.Background()
+
+	var fieldNames []string
+	fb := &mockFormBuilder{
+		mockCreateFormFileReader: func(fieldname string, _ io.Reader, _ string) error {
+			fieldNames = append(fieldNames, fieldname)
+			return nil
+		},
+		mockWriteField: func(string, string) error { return nil },
+		mockClose:      func() error { return nil },
+	}
+
+	cfg := DefaultConfig("")
+	cfg.BaseURL = ""
+	c := NewClientWithConfig(cfg)
+	c.createFormBuilder = func(io.Writer) utils.FormBuilder { return fb }
+	c.requestBuilder = &failingRequestBuilder{}
+
+	req := ImageEditRequest{
+		Images: []io.Reader{bytes.NewBuffer(nil), bytes.NewBuffer(nil)},
+	}
+	_, err := c.CreateEditImage(ctx, req)
+	// request building fails but form building must have succeeded
+	if err == nil || !errors.Is(err, errTestRequestBuilderFailed) {
+		// if err is something else entirely, check form calls first
+	}
+
+	if len(fieldNames) != 2 {
+		t.Fatalf("expected 2 CreateFormFileReader calls, got %d", len(fieldNames))
+	}
+	for i, name := range fieldNames {
+		if name != "image[]" {
+			t.Errorf("call %d: expected fieldname 'image[]', got %q", i, name)
+		}
+	}
 }
 
 func TestVariImageFormBuilderFailures(t *testing.T) {


### PR DESCRIPTION
**Describe the change**
Adds `Images []io.Reader` to `ImageEditRequest` so callers can pass multiple images per the updated OpenAI API spec. The existing `Image io.Reader` field stays, so nothing breaks.

**Provide OpenAI documentation link**
https://platform.openai.com/docs/api-reference/images/createEdit

**Describe your solution**
When `Images` is non-empty, `CreateEditImage` writes each reader as `image[]` form fields. If `Images` is empty it falls back to the existing `image` field. The two code paths are mutually exclusive so old code works without changes.

**Tests**
Added table-driven error tests for `images[0] fails` and `images[1] fails` cases, plus a positive test that confirms the builder gets two `image[]` calls when `Images` has two elements. All existing tests still pass.

**Additional context**
Issue: #1075