### PR TITLE
feat: add ChunkingStrategy to AudioRequest for diarization models

### DIFF
--- a/audio.go
+++ b/audio.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -38,6 +39,16 @@ const (
 	TranscriptionTimestampGranularitySegment TranscriptionTimestampGranularity = "segment"
 )
 
+// TranscriptionChunkingStrategy configures server-side VAD chunking for transcription.
+// Assign it to AudioRequest.ChunkingStrategy when you need explicit control; pass the
+// string "auto" instead to let the server pick the boundaries.
+type TranscriptionChunkingStrategy struct {
+	Type              string  `json:"type"` // "server_vad"
+	PrefixPaddingMs   int     `json:"prefix_padding_ms,omitempty"`
+	SilenceDurationMs int     `json:"silence_duration_ms,omitempty"`
+	Threshold         float64 `json:"threshold,omitempty"`
+}
+
 // AudioRequest represents a request structure for audio API.
 type AudioRequest struct {
 	Model string
@@ -53,6 +64,11 @@ type AudioRequest struct {
 	Language               string // Only for transcription.
 	Format                 AudioResponseFormat
 	TimestampGranularities []TranscriptionTimestampGranularity // Only for transcription.
+
+	// ChunkingStrategy controls how the audio is split before processing. Diarization models
+	// such as gpt-4o-transcribe-diarize require it on longer audio, otherwise the API rejects
+	// the request. Pass the string "auto" or a TranscriptionChunkingStrategy. Only for transcription.
+	ChunkingStrategy any
 }
 
 // AudioResponse represents a response structure for audio API.
@@ -200,17 +216,49 @@ func audioMultipartForm(request AudioRequest, b utils.FormBuilder) error {
 		}
 	}
 
-	if len(request.TimestampGranularities) > 0 {
-		for _, tg := range request.TimestampGranularities {
-			err = b.WriteField("timestamp_granularities[]", string(tg))
-			if err != nil {
-				return fmt.Errorf("writing timestamp_granularities[]: %w", err)
-			}
-		}
+	// Create form fields for the timestamp granularities (if provided)
+	if err = writeTimestampGranularities(request.TimestampGranularities, b); err != nil {
+		return err
+	}
+
+	// Create a form field for the chunking strategy (if provided)
+	if err = writeChunkingStrategy(request.ChunkingStrategy, b); err != nil {
+		return err
 	}
 
 	// Close the multipart writer
 	return b.Close()
+}
+
+func writeTimestampGranularities(granularities []TranscriptionTimestampGranularity, b utils.FormBuilder) error {
+	for _, tg := range granularities {
+		if err := b.WriteField("timestamp_granularities[]", string(tg)); err != nil {
+			return fmt.Errorf("writing timestamp_granularities[]: %w", err)
+		}
+	}
+	return nil
+}
+
+// writeChunkingStrategy serializes ChunkingStrategy into the multipart form. A plain string
+// such as "auto" is sent verbatim; anything else is JSON-encoded (e.g. server_vad config).
+func writeChunkingStrategy(strategy any, b utils.FormBuilder) error {
+	if strategy == nil {
+		return nil
+	}
+
+	value, ok := strategy.(string)
+	if !ok {
+		data, err := json.Marshal(strategy)
+		if err != nil {
+			return fmt.Errorf("marshaling chunking_strategy: %w", err)
+		}
+		value = string(data)
+	}
+
+	if err := b.WriteField("chunking_strategy", value); err != nil {
+		return fmt.Errorf("writing chunking_strategy: %w", err)
+	}
+	return nil
 }
 
 // createFileField creates the "file" form field from either an existing file or by using the reader.

--- a/audio_test.go
+++ b/audio_test.go
@@ -30,6 +30,7 @@ func TestAudioWithFailingFormBuilder(t *testing.T) {
 			TranscriptionTimestampGranularitySegment,
 			TranscriptionTimestampGranularityWord,
 		},
