### PR TITLE
[BREAKING_CHANGES] fix: use pointer for ContentFilterResults to distinguish absent from empty

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -64,8 +64,8 @@ type ContentFilterResults struct {
 }
 
 type PromptAnnotation struct {
-	PromptIndex          int                  `json:"prompt_index,omitempty"`
-	ContentFilterResults ContentFilterResults `json:"content_filter_results,omitempty"`
+	PromptIndex          int                   `json:"prompt_index,omitempty"`
+	ContentFilterResults *ContentFilterResults `json:"content_filter_results,omitempty"`
 }
 
 type ImageURLDetail string
@@ -442,9 +442,9 @@ type ChatCompletionChoice struct {
 	// function_call: The model decided to call a function
 	// content_filter: Omitted content due to a flag from our content filters
 	// null: API response still in progress or incomplete
-	FinishReason         FinishReason         `json:"finish_reason"`
-	LogProbs             *LogProbs            `json:"logprobs,omitempty"`
-	ContentFilterResults ContentFilterResults `json:"content_filter_results,omitempty"`
+	FinishReason         FinishReason          `json:"finish_reason"`
+	LogProbs             *LogProbs             `json:"logprobs,omitempty"`
+	ContentFilterResults *ContentFilterResults `json:"content_filter_results,omitempty"`
 }
 
 // ChatCompletionResponse represents a response structure for chat completion API.

--- a/chat_stream.go
+++ b/chat_stream.go
@@ -42,12 +42,12 @@ type ChatCompletionStreamChoice struct {
 	Delta                ChatCompletionStreamChoiceDelta     `json:"delta"`
 	Logprobs             *ChatCompletionStreamChoiceLogprobs `json:"logprobs,omitempty"`
 	FinishReason         FinishReason                        `json:"finish_reason"`
-	ContentFilterResults ContentFilterResults                `json:"content_filter_results,omitempty"`
+	ContentFilterResults *ContentFilterResults               `json:"content_filter_results,omitempty"`
 }
 
 type PromptFilterResult struct {
-	Index                int                  `json:"index"`
-	ContentFilterResults ContentFilterResults `json:"content_filter_results,omitempty"`
+	Index                int                   `json:"index"`
+	ContentFilterResults *ContentFilterResults `json:"content_filter_results,omitempty"`
 }
 
 type ChatCompletionStreamResponse struct {

--- a/error.go
+++ b/error.go
@@ -20,8 +20,8 @@ type APIError struct {
 
 // InnerError Azure Content filtering. Only valid for Azure OpenAI Service.
 type InnerError struct {
-	Code                 string               `json:"code,omitempty"`
-	ContentFilterResults ContentFilterResults `json:"content_filter_result,omitempty"`
+	Code                 string                `json:"code,omitempty"`
+	ContentFilterResults *ContentFilterResults `json:"content_filter_result,omitempty"`
 }
 
 // RequestError provides information about generic request errors.

--- a/error_test.go
+++ b/error_test.go
@@ -92,7 +92,7 @@ func TestAPIErrorUnmarshalJSON(t *testing.T) {
 			checkFunc: func(t *testing.T, apiErr openai.APIError) {
 				assertAPIErrorInnerError(t, apiErr, &openai.InnerError{
 					Code: "ResponsibleAIPolicyViolation",
-					ContentFilterResults: openai.ContentFilterResults{
+					ContentFilterResults: &openai.ContentFilterResults{
 						Hate: openai.Hate{
 							Filtered: false,
 							Severity: "safe",


### PR DESCRIPTION
**Describe the change**

Change `ContentFilterResults` fields from value type to pointer across all structs that contain it. When the API omits `content_filter_results` (non-Azure providers), the field is now `nil` instead of a zero-valued struct that serializes as an empty object with all sub-fields at their zero values.

**Provide OpenAI documentation link**

https://platform.openai.com/docs/api-reference/chat/object#chat/object-choices

The `content_filter_results` field is only populated by Azure OpenAI Service and should be absent from non-Azure responses.

**Describe your solution**

Changed `ContentFilterResults ContentFilterResults` to `ContentFilterResults *ContentFilterResults` in 5 structs:
- `ChatCompletionChoice` (chat.go)
- `PromptAnnotation` (chat.go)
- `ChatCompletionStreamChoice` (chat_stream.go)
- `PromptFilterResult` (chat_stream.go)
- `InnerError` (error.go)

This is a breaking change: code that accesses `ContentFilterResults` fields directly must now nil-check first.

**Tests**

All existing tests pass. Updated `error_test.go` to use pointer literal (`&openai.ContentFilterResults{}`).

**Additional context**

Issue: #960