### PR TITLE
fix(images): send omitted image edit fields

### DIFF
--- a/image.go
+++ b/image.go
@@ -195,6 +195,27 @@ func (c *Client) CreateEditImage(ctx context.Context, request ImageEditRequest) 
 		return
 	}
 
+	if request.Model != "" {
+		err = builder.WriteField("model", request.Model)
+		if err != nil {
+			return
+		}
+	}
+
+	if request.Quality != "" {
+		err = builder.WriteField("quality", request.Quality)
+		if err != nil {
+			return
+		}
+	}
+
+	if request.User != "" {
+		err = builder.WriteField("user", request.User)
+		if err != nil {
+			return
+		}
+	}
+
 	err = builder.WriteField("n", strconv.Itoa(request.N))
 	if err != nil {
 		return

--- a/image_api_test.go
+++ b/image_api_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -129,6 +130,41 @@ func TestImageEditWithoutMask(t *testing.T) {
 		ResponseFormat: openai.CreateImageResponseFormatURL,
 	})
 	checks.NoError(t, err, "CreateImage error")
+}
+
+func TestImageEditSendsOptionalFields(t *testing.T) {
+	client, server, teardown := setupOpenAITestServer()
+	defer teardown()
+
+	server.RegisterHandler("/v1/images/edits", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Errorf("ParseMultipartForm error: %v", err)
+			http.Error(w, "could not parse multipart form", http.StatusBadRequest)
+			return
+		}
+
+		for field, want := range map[string]string{
+			"model":   openai.CreateImageModelGptImage1,
+			"quality": openai.CreateImageQualityHigh,
+			"user":    "test-user",
+		} {
+			if got := r.FormValue(field); got != want {
+				t.Errorf("%s = %q, want %q", field, got, want)
+			}
+		}
+
+		_, err := fmt.Fprintln(w, `{}`)
+		checks.NoError(t, err, "Write response error")
+	})
+
+	_, err := client.CreateEditImage(context.Background(), openai.ImageEditRequest{
+		Image:   openai.WrapReader(strings.NewReader("image"), "image.png", "image/png"),
+		Prompt:  "There is a turtle in the pool",
+		Model:   openai.CreateImageModelGptImage1,
+		Quality: openai.CreateImageQualityHigh,
+		User:    "test-user",
+	})
+	checks.NoError(t, err, "CreateEditImage error")
 }
 
 // handleEditImageEndpoint Handles the images endpoint by the test server.

