### PR TITLE
form_builder: always set a Content-Type on reader-based form parts

### DIFF
--- a/internal/form_builder.go
+++ b/internal/form_builder.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"fmt"
 	"io"
+	"mime"
 	"mime/multipart"
 	"net/textproto"
 	"os"
@@ -50,6 +51,19 @@ func (fb *DefaultFormBuilder) CreateFormFileReader(fieldname string, r io.Reader
 	if f, ok := r.(interface{ ContentType() string }); ok {
 		contentType = f.ContentType()
 	}
+	// The OpenAI API rejects the file part when Content-Type is
+	// missing, so when the reader doesn't supply one and we can't
+	// derive it from the filename extension, fall back to the same
+	// default the stdlib's multipart.Writer.CreateFormFile uses.
+	// See #1010.
+	if contentType == "" {
+		if ext := filepath.Ext(filename); ext != "" {
+			contentType = mime.TypeByExtension(ext)
+		}
+		if contentType == "" {
+			contentType = "application/octet-stream"
+		}
+	}
 
 	h := make(textproto.MIMEHeader)
 	h.Set(
@@ -60,10 +74,7 @@ func (fb *DefaultFormBuilder) CreateFormFileReader(fieldname string, r io.Reader
 			escapeQuotes(filepath.Base(filename)),
 		),
 	)
-	// content type is optional, but it can be set
-	if contentType != "" {
-		h.Set("Content-Type", contentType)
-	}
+	h.Set("Content-Type", contentType)
 
 	fieldWriter, err := fb.writer.CreatePart(h)
 	if err != nil {

--- a/internal/form_builder_test.go
+++ b/internal/form_builder_test.go
@@ -188,3 +188,30 @@ func TestCreateFormFileSuccess(t *testing.T) {
 		t.Fatalf("expected filename header, got %q", buf.String())
 	}
 }
+
+// Regression for #1010. CreateFormFileReader used to omit Content-Type
+// entirely when the reader didn't supply one, which made the OpenAI
+// audio endpoints reject the file. Derive a type from the filename
+// extension and fall back to application/octet-stream so the part
+// always has a Content-Type, matching the stdlib's CreateFormFile.
+func TestCreateFormFileReaderSetsContentType(t *testing.T) {
+	t.Run("derived from extension", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		builder := NewFormBuilder(buf)
+		err := builder.CreateFormFileReader("file", bytes.NewBufferString("RIFF"), "clip.mp3")
+		checks.NoError(t, err, "CreateFormFileReader should succeed")
+		if !strings.Contains(buf.String(), "Content-Type: audio/mpeg") {
+			t.Fatalf("expected audio/mpeg content type, got %q", buf.String())
+		}
+	})
+
+	t.Run("fallback when unknown", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		builder := NewFormBuilder(buf)
+		err := builder.CreateFormFileReader("file", bytes.NewBufferString("data"), "unknown-ext.xyzqq")
+		checks.NoError(t, err, "CreateFormFileReader should succeed")
+		if !strings.Contains(buf.String(), "Content-Type: application/octet-stream") {
+			t.Fatalf("expected application/octet-stream fallback, got %q", buf.String())
+		}
+	})
+}


### PR DESCRIPTION
Fixes #1010.

\`CreateFormFileReader\` only set \`Content-Type\` when the reader satisfied the \`ContentType() string\` optional interface. The OpenAI audio endpoints reject the file part when that header is missing, so passing a plain \`io.Reader\` through \`CreateTranscription\` came back as a 400.

Derive a Content-Type from the filename extension via \`mime.TypeByExtension\`, falling back to \`\"application/octet-stream\"\` which is what the stdlib's \`multipart.Writer.CreateFormFile\` uses by default. Readers that supply their own \`ContentType()\` still win.

Added \`TestCreateFormFileReaderSetsContentType\` covering both branches.