### PR TITLE
Document OpenAI-compatible base URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,23 @@ See also: https://pkg.go.dev/github.com/sashabaranov/go-openai#ClientConfig
 </details>
 
 <details>
+<summary>Configuring an OpenAI-compatible endpoint</summary>
+
+```go
+config := openai.DefaultConfig(os.Getenv("OPENAI_API_KEY"))
+if baseURL := os.Getenv("OPENAI_BASE_URL"); baseURL != "" {
+	config.BaseURL = baseURL
+}
+
+c := openai.NewClientWithConfig(config)
+```
+
+This keeps the default OpenAI endpoint when `OPENAI_BASE_URL` is unset, while
+allowing local inference servers, private gateways, or other OpenAI-compatible
+endpoints to be configured by environment.
+</details>
+
+<details>
 <summary>ChatGPT support context</summary>
 
 ```go


### PR DESCRIPTION
This keeps the default OpenAI endpoint unchanged while documenting how to configure an OpenAI-compatible endpoint through OPENAI_BASE_URL.\n\nWhy this may be useful:\n- local inference servers\n- private model gateways\n- self-hosted routers\n- observability and enterprise control planes\n\nThe example uses the existing ClientConfig.BaseURL field and does not add a provider-specific integration.