### PR TITLE
fix: require non-empty model for chat completions

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -24,6 +24,7 @@ const chatCompletionsSuffix = "/chat/completions"
 var (
 	ErrChatCompletionInvalidModel       = errors.New("this model is not supported with this method, please use CreateCompletion client method instead") //nolint:lll
 	ErrChatCompletionStreamNotSupported = errors.New("streaming is not supported with this method, please use CreateChatCompletionStream")              //nolint:lll
+	ErrChatCompletionRequestEmptyModel  = errors.New("model is required for chat completion requests")
 	ErrContentFieldsMisused             = errors.New("can't use both Content and MultiContent properties simultaneously")
 )
 
@@ -469,6 +470,10 @@ func (c *Client) CreateChatCompletion(
 ) (response ChatCompletionResponse, err error) {
 	if request.Stream {
 		err = ErrChatCompletionStreamNotSupported
+		return
+	}
+	if request.Model == "" {
+		err = ErrChatCompletionRequestEmptyModel
 		return
 	}
 

--- a/chat_model_test.go
+++ b/chat_model_test.go
@@ -1,0 +1,19 @@
+package openai_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+func TestCreateChatCompletionEmptyModel(t *testing.T) {
+	c := openai.NewClient("test-key")
+	_, err := c.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
+		Messages: []openai.ChatCompletionMessage{{Role: openai.ChatMessageRoleUser, Content: "hi"}},
+	})
+	if !errors.Is(err, openai.ErrChatCompletionRequestEmptyModel) {
+		t.Fatalf("got %v", err)
+	}
+}

--- a/chat_stream.go
+++ b/chat_stream.go
@@ -80,6 +80,10 @@ func (c *Client) CreateChatCompletionStream(
 	request ChatCompletionRequest,
 ) (stream *ChatCompletionStream, err error) {
 	urlSuffix := chatCompletionsSuffix
+	if request.Model == "" {
+		err = ErrChatCompletionRequestEmptyModel
+		return
+	}
 	if !checkEndpointSupportsModel(urlSuffix, request.Model) {
 		err = ErrChatCompletionInvalidModel
 		return


### PR DESCRIPTION
## What

`CreateChatCompletion` and `CreateChatCompletionStream` return `ErrChatCompletionRequestEmptyModel` when `Model` is empty.

## Why

The API rejects empty model names. Failing early saves a round trip and gives a clear, typed error.

## Test

- `TestCreateChatCompletionEmptyModel`