### PR TITLE
stream_reader: stop wrapping nil APIError into "error, <nil>"

### DIFF
--- a/stream_reader.go
+++ b/stream_reader.go
@@ -64,7 +64,13 @@ func (stream *streamReader[T]) processLines() ([]byte, error) {
 		rawLine, readErr := stream.reader.ReadBytes('\n')
 		if readErr != nil || hasErrorPrefix {
 			respErr := stream.unmarshalError()
-			if respErr != nil {
+			// respErr.Error can be nil even when respErr itself isn't:
+			// any payload that round-trips through unmarshaler.Unmarshal
+			// (an empty object, an aborted partial frame after context
+			// cancellation, etc.) ends up as a non-nil *ErrorResponse with
+			// a nil Error field. Wrapping that produced the famously
+			// useless "error, <nil>" message in #1060.
+			if respErr != nil && respErr.Error != nil {
 				return nil, fmt.Errorf("error, %w", respErr.Error)
 			}
 			return nil, readErr

--- a/stream_reader_test.go
+++ b/stream_reader_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"io"
 	"testing"
 
 	utils "github.com/sashabaranov/go-openai/internal"
@@ -75,4 +76,25 @@ func TestStreamReaderRecvRaw(t *testing.T) {
 	if !bytes.Equal(rawLine, []byte("{\"key\": \"value\"}")) {
 		t.Fatalf("Did not return raw line: %v", string(rawLine))
 	}
+}
+
+// Regression for #1060. When the read aborts (context cancel, network
+// reset, etc) and whatever was buffered in errAccumulator happens to
+// parse as an ErrorResponse with a nil Error field, the stream used to
+// surface a useless "error, <nil>" instead of the real read error.
+func TestStreamReaderPropagatesReadErrorWhenErrorResponseIsEmpty(t *testing.T) {
+	stream := &streamReader[ChatCompletionStreamResponse]{
+		reader:         bufio.NewReader(bytes.NewReader([]byte(""))),
+		errAccumulator: utils.NewErrorAccumulator(),
+		unmarshaler:    &utils.JSONUnmarshaler{},
+	}
+	// Prime the accumulator with a payload that unmarshals successfully
+	// into ErrorResponse{} but leaves the Error pointer nil. This mirrors
+	// what we end up with after a partial SSE frame plus EOF.
+	if err := stream.errAccumulator.Write([]byte("{}")); err != nil {
+		t.Fatalf("write to accumulator: %v", err)
+	}
+
+	_, err := stream.Recv()
+	checks.ErrorIs(t, err, io.EOF, "expected the underlying io.EOF to propagate")
 }


### PR DESCRIPTION
Fixes #1060.

After cancelling the context on a chat completion stream, `stream.Recv()` returns the famously useless \`\"error, <nil>\"\` instead of the real read error. The unmarshaler can return a non-nil `*ErrorResponse` whose `Error` pointer is nil whenever the accumulator contents round-trip through `Unmarshal` without producing an `Error` field. A partial SSE frame buffered before cancellation does it, an empty `{}` does it too. `processLines` then runs:

```go
return nil, fmt.Errorf(\"error, %w\", respErr.Error)
```

and wraps the nil into the misleading message.

Guard on `respErr.Error != nil` so the original `readErr` (`io.EOF` or `context.Canceled` in practice) propagates when there's no real API error to report.

Added a regression test that primes the accumulator with `{}` and asserts the underlying `io.EOF` makes it back out of `Recv()`.