### PR TITLE
fix: detect Content-Type from file extension in multipart uploads

### DIFF
--- a/internal/form_builder.go
+++ b/internal/form_builder.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"fmt"
 	"io"
+	"mime"
 	"mime/multipart"
 	"net/textproto"
 	"os"
@@ -50,6 +51,12 @@ func (fb *DefaultFormBuilder) CreateFormFileReader(fieldname string, r io.Reader
 	if f, ok := r.(interface{ ContentType() string }); ok {
 		contentType = f.ContentType()
 	}
+	// Fall back to detecting content type from the file extension when the
+	// reader does not implement ContentType(). Some API endpoints (e.g.
+	// gpt-image-1 image edits) require Content-Type to be set explicitly.
+	if contentType == "" && filename != "" {
+		contentType = mime.TypeByExtension(filepath.Ext(filename))
+	}
 
 	h := make(textproto.MIMEHeader)
 	h.Set(
@@ -60,7 +67,6 @@ func (fb *DefaultFormBuilder) CreateFormFileReader(fieldname string, r io.Reader
 			escapeQuotes(filepath.Base(filename)),
 		),
 	)
-	// content type is optional, but it can be set
 	if contentType != "" {
 		h.Set("Content-Type", contentType)
 	}

--- a/internal/form_builder_test.go
+++ b/internal/form_builder_test.go
@@ -188,3 +188,17 @@ func TestCreateFormFileSuccess(t *testing.T) {
 		t.Fatalf("expected filename header, got %q", buf.String())
 	}
 }
+
+func TestCreateFormFileReaderDetectsMimeFromExtension(t *testing.T) {
+	buf := &bytes.Buffer{}
+	builder := NewFormBuilder(buf)
+
+	// Plain reader (no ContentType interface), but filename has .png extension.
+	// The builder should detect image/png from the extension.
+	err := builder.CreateFormFileReader("image", bytes.NewBufferString("fake-png"), "test.png")
+	checks.NoError(t, err, "CreateFormFileReader should succeed")
+
+	if !strings.Contains(buf.String(), "Content-Type: image/png") {
+		t.Fatalf("expected Content-Type header with image/png, got %q", buf.String())
+	}
+}


### PR DESCRIPTION
**Describe the change**

`CreateFormFileReader` only sets the `Content-Type` multipart header when the reader implements a `ContentType() string` interface. A plain `*os.File` does not implement this, so the header is omitted. The `gpt-image-1` model requires `Content-Type` and rejects requests with `missing_file_mimetype` when it is absent.

**Provide OpenAI documentation link**

https://platform.openai.com/docs/api-reference/images/createEdit

**Describe your solution**

When the reader does not implement `ContentType()`, fall back to `mime.TypeByExtension(filepath.Ext(filename))` to detect the content type from the file extension. This covers common image formats (.png, .jpg, .webp, .gif) and any other extension registered in the system's MIME database.

**Tests**

Added `TestCreateFormFileReaderDetectsMimeFromExtension` verifying that a plain reader with a `.png` filename gets `Content-Type: image/png` in the multipart header.

All tests pass: `go test ./...`

Issue: #1012