### PR TITLE
fix: don't append api-version query param for Anthropic clients

### DIFF
--- a/api_internal_test.go
+++ b/api_internal_test.go
@@ -36,6 +36,15 @@ func TestOpenAIFullURL(t *testing.T) {
 	}
 }
 
+func TestAnthropicFullURL(t *testing.T) {
+	cli := NewClientWithConfig(DefaultAnthropicConfig("dummy", ""))
+	// APIVersion is set for the anthropic-version header; it must not be
+	// appended as an api-version query param the way Azure requires.
+	if actual := cli.fullURL("/chat/completions"); actual != "https://api.anthropic.com/v1/chat/completions" {
+		t.Errorf("Expected https://api.anthropic.com/v1/chat/completions, got %s", actual)
+	}
+}
+
 func TestRequestAuthHeader(t *testing.T) {
 	cases := []struct {
 		Name      string

--- a/client.go
+++ b/client.go
@@ -278,7 +278,9 @@ func (c *Client) fullURL(suffix string, setters ...fullURLOption) string {
 		baseURL = c.baseURLWithAzureDeployment(baseURL, suffix, args.model)
 	}
 
-	if c.config.APIVersion != "" {
+	// api-version is an Azure query param; Anthropic reuses APIVersion only for
+	// the anthropic-version header, so it must not leak into the URL.
+	if c.config.APIVersion != "" && c.config.APIType != APITypeAnthropic {
 		suffix = c.suffixWithAPIVersion(suffix)
 	}
 	return fmt.Sprintf("%s%s", baseURL, suffix)


### PR DESCRIPTION
Building a client with `DefaultAnthropicConfig` sends every request to `https://api.anthropic.com/v1/chat/completions?api-version=2023-06-01`. That `APIVersion` value is only meant for the `anthropic-version` header, which `setCommonHeaders` already sets — but `fullURL` also appends it as an `api-version` query param whenever it's non-empty, which is an Azure convention that Anthropic got swept into once it started reusing the `APIVersion` field.

Added `&& c.config.APIType != APITypeAnthropic` to the guard so Azure/AzureAD/CloudflareAzure keep the query param they need and Anthropic clients get a clean URL. Added a `fullURL` test for the Anthropic case; existing tests still pass.
