### PR TITLE
fix: preserve json_schema verbatim when unmarshaling response_format

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-
-	"github.com/sashabaranov/go-openai/jsonschema"
 )
 
 // Chat message role defined by the OpenAI API.
@@ -237,13 +235,16 @@ func (r *ChatCompletionResponseFormatJSONSchema) UnmarshalJSON(data []byte) erro
 	r.Name = raw.Name
 	r.Description = raw.Description
 	r.Strict = raw.Strict
+	r.Schema = nil
 	if len(raw.Schema) > 0 && string(raw.Schema) != "null" {
-		var d jsonschema.Definition
-		err := json.Unmarshal(raw.Schema, &d)
-		if err != nil {
+		// Keep the schema verbatim. Decoding into jsonschema.Definition silently
+		// drops any keyword it doesn't model (anyOf, title, $schema, ...), which
+		// corrupts the schema on round-trip. RawMessage still implements Marshaler.
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(raw.Schema, &obj); err != nil {
 			return err
 		}
-		r.Schema = &d
+		r.Schema = raw.Schema
 	}
 	return nil
 }

--- a/chat_test.go
+++ b/chat_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -1144,6 +1145,36 @@ func TestChatCompletionResponseFormatJSONSchema_UnmarshalJSON(t *testing.T) {
 				t.Errorf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// Keywords the typed jsonschema.Definition doesn't model (anyOf, title, $defs,
+// $ref, ...) must survive an unmarshal → marshal round-trip instead of being
+// silently dropped.
+func TestChatCompletionResponseFormatJSONSchema_UnmarshalPreservesSchema(t *testing.T) {
+	schema := `{"type":"object","title":"Root",` +
+		`"properties":{"summary":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Summary"}},` +
+		`"required":["summary"],"additionalProperties":false}`
+	data := []byte(`{"name":"s","strict":true,"schema":` + schema + `}`)
+
+	var r openai.ChatCompletionResponseFormatJSONSchema
+	if err := r.UnmarshalJSON(data); err != nil {
+		t.Fatalf("UnmarshalJSON() error = %v", err)
+	}
+
+	got, err := json.Marshal(r.Schema)
+	if err != nil {
+		t.Fatalf("Marshal(schema) error = %v", err)
+	}
+	var gotMap, wantMap map[string]any
+	if err = json.Unmarshal(got, &gotMap); err != nil {
+		t.Fatalf("unmarshal got = %v", err)
+	}
+	if err = json.Unmarshal([]byte(schema), &wantMap); err != nil {
+		t.Fatalf("unmarshal want = %v", err)
+	}
+	if !reflect.DeepEqual(gotMap, wantMap) {
+		t.Errorf("schema not preserved:\n got  %s\n want %s", got, schema)
 	}
 }
 


### PR DESCRIPTION
Unmarshaling a `response_format` with a `json_schema` currently decodes the schema into `jsonschema.Definition`, which only models a subset of JSON Schema. Any keyword it has no field for — `anyOf`, `title`, `$schema`, `oneOf`, `allOf`, `format`, and so on — gets silently dropped, so the schema comes back corrupted. A nullable field written as `{"anyOf":[{"type":"string"},{"type":"null"}]}` round-trips down to `{}`, and titles disappear entirely.

Kept the raw schema instead. `Schema` is typed `json.Marshaler` and `json.RawMessage` implements it, so storing the verbatim bytes preserves the schema exactly without changing the field type. It still checks the schema is a JSON object, so the existing rejection of non-object schemas (a bare number, an array) is unchanged. Added a round-trip test where a schema with `anyOf`/`title` survives intact.
