### PR TITLE
docs: fix LogitBias, ToolChoice, and CreateEditImage godoc

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -280,7 +280,7 @@ type ChatCompletionRequest struct {
 	ResponseFormat      *ChatCompletionResponseFormat `json:"response_format,omitempty"`
 	Seed                *int                          `json:"seed,omitempty"`
 	FrequencyPenalty    float32                       `json:"frequency_penalty,omitempty"`
-	// LogitBias is must be a token id string (specified by their token ID in the tokenizer), not a word string.
+	// LogitBias must be a token id string (specified by their token ID in the tokenizer), not a word string.
 	// incorrect: `"logit_bias":{"You": 6}`, correct: `"logit_bias":{"1639": 6}`
 	// refs: https://platform.openai.com/docs/api-reference/chat/create#chat/create-logit_bias
 	LogitBias map[string]int `json:"logit_bias,omitempty"`
@@ -298,7 +298,7 @@ type ChatCompletionRequest struct {
 	// Deprecated: use ToolChoice instead.
 	FunctionCall any    `json:"function_call,omitempty"`
 	Tools        []Tool `json:"tools,omitempty"`
-	// This can be either a string or an ToolChoice object.
+	// This can be either a string or a ToolChoice object.
 	ToolChoice any `json:"tool_choice,omitempty"`
 	// Options for streaming response. Only set this when you set stream: true.
 	StreamOptions *StreamOptions `json:"stream_options,omitempty"`

--- a/completion.go
+++ b/completion.go
@@ -203,7 +203,7 @@ type CompletionRequest struct {
 	BestOf           int     `json:"best_of,omitempty"`
 	Echo             bool    `json:"echo,omitempty"`
 	FrequencyPenalty float32 `json:"frequency_penalty,omitempty"`
-	// LogitBias is must be a token id string (specified by their token ID in the tokenizer), not a word string.
+	// LogitBias must be a token id string (specified by their token ID in the tokenizer), not a word string.
 	// incorrect: `"logit_bias":{"You": 6}`, correct: `"logit_bias":{"1639": 6}`
 	// refs: https://platform.openai.com/docs/api-reference/completions/create#completions/create-logit_bias
 	LogitBias map[string]int `json:"logit_bias,omitempty"`

--- a/image.go
+++ b/image.go
@@ -170,7 +170,7 @@ type ImageEditRequest struct {
 	User           string    `json:"user,omitempty"`
 }
 
-// CreateEditImage - API call to create an image. This is the main endpoint of the DALL-E API.
+// CreateEditImage - API call to create an edited image from an original image and a prompt.
 func (c *Client) CreateEditImage(ctx context.Context, request ImageEditRequest) (response ImageResponse, err error) {
 	body := &bytes.Buffer{}
 	builder := c.createFormBuilder(body)


### PR DESCRIPTION
## Summary
Small godoc accuracy/grammar fixes:

- `LogitBias is must be` → `LogitBias must be` in `chat.go` and `completion.go`
- `an ToolChoice` → `a ToolChoice`
- `CreateEditImage` was documented as "API call to create an image" (same as `CreateImage`); clarify that it creates an **edited** image from an original image and a prompt

## Test plan
- [x] Docs-only change; no code behavior change