+		ChunkingStrategy: "auto",
 	}
 
 	mockFailedErr := fmt.Errorf("mock form builder fail")
@@ -53,7 +54,10 @@ func TestAudioWithFailingFormBuilder(t *testing.T) {
 		return nil
 	}
 
-	failOn := []string{"model", "prompt", "temperature", "language", "response_format", "timestamp_granularities[]"}
+	failOn := []string{
+		"model", "prompt", "temperature", "language",
+		"response_format", "timestamp_granularities[]", "chunking_strategy",
+	}
 	for _, failingField := range failOn {
 		failForField = failingField
 		mockFailedErr = fmt.Errorf("mock form builder fail on field %s", failingField)
@@ -61,6 +65,72 @@ func TestAudioWithFailingFormBuilder(t *testing.T) {
 		err = audioMultipartForm(req, mockBuilder)
 		checks.ErrorIs(t, err, mockFailedErr, "audioMultipartForm should return error if form builder fails")
 	}
+}
+
+// captureChunkingStrategy runs audioMultipartForm and returns the value written for the
+// chunking_strategy field, or ("", false) if the field was never written.
+func captureChunkingStrategy(t *testing.T, path string, strategy any) (string, bool) {
+	t.Helper()
+
+	var got string
+	seen := false
+	mockBuilder := &mockFormBuilder{
+		mockCreateFormFile: func(string, *os.File) error { return nil },
+		mockWriteField: func(field, value string) error {
+			if field == "chunking_strategy" {
+				seen = true
+				got = value
+			}
+			return nil
+		},
+		mockClose: func() error { return nil },
+	}
+
+	req := AudioRequest{FilePath: path, Model: GPT4oTranscribeDiarize, ChunkingStrategy: strategy}
+	if err := audioMultipartForm(req, mockBuilder); err != nil {
+		t.Fatalf("audioMultipartForm returned error: %v", err)
+	}
+	return got, seen
+}
+
+func TestAudioChunkingStrategyField(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fake.mp3")
+	test.CreateTestFile(t, path)
+
+	vadStrategy := TranscriptionChunkingStrategy{
+		Type:              "server_vad",
+		PrefixPaddingMs:   300,
+		SilenceDurationMs: 200,
+		Threshold:         0.5,
+	}
+	vadJSON := `{"type":"server_vad","prefix_padding_ms":300,"silence_duration_ms":200,"threshold":0.5}`
+
+	tests := []struct {
+		name     string
+		strategy any
+		want     string
+	}{
+		{name: "auto string", strategy: "auto", want: "auto"},
+		{name: "server_vad struct", strategy: vadStrategy, want: vadJSON},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, seen := captureChunkingStrategy(t, path, tt.strategy)
+			if !seen {
+				t.Fatalf("chunking_strategy field was not written")
+			}
+			if got != tt.want {
+				t.Fatalf("chunking_strategy = %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	t.Run("unset", func(t *testing.T) {
+		if _, seen := captureChunkingStrategy(t, path, nil); seen {
+			t.Fatalf("chunking_strategy should not be written when unset")
+		}
+	})
 }
 
 func TestCreateFileField(t *testing.T) {


### PR DESCRIPTION
Closes #1101. Transcription with a diarization model (`gpt-4o-transcribe-diarize`) fails on anything longer than a short clip with `chunking_strategy is required for diarization models: bad request`, and there was no way to set that parameter through `AudioRequest`.

Added a `ChunkingStrategy` field. It takes the string `"auto"` for automatic chunking, or a `TranscriptionChunkingStrategy` value when you want explicit server_vad control — the latter gets JSON-encoded into the multipart form, a plain string is sent as-is. When unset nothing is written, so existing requests are unchanged.

While adding the form-writing I pulled the timestamp-granularities loop out into its own helper alongside the new one; the multipart builder was getting long.

Tests cover both the `"auto"` and server_vad-object cases (asserting the exact form value) plus the unset case, and the field is added to the existing failing-form-builder coverage.