--- a/image_test.go
+++ b/image_test.go
@@ -94,6 +94,48 @@ func TestImageFormBuilderFailures(t *testing.T) {
 			req: ImageEditRequest{Image: bytes.NewBuffer(nil), Mask: bytes.NewBuffer(nil)},
 		},
 		{
+			name: "model",
+			setup: func(fb *mockFormBuilder) {
+				fb.mockCreateFormFileReader = func(string, io.Reader, string) error { return nil }
+				fb.mockWriteField = func(field, _ string) error {
+					if field == "model" {
+						return mockFailedErr
+					}
+					return nil
+				}
+				fb.mockClose = func() error { return nil }
+			},
+			req: ImageEditRequest{Image: bytes.NewBuffer(nil), Model: CreateImageModelGptImage1},
+		},
+		{
+			name: "quality",
+			setup: func(fb *mockFormBuilder) {
+				fb.mockCreateFormFileReader = func(string, io.Reader, string) error { return nil }
+				fb.mockWriteField = func(field, _ string) error {
+					if field == "quality" {
+						return mockFailedErr
+					}
+					return nil
+				}
+				fb.mockClose = func() error { return nil }
+			},
+			req: ImageEditRequest{Image: bytes.NewBuffer(nil), Quality: CreateImageQualityHigh},
+		},
+		{
+			name: "user",
+			setup: func(fb *mockFormBuilder) {
+				fb.mockCreateFormFileReader = func(string, io.Reader, string) error { return nil }
+				fb.mockWriteField = func(field, _ string) error {
+					if field == "user" {
+						return mockFailedErr
+					}
+					return nil
+				}
+				fb.mockClose = func() error { return nil }
+			},
+			req: ImageEditRequest{Image: bytes.NewBuffer(nil), User: "test-user"},
+		},
+		{
 			name: "n",
 			setup: func(fb *mockFormBuilder) {
 				fb.mockCreateFormFileReader = func(string, io.Reader, string) error { return nil }

--- a/image_test.go
+++ b/image_test.go
@@ -94,48 +94,6 @@ func TestImageFormBuilderFailures(t *testing.T) {
 			req: ImageEditRequest{Image: bytes.NewBuffer(nil), Mask: bytes.NewBuffer(nil)},
 		},
 		{
-			name: "model",
-			setup: func(fb *mockFormBuilder) {
-				fb.mockCreateFormFileReader = func(string, io.Reader, string) error { return nil }
-				fb.mockWriteField = func(field, _ string) error {
-					if field == "model" {
-						return mockFailedErr
-					}
-					return nil
-				}
-				fb.mockClose = func() error { return nil }
-			},
-			req: ImageEditRequest{Image: bytes.NewBuffer(nil), Model: CreateImageModelGptImage1},
-		},
-		{
-			name: "quality",
-			setup: func(fb *mockFormBuilder) {
-				fb.mockCreateFormFileReader = func(string, io.Reader, string) error { return nil }
-				fb.mockWriteField = func(field, _ string) error {
-					if field == "quality" {
-						return mockFailedErr
-					}
-					return nil
-				}
-				fb.mockClose = func() error { return nil }
-			},
-			req: ImageEditRequest{Image: bytes.NewBuffer(nil), Quality: CreateImageQualityHigh},
-		},
-		{
-			name: "user",
-			setup: func(fb *mockFormBuilder) {
-				fb.mockCreateFormFileReader = func(string, io.Reader, string) error { return nil }
-				fb.mockWriteField = func(field, _ string) error {
-					if field == "user" {
-						return mockFailedErr
-					}
-					return nil
-				}
-				fb.mockClose = func() error { return nil }
-			},
-			req: ImageEditRequest{Image: bytes.NewBuffer(nil), User: "test-user"},
-		},
-		{
 			name: "n",
 			setup: func(fb *mockFormBuilder) {
 				fb.mockCreateFormFileReader = func(string, io.Reader, string) error { return nil }
@@ -210,6 +168,43 @@ func TestImageFormBuilderFailures(t *testing.T) {
 		_, err := client.CreateEditImage(ctx, ImageEditRequest{Image: bytes.NewBuffer(nil), Mask: bytes.NewBuffer(nil)})
 		checks.ErrorIs(t, err, errTestRequestBuilderFailed, "CreateEditImage should return error if request builder fails")
 	})
+}
+
+func TestImageEditOptionalFieldWriteFailures(t *testing.T) {
+	ctx := context.Background()
+	mockFailedErr := fmt.Errorf("mock form builder fail")
+
+	tests := []struct {
+		name string
+		req  ImageEditRequest
+	}{
+		{name: "model", req: ImageEditRequest{Image: bytes.NewBuffer(nil), Model: CreateImageModelGptImage1}},
+		{name: "quality", req: ImageEditRequest{Image: bytes.NewBuffer(nil), Quality: CreateImageQualityHigh}},
+		{name: "user", req: ImageEditRequest{Image: bytes.NewBuffer(nil), User: "test-user"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultConfig("")
+			cfg.BaseURL = ""
+			client := NewClientWithConfig(cfg)
+			client.createFormBuilder = func(io.Writer) utils.FormBuilder {
+				return &mockFormBuilder{
+					mockCreateFormFileReader: func(string, io.Reader, string) error { return nil },
+					mockWriteField: func(field, _ string) error {
+						if field == tc.name {
+							return mockFailedErr
+						}
+						return nil
+					},
+					mockClose: func() error { return nil },
+				}
+			}
+
+			_, err := client.CreateEditImage(ctx, tc.req)
+			checks.ErrorIs(t, err, mockFailedErr, "CreateEditImage should return error if form builder fails")
+		})
+	}
 }
 
 func TestVariImageFormBuilderFailures(t *testing.T) {


### PR DESCRIPTION
## Describe the change

Send the nonempty model, quality, and user fields in the multipart request created by CreateEditImage.

## OpenAI documentation

https://developers.openai.com/api/reference/resources/images/methods/edit

## Describe your solution

ImageEditRequest already exposes these optional fields, but CreateEditImage only wrote prompt, n, size, and response_format. For a standard OpenAI client, model was therefore never transmitted. The request now writes the three optional fields when supplied, preserving existing defaults when they are omitted.

## Tests

- go test ./...
- go test -race -covermode=atomic ./...
- go vet -stdversion ./...
- golangci-lint run --new-from-rev=HEAD

The multipart integration test asserts that all three fields reach the edits endpoint. Unit tests cover errors while writing each new field.

## Additional context

This intentionally does not change Azure image-edit deployment routing, which is separate from the missing multipart fields.
