### PR TITLE
fix: always serialize stream field in request JSON

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -129,7 +129,7 @@ func TestUploadBatchFileRequest_AddChatCompletion(t *testing.T) {
 					},
 				},
 			},
-		}, []byte("{\"custom_id\":\"req-1\",\"body\":{\"model\":\"gpt-3.5-turbo\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello!\"}],\"max_tokens\":5},\"method\":\"POST\",\"url\":\"/v1/chat/completions\"}\n{\"custom_id\":\"req-2\",\"body\":{\"model\":\"gpt-3.5-turbo\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello!\"}],\"max_tokens\":5},\"method\":\"POST\",\"url\":\"/v1/chat/completions\"}")}, //nolint:lll
+		}, []byte("{\"custom_id\":\"req-1\",\"body\":{\"model\":\"gpt-3.5-turbo\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello!\"}],\"max_tokens\":5,\"stream\":false},\"method\":\"POST\",\"url\":\"/v1/chat/completions\"}\n{\"custom_id\":\"req-2\",\"body\":{\"model\":\"gpt-3.5-turbo\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello!\"}],\"max_tokens\":5,\"stream\":false},\"method\":\"POST\",\"url\":\"/v1/chat/completions\"}")}, //nolint:lll
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -170,7 +170,7 @@ func TestUploadBatchFileRequest_AddCompletion(t *testing.T) {
 					User:  "Hello",
 				},
 			},
-		}, []byte("{\"custom_id\":\"req-1\",\"body\":{\"model\":\"gpt-3.5-turbo\",\"user\":\"Hello\"},\"method\":\"POST\",\"url\":\"/v1/completions\"}\n{\"custom_id\":\"req-2\",\"body\":{\"model\":\"gpt-3.5-turbo\",\"user\":\"Hello\"},\"method\":\"POST\",\"url\":\"/v1/completions\"}")}, //nolint:lll
+		}, []byte("{\"custom_id\":\"req-1\",\"body\":{\"model\":\"gpt-3.5-turbo\",\"stream\":false,\"user\":\"Hello\"},\"method\":\"POST\",\"url\":\"/v1/completions\"}\n{\"custom_id\":\"req-2\",\"body\":{\"model\":\"gpt-3.5-turbo\",\"stream\":false,\"user\":\"Hello\"},\"method\":\"POST\",\"url\":\"/v1/completions\"}")}, //nolint:lll
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/chat.go
+++ b/chat.go
@@ -274,7 +274,7 @@ type ChatCompletionRequest struct {
 	Temperature         float32                       `json:"temperature,omitempty"`
 	TopP                float32                       `json:"top_p,omitempty"`
 	N                   int                           `json:"n,omitempty"`
-	Stream              bool                          `json:"stream,omitempty"`
+	Stream              bool                          `json:"stream"`
 	Stop                []string                      `json:"stop,omitempty"`
 	PresencePenalty     float32                       `json:"presence_penalty,omitempty"`
 	ResponseFormat      *ChatCompletionResponseFormat `json:"response_format,omitempty"`

--- a/chat_test.go
+++ b/chat_test.go
@@ -458,8 +458,8 @@ func TestChatRequestOmitEmpty(t *testing.T) {
 	})
 	checks.NoError(t, err)
 
-	// messages is also required so isn't omitted
-	const expected = `{"model":"gpt-4","messages":null}`
+	// messages is also required so isn't omitted; stream is always present
+	const expected = `{"model":"gpt-4","messages":null,"stream":false}`
 	if string(data) != expected {
 		t.Errorf("expected JSON with all empty fields to be %v but was %v", expected, string(data))
 	}
@@ -1203,5 +1203,29 @@ func TestChatCompletionRequest_UnmarshalJSON(t *testing.T) {
 				t.Errorf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestChatCompletionRequest_StreamFalsePresent(t *testing.T) {
+	req := openai.ChatCompletionRequest{
+		Model: openai.GPT4,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: "hello"},
+		},
+		Stream: false,
+	}
+	b, err := json.Marshal(req)
+	checks.NoError(t, err, "marshal error")
+
+	var raw map[string]interface{}
+	err = json.Unmarshal(b, &raw)
+	checks.NoError(t, err, "unmarshal error")
+
+	val, exists := raw["stream"]
+	if !exists {
+		t.Fatal("expected \"stream\" field to be present in JSON, but it was omitted")
+	}
+	if val != false {
+		t.Fatalf("expected \"stream\" to be false, got %v", val)
 	}
 }

--- a/completion.go
+++ b/completion.go
@@ -218,7 +218,7 @@ type CompletionRequest struct {
 	PresencePenalty float32           `json:"presence_penalty,omitempty"`
 	Seed            *int              `json:"seed,omitempty"`
 	Stop            []string          `json:"stop,omitempty"`
-	Stream          bool              `json:"stream,omitempty"`
+	Stream          bool              `json:"stream"`
 	Suffix          string            `json:"suffix,omitempty"`
 	Temperature     float32           `json:"temperature,omitempty"`
 	TopP            float32           `json:"top_p,omitempty"`


### PR DESCRIPTION
**Describe the change**

Remove `omitempty` from the `Stream` field tag in `ChatCompletionRequest` and `CompletionRequest`. Go's `omitempty` omits `false` for bool fields, which means non-streaming requests never include `"stream": false` in the serialized JSON. Some OpenAI-compatible endpoints (proxies, Azure configurations) require the field to be explicitly present.

**Provide OpenAI documentation link**

https://platform.openai.com/docs/api-reference/chat/create#chat-create-stream

The `stream` field is documented as `boolean or null, Optional, Defaults to false`. Explicitly sending `false` is valid and expected by strict implementations.

**Describe your solution**

Changed `json:"stream,omitempty"` to `json:"stream"` in both `ChatCompletionRequest` (chat.go) and `CompletionRequest` (completion.go). The streaming code path already sets `Stream = true` explicitly before sending, so this change only affects non-streaming requests, which now correctly emit `"stream": false`.

**Tests**

- Added `TestChatCompletionRequest_StreamFalsePresent` verifying the field is present in serialized JSON
- Updated `TestChatRequestOmitEmpty` expected output to include `"stream":false`
- Updated `TestUploadBatchFileRequest_AddChatCompletion` and `TestUploadBatchFileRequest_AddCompletion` expected JSONL output
- All tests pass: `go test ./...`
- `go vet ./...` clean

Issue: #1